### PR TITLE
Ressurs test

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/PersonInfoController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/PersonInfoController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.api
 
 import no.nav.familie.ef.sak.api.dto.Person
 import no.nav.familie.ef.sak.service.PersonService
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.ResponseEntity
@@ -20,8 +21,8 @@ class PersonInfoController(private val personService: PersonService) {
     }
 
     @GetMapping
-    fun personinfo(@RequestHeader(name = "Nav-Personident") ident: String): Person {
-        return personService.hentPerson(ident)
+    fun personinfo(@RequestHeader(name = "Nav-Personident") ident: String): Ressurs<Person> {
+        return Ressurs.success(personService.hentPerson(ident))
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfig.kt
@@ -18,6 +18,9 @@ class IntegrasjonerConfig(@Value("\${FAMILIE_INTEGRASJONER_URL}") private val in
     val personhistorikkUri: URI =
             UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_PERSONHISTORIKK).build().toUri()
 
+    val personhistorikkUriBuilder  =
+            UriComponentsBuilder.fromUri(integrasjonUri).pathSegment(PATH_PERSONHISTORIKK)
+
     companion object {
         private const val PATH_PING = "/internal/status/isAlive"
         private const val PATH_TILGANGER = "api/tilgang/personer"

--- a/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
@@ -30,7 +30,7 @@ class FamilieIntegrasjonerClient(restOperations: RestOperations,
     fun hentPersonhistorikk(ident: String): PersonhistorikkInfo {
 
         val uri = integrasjonerConfig.personhistorikkUriBuilder
-                .queryParam("fomDato", LocalDate.MIN)
+                .queryParam("fomDato", LocalDate.now().minusYears(5))
                 .queryParam("tomDato", LocalDate.now()).build().toUri()
 
         return getForEntity<Ressurs<PersonhistorikkInfo>>(uri,

--- a/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import java.net.URI
+import java.time.LocalDate
 
 @Component
 class FamilieIntegrasjonerClient(restOperations: RestOperations,
@@ -27,7 +28,12 @@ class FamilieIntegrasjonerClient(restOperations: RestOperations,
     }
 
     fun hentPersonhistorikk(ident: String): PersonhistorikkInfo {
-        return getForEntity<Ressurs<PersonhistorikkInfo>>(integrasjonerConfig.personhistorikkUri,
+
+        val uri = integrasjonerConfig.personhistorikkUriBuilder
+                .queryParam("fomDato", LocalDate.MIN)
+                .queryParam("tomDato", LocalDate.now()).build().toUri()
+
+        return getForEntity<Ressurs<PersonhistorikkInfo>>(uri,
                                                           personIdentHeader(ident)).data!!
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/integration/dto/personopplysning/relasjon/Familierelasjon.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/integration/dto/personopplysning/relasjon/Familierelasjon.kt
@@ -5,8 +5,8 @@ import java.time.LocalDate
 
 class Familierelasjon(val personIdent: PersonIdent,
                       val relasjonsrolle: RelasjonsRolleType,
-                      val fødselsdato: LocalDate,
-                      val harSammeBosted: Boolean) {
+                      val fødselsdato: LocalDate?,
+                      val harSammeBosted: Boolean?) {
 
     override fun toString(): String {
         return (javaClass.simpleName

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/PersonService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/PersonService.kt
@@ -14,3 +14,5 @@ class PersonService(val integrasjonerClient: FamilieIntegrasjonerClient) {
     }
 
 }
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,8 @@ no.nav.security.jwt:
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
         scope: ${FAMILIE_INTEGRASJONER_SCOPE}
         authentication:
-          client-id: ${EF_SAK_CLIENT_ID}
-          client-secret: ${CLIENT_SECRET}
+          client-id: ${AZURE_CLIENT_ID}
+          client-secret: ${AZURE_CLIENT_SECRET}
           client-auth-method: client_secret_basic
 
 spring:

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
@@ -52,7 +52,8 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(personhistorikkInfo))))
 
-        val response = restTemplate.exchange<Ressurs<Person>> (localhost(GET_PERSONINFO), HttpMethod.GET, HttpEntity(null, headers))
+        val response =
+                restTemplate.exchange<Ressurs<Person>>(localhost(GET_PERSONINFO), HttpMethod.GET, HttpEntity(null, headers))
 
         Assertions.assertThat(response).isNotNull
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
@@ -52,13 +52,13 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(personhistorikkInfo))))
 
-        val response: ResponseEntity<Person> = restTemplate.exchange(localhost(GET_PERSONINFO),
-                                                                     HttpMethod.GET,
-                                                                     HttpEntity(null, headers))
+        val response = restTemplate.exchange<Ressurs<Person>> (localhost(GET_PERSONINFO), HttpMethod.GET, HttpEntity(null, headers))
+
+        Assertions.assertThat(response).isNotNull
 
         Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        Assertions.assertThat(response.body?.personhistorikkInfo?.personIdent?.id).isEqualTo(person.data?.personIdent?.id)
-        Assertions.assertThat(response.body?.personinfo?.personIdent?.id).isEqualTo(person.data?.personIdent?.id)
+        Assertions.assertThat(response.body?.data?.personhistorikkInfo?.personIdent?.id).isEqualTo(person.data?.personIdent?.id)
+        Assertions.assertThat(response.body?.data?.personinfo?.personIdent?.id).isEqualTo(person.data?.personIdent?.id)
     }
 
     @Test
@@ -96,7 +96,7 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
                                                                      HttpMethod.GET,
                                                                      HttpEntity(null, headers))
 
-       Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        Assertions.assertThat(response.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
         Assertions.assertThat(response.body).isEqualTo("Feil mot personopplysning. Message=404 Not Found: [no body]")
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
@@ -46,7 +46,7 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(person))))
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/historikk"))
+        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/api/personopplysning/v1/historikk"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
@@ -88,7 +88,7 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(person))))
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/historikk"))
+        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/api/personopplysning/v1/historikk"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(404)))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.config
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import no.nav.familie.ef.sak.config.IntegrasjonerConfig
 import no.nav.familie.ef.sak.integration.dto.personopplysning.Periode
 import no.nav.familie.ef.sak.integration.dto.personopplysning.PersonIdent
@@ -29,18 +30,24 @@ import java.time.LocalDate
 @Component
 class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
 
-    val responses = listOf(WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.pingUri.path))
+    val responses = listOf(
+    WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.pingUri.path))
                                    .willReturn(WireMock.aResponse().withStatus(200)),
                            WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.personopplysningerUri.path))
                                    .willReturn(WireMock.aResponse()
                                                        .withStatus(200)
                                                        .withHeader("Content-Type", "application/json")
-                                                       .withBody(objectMapper.writeValueAsString(person))),
+                                                       .withBody(objectMapper.writeValueAsString(person)))
+                           ,
                            WireMock.get(WireMock.urlPathMatching(integrasjonerConfig.personhistorikkUri.path))
+                                    .withQueryParam( "tomDato",  WireMock.equalTo(LocalDate.now().toString()))
+                                    .withQueryParam( "fomDato", WireMock.equalTo(LocalDate.now().minusYears(5).toString()))
                                    .willReturn(WireMock.aResponse()
                                                        .withStatus(200)
                                                        .withHeader("Content-Type", "application/json")
-                                                       .withBody(objectMapper.writeValueAsString(personhistorikkInfo))))
+                                                       .withBody(objectMapper.writeValueAsString(personhistorikkInfo)))
+    )
+
 
     @Bean("mock-integrasjoner")
     @Profile("mock-integrasjoner")
@@ -54,7 +61,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
     }
 
     companion object {
-        private val person = Ressurs.success(Personinfo(PersonIdent("12137578901"),
+        public val person = Ressurs.success(Personinfo(PersonIdent("12137578901"),
                                                         "Bob",
                                                         Adresseinfo(AdresseType.BOSTEDSADRESSE,
                                                                     "Bob",
@@ -106,7 +113,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                                                                            "Norge",
                                                                            PersonstatusType.BOSA)),
                                                         45))
-        private val personhistorikkInfo =
+        public val personhistorikkInfo =
                 Ressurs.success(PersonhistorikkInfo(PersonIdent("12137578901"),
                                                     listOf(PersonstatusPeriode(Periode(LocalDate.of(1975, 12, 13),
                                                                                        LocalDate.of(2004, 5, 21)),

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.config
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import no.nav.familie.ef.sak.config.IntegrasjonerConfig
 import no.nav.familie.ef.sak.integration.dto.personopplysning.Periode
 import no.nav.familie.ef.sak.integration.dto.personopplysning.PersonIdent
@@ -31,21 +30,21 @@ import java.time.LocalDate
 class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
 
     val responses = listOf(
-    WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.pingUri.path))
-                                   .willReturn(WireMock.aResponse().withStatus(200)),
-                           WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.personopplysningerUri.path))
-                                   .willReturn(WireMock.aResponse()
-                                                       .withStatus(200)
-                                                       .withHeader("Content-Type", "application/json")
-                                                       .withBody(objectMapper.writeValueAsString(person)))
-                           ,
-                           WireMock.get(WireMock.urlPathMatching(integrasjonerConfig.personhistorikkUri.path))
-                                    .withQueryParam( "tomDato",  WireMock.equalTo(LocalDate.now().toString()))
-                                    .withQueryParam( "fomDato", WireMock.equalTo(LocalDate.now().minusYears(5).toString()))
-                                   .willReturn(WireMock.aResponse()
-                                                       .withStatus(200)
-                                                       .withHeader("Content-Type", "application/json")
-                                                       .withBody(objectMapper.writeValueAsString(personhistorikkInfo)))
+            WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.pingUri.path))
+                    .willReturn(WireMock.aResponse().withStatus(200)),
+            WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.personopplysningerUri.path))
+                    .willReturn(WireMock.aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(objectMapper.writeValueAsString(person)))
+            ,
+            WireMock.get(WireMock.urlPathMatching(integrasjonerConfig.personhistorikkUri.path))
+                    .withQueryParam("tomDato", WireMock.equalTo(LocalDate.now().toString()))
+                    .withQueryParam("fomDato", WireMock.equalTo(LocalDate.now().minusYears(5).toString()))
+                    .willReturn(WireMock.aResponse()
+                                        .withStatus(200)
+                                        .withHeader("Content-Type", "application/json")
+                                        .withBody(objectMapper.writeValueAsString(personhistorikkInfo)))
     )
 
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
@@ -36,7 +36,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                                                        .withStatus(200)
                                                        .withHeader("Content-Type", "application/json")
                                                        .withBody(objectMapper.writeValueAsString(person))),
-                           WireMock.get(WireMock.urlEqualTo(integrasjonerConfig.personhistorikkUri.path))
+                           WireMock.get(WireMock.urlPathMatching(integrasjonerConfig.personhistorikkUri.path))
                                    .willReturn(WireMock.aResponse()
                                                        .withStatus(200)
                                                        .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
@@ -44,7 +44,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                     .willReturn(WireMock.aResponse()
                                         .withStatus(200)
                                         .withHeader("Content-Type", "application/json")
-                                        .withBody(objectMapper.writeValueAsString(personhistorikkInfo)))
+                                        .withBody(objectMapper.writeValueAsString(personhistorikkInfo))),
             WireMock.post(WireMock.urlEqualTo(integrasjonerConfig.tilgangUri.path))
                     .willReturn(WireMock.aResponse()
                                         .withStatus(200)

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/FamilieIntegrasjonerMock.kt
@@ -61,7 +61,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
     }
 
     companion object {
-        public val person = Ressurs.success(Personinfo(PersonIdent("12137578901"),
+        private val person = Ressurs.success(Personinfo(PersonIdent("12137578901"),
                                                         "Bob",
                                                         Adresseinfo(AdresseType.BOSTEDSADRESSE,
                                                                     "Bob",
@@ -113,7 +113,7 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                                                                            "Norge",
                                                                            PersonstatusType.BOSA)),
                                                         45))
-        public val personhistorikkInfo =
+        private val personhistorikkInfo =
                 Ressurs.success(PersonhistorikkInfo(PersonIdent("12137578901"),
                                                     listOf(PersonstatusPeriode(Periode(LocalDate.of(1975, 12, 13),
                                                                                        LocalDate.of(2004, 5, 21)),


### PR DESCRIPTION
PR = forslag. 
Bruker Ressurs i controller (personinfo). Vil gjerne snakke om dette. Forenkler arbeid i frontend. 
ResponseEntity<Ressurs<PersonhistorikkInfo>>, eller <Ressurs<PersonhistorikkInfo>>, eller <PersonhistorikkInfo> -> hva med error handler? 

La på fomDato og tomDato -> 5år siden til nå. Er dette nok? Vil foreslå en endring til familie-integrasjoner, men løser det slik her. 

Endringene med Ressurs og requestparams i client fører også til endringer endringer i tester og mock