### PR TITLE
Oppdatert mot nye endepunkter for å hente personinfo i integrasjoner.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <fasterxml.version>2.11.0</fasterxml.version>
         <felles.version>1.20200624154125_0d8ff39</felles.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20200622112240_8ea1e3e</kontrakter.version>
+        <kontrakter.version>2.0_20200625154602_9f6d526</kontrakter.version>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
         <sonar.organization>navit</sonar.organization>

--- a/src/main/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfig.kt
@@ -34,8 +34,8 @@ class IntegrasjonerConfig(@Value("\${FAMILIE_INTEGRASJONER_URL}") private val in
         private const val PATH_KODEVERK_LANDKODER = "api/kodeverk/landkoder"
         private const val PATH_KODEVERK_POSTSTED = "api/kodeverk/poststed"
         private const val PATH_TILGANGER = "api/tilgang/personer"
-        private const val PATH_PERSONOPPLYSNING = "api/personopplysning/v1/info"
-        private const val PATH_PERSONHISTORIKK = "api/personopplysning/v1/historikk"
+        private const val PATH_PERSONOPPLYSNING = "api/personopplysning/v2/info"
+        private const val PATH_PERSONHISTORIKK = "api/personopplysning/v2/historikk"
         private const val PATH_EGEN_ANSATT = "api/egenansatt"
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/integration/FamilieIntegrasjonerClient.kt
@@ -10,6 +10,7 @@ import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
+import no.nav.familie.kontrakter.felles.personinfo.Ident
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Component
@@ -29,7 +30,7 @@ class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperati
     }
 
     fun hentMedlemskapsinfo(ident: String): Medlemskapsinfo {
-        return getForEntity<Ressurs<Medlemskapsinfo>>(integrasjonerConfig.personopplysningerUri, personIdentHeader(ident)).data!!
+        return postForEntity<Ressurs<Medlemskapsinfo>>(integrasjonerConfig.personopplysningerUri, Ident(ident)).data!!
     }
 
     fun hentKodeverkLandkoder(): KodeverkDto {
@@ -42,7 +43,7 @@ class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperati
 
     @Deprecated("bruk Pdl-løsning")
     fun hentPersonopplysninger(ident: String): Personinfo {
-        return getForEntity<Ressurs<Personinfo>>(integrasjonerConfig.personopplysningerUri, personIdentHeader(ident)).data!!
+        return postForEntity<Ressurs<Personinfo>>(integrasjonerConfig.personopplysningerUri, Ident(ident)).data!!
     }
 
     @Deprecated("bruk Pdl-løsning")
@@ -52,16 +53,12 @@ class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperati
                 .queryParam("fomDato", LocalDate.now().minusYears(5))
                 .queryParam("tomDato", LocalDate.now()).build().toUri()
 
-        return getForEntity<Ressurs<PersonhistorikkInfo>>(uri,
-                                                          personIdentHeader(ident)).data!!
+        return postForEntity<Ressurs<PersonhistorikkInfo>>(uri,
+                                                          Ident(ident)).data!!
     }
 
     fun egenAnsatt(ident: String): Boolean {
         return postForEntity<Ressurs<EgenAnsattResponse>>(integrasjonerConfig.egenAnsattUri,
                                                           EgenAnsattRequest(ident)).data!!.erEgenAnsatt
     }
-
-
-    private fun personIdentHeader(ident: String) = HttpHeaders().apply { add("Nav-Personident", ident) }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/PersonInfoControllerTest.kt
@@ -56,12 +56,12 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `skal korrekt behandle returobjekt`() {
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/info"))
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/personopplysning/v2/info"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(person))))
-        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/api/personopplysning/v1/historikk"))
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/api/personopplysning/v2/historikk"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
@@ -81,10 +81,10 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `skal kaste feil hvis personinfo ikke funnet`() {
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/info"))
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/personopplysning/v2/info"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(404)))
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/historikk"))
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/personopplysning/v2/historikk"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
@@ -101,12 +101,12 @@ class PersonInfoControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `skal kaste feil hvis personhistorikk ikke funnet`() {
-        WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/api/personopplysning/v1/info"))
+        WireMock.stubFor(WireMock.post(WireMock.urlEqualTo("/api/personopplysning/v2/info"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(200)
                                                      .withHeader("Content-Type", "application/json")
                                                      .withBody(objectMapper.writeValueAsString(person))))
-        WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/api/personopplysning/v1/historikk"))
+        WireMock.stubFor(WireMock.post(WireMock.urlPathEqualTo("/api/personopplysning/v2/historikk"))
                                  .willReturn(WireMock.aResponse()
                                                      .withStatus(404)))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfigTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/IntegrasjonerConfigTest.kt
@@ -21,12 +21,12 @@ internal class IntegrasjonerConfigTest {
     @Test
     fun getPersonopplysninger() {
         assertThat(integrasjonerConfig.personopplysningerUri)
-                .isEqualTo(URI("http://familie-integrasjoner/api/personopplysning/v1/info"))
+                .isEqualTo(URI("http://familie-integrasjoner/api/personopplysning/v2/info"))
     }
 
     @Test
     fun getPersonhistorikk() {
         assertThat(integrasjonerConfig.personhistorikkUri)
-                .isEqualTo(URI("http://familie-integrasjoner/api/personopplysning/v1/historikk"))
+                .isEqualTo(URI("http://familie-integrasjoner/api/personopplysning/v2/historikk"))
     }
 }


### PR DESCRIPTION
Tatt i bruk endepunkter som er endret fra get til post med personidenten som body i stedet for som request-header. 