### PR TITLE
Bruk body istedet for header når man skal sende inn personident

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/PersonIdent.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/PersonIdent.kt
@@ -1,0 +1,3 @@
+package no.nav.familie.ef.sak.api.dto
+
+class PersonIdentDto(val personIdent: String)

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/PersonInfoController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/PersonInfoController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.api.gui
 
 import no.nav.familie.ba.sak.validering.PersontilgangConstraint
+import no.nav.familie.ef.sak.api.dto.PersonIdentDto
 import no.nav.familie.ef.sak.api.gui.dto.Person
 import no.nav.familie.ef.sak.integration.dto.pdl.PdlAnnenForelder
 import no.nav.familie.ef.sak.integration.dto.pdl.PdlBarn
@@ -32,11 +33,16 @@ class PersonInfoController(private val personService: PersonService) {
         return Ressurs.failure(e.message, null, e)
     }
 
+    // TODO slett når frontend er oppdatert
     @GetMapping
-    fun personinfo(@RequestHeader(name = "Nav-Personident") @PersontilgangConstraint ident: String): Ressurs<Person> {
-        return Ressurs.success(personService.hentPerson(ident))
+    fun personinfo(@PersontilgangConstraint @RequestHeader(name = "Nav-Personident") ident: String): Ressurs<Person> {
+        return personinfo(PersonIdentDto(ident))
     }
 
+    @PostMapping
+    fun personinfo(@PersontilgangConstraint @RequestBody personIdent: PersonIdentDto): Ressurs<Person> {
+        return Ressurs.success(personService.hentPerson(personIdent.personIdent))
+    }
 
     @GetMapping("/soker") // TODO Testendepunkt. Fjernes etter hvert
     fun søkerinfo(@RequestHeader(name = "Nav-Personident") @PersontilgangConstraint ident: String): PdlSøker {

--- a/src/main/kotlin/no/nav/familie/ef/sak/validering/Persontilgang.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/validering/Persontilgang.kt
@@ -1,22 +1,21 @@
 package no.nav.familie.ef.sak.validering
 
 import no.nav.familie.ba.sak.validering.PersontilgangConstraint
-import no.nav.familie.ba.sak.validering.SakstilgangConstraint
+import no.nav.familie.ef.sak.api.dto.PersonIdentDto
 import no.nav.familie.ef.sak.integration.FamilieIntegrasjonerClient
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.*
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
 @Component
 class Persontilgang(private val integrasjonerClient: FamilieIntegrasjonerClient)
-    : ConstraintValidator<PersontilgangConstraint, String> {
+    : ConstraintValidator<PersontilgangConstraint, PersonIdentDto> {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    override fun isValid(personIdent: String, ctx: ConstraintValidatorContext): Boolean {
-        integrasjonerClient.sjekkTilgangTilPersoner(listOf(personIdent))
+    override fun isValid(personIdent: PersonIdentDto, ctx: ConstraintValidatorContext): Boolean {
+        integrasjonerClient.sjekkTilgangTilPersoner(listOf(personIdent.personIdent))
                 .filterNot { it.harTilgang }
                 .forEach {
                     logger.error("Bruker har ikke tilgang: ${it.begrunnelse}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/validering/Persontilgang2.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/validering/Persontilgang2.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ef.sak.validering
+
+import no.nav.familie.ba.sak.validering.PersontilgangConstraint
+import no.nav.familie.ef.sak.api.dto.PersonIdentDto
+import org.springframework.stereotype.Component
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+@Component
+class Persontilgang2(val persontilgang: Persontilgang) : ConstraintValidator<PersontilgangConstraint, String> {
+
+    override fun isValid(personIdent: String, ctx: ConstraintValidatorContext): Boolean =
+            persontilgang.isValid(PersonIdentDto(personIdent), ctx)
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/validering/PersontilgangConstraint.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/validering/PersontilgangConstraint.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ba.sak.validering
 
 import no.nav.familie.ef.sak.validering.Persontilgang
+import no.nav.familie.ef.sak.validering.Persontilgang2
 import no.nav.familie.ef.sak.validering.Sakstilgang
 import javax.validation.Constraint
 import javax.validation.Payload
@@ -8,8 +9,8 @@ import kotlin.reflect.KClass
 
 @Suppress("unused")
 @MustBeDocumented
-@Constraint(validatedBy = [Persontilgang::class])
-@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER)
+@Constraint(validatedBy = [Persontilgang::class, Persontilgang2::class])
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class PersontilgangConstraint(val message: String = "Ikke tilgang til person",
                                          val groups: Array<KClass<*>> = [],

--- a/src/test/kotlin/no/nav/familie/ef/sak/validering/PersontilgangTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/validering/PersontilgangTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.validering
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ef.sak.api.dto.PersonIdentDto
 import no.nav.familie.ef.sak.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.integration.dto.Tilgang
 import org.assertj.core.api.Assertions.assertThat
@@ -18,7 +19,7 @@ internal class PersontilgangTest {
         every { integrasjonerClient.sjekkTilgangTilPersoner(any()) }
                 .returns(listOf(Tilgang (true, null)))
 
-        val valid = persontilgang.isValid("654654654", mockk())
+        val valid = persontilgang.isValid(PersonIdentDto("654654654"), mockk())
 
         assertThat(valid).isTrue()
     }
@@ -28,7 +29,7 @@ internal class PersontilgangTest {
         every { integrasjonerClient.sjekkTilgangTilPersoner(any()) }
                 .returns(listOf(Tilgang (false, null)))
 
-        val valid = persontilgang.isValid("654654654", mockk())
+        val valid = persontilgang.isValid(PersonIdentDto("654654654"), mockk())
 
         assertThat(valid).isFalse()
     }


### PR DESCRIPTION
ba-sak bruker `personIdent` i body, muligens vi burde bruke noe annet? Hva tenker dere? 
Det er nog mulig å endre PersonIdentDto til å være ett interface og bruke på flere olike DTO's