### PR TITLE
Validering av inngangsvilkår

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
@@ -32,7 +32,7 @@ class VurderingController(private val vurderingService: VurderingService,
         return Ressurs.success(vurderingService.hentInngangsvilkår(behandlingId))
     }
 
-    @PostMapping("/{behandlingId}/inngangsvilkar/validering")
+    @PostMapping("/{behandlingId}/inngangsvilkar/fullfor")
     fun validerInngangsvilkår(@BehandlingConstraint @PathVariable behandlingId: UUID): Ressurs<UUID> {
         val behandling = behandlingService.hentBehandling(behandlingId)
         return Ressurs.success(stegService.håndterInngangsvilkår(behandling).id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
@@ -18,7 +18,7 @@ import java.util.*
 @RequestMapping(path = ["/api/vurdering"], produces = [MediaType.APPLICATION_JSON_VALUE])
 @ProtectedWithClaims(issuer = "azuread")
 @Validated
-class VurderingController(val vurderingService: VurderingService,
+class VurderingController(private val vurderingService: VurderingService,
                           private val stegService: StegService,
                           private val behandlingService: BehandlingService) {
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ef.sak.service.steg.StegService
 import no.nav.familie.ef.sak.validering.BehandlingConstraint
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -17,8 +16,7 @@ import java.util.*
 
 @RestController
 @RequestMapping(path = ["/api/vurdering"], produces = [MediaType.APPLICATION_JSON_VALUE])
-//@ProtectedWithClaims(issuer = "azuread")
-@Unprotected
+@ProtectedWithClaims(issuer = "azuread")
 @Validated
 class VurderingController(val vurderingService: VurderingService,
                           private val stegService: StegService,

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VurderingController.kt
@@ -2,10 +2,13 @@ package no.nav.familie.ef.sak.api.gui
 
 import no.nav.familie.ef.sak.api.dto.InngangsvilkårDto
 import no.nav.familie.ef.sak.api.dto.VurderingDto
+import no.nav.familie.ef.sak.service.BehandlingService
 import no.nav.familie.ef.sak.service.VurderingService
+import no.nav.familie.ef.sak.service.steg.StegService
 import no.nav.familie.ef.sak.validering.BehandlingConstraint
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -14,9 +17,12 @@ import java.util.*
 
 @RestController
 @RequestMapping(path = ["/api/vurdering"], produces = [MediaType.APPLICATION_JSON_VALUE])
-@ProtectedWithClaims(issuer = "azuread")
+//@ProtectedWithClaims(issuer = "azuread")
+@Unprotected
 @Validated
-class VurderingController(val vurderingService: VurderingService) {
+class VurderingController(val vurderingService: VurderingService,
+                          private val stegService: StegService,
+                          private val behandlingService: BehandlingService) {
 
     @PostMapping("inngangsvilkar")
     fun oppdaterVurderingInngangsvilkår(@RequestBody vurdering: VurderingDto): Ressurs<UUID> {
@@ -28,4 +34,9 @@ class VurderingController(val vurderingService: VurderingService) {
         return Ressurs.success(vurderingService.hentInngangsvilkår(behandlingId))
     }
 
+    @PostMapping("/{behandlingId}/inngangsvilkar/validering")
+    fun validerInngangsvilkår(@BehandlingConstraint @PathVariable behandlingId: UUID): Ressurs<UUID> {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        return Ressurs.success(stegService.håndterInngangsvilkår(behandling).id)
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -22,13 +22,13 @@ class BehandlingService(private val søknadRepository: SøknadRepository,
     val logger: Logger = LoggerFactory.getLogger(this.javaClass)
 
     @Transactional
-    fun mottaSakOvergangsstønad(sak: SakRequest<SøknadOvergangsstønad>, vedleggMap: Map<String, ByteArray>): UUID {
+    fun mottaSakOvergangsstønad(sak: SakRequest<SøknadOvergangsstønad>, vedleggMap: Map<String, ByteArray>): Behandling {
         val ident = sak.søknad.søknad.personalia.verdi.fødselsnummer.verdi.verdi
         val behandling = hentBehandling(ident)
         mottaSøknad(SøknadMapper.toDomain(sak.saksnummer, sak.journalpostId, sak.søknad.søknad, behandling.id),
                     sak,
                     vedleggMap)
-        return behandling.id
+        return behandling
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.integration.dto.pdl.Familierelasjonsrolle
 import no.nav.familie.ef.sak.mapper.AleneomsorgMapper
 import no.nav.familie.ef.sak.mapper.MedlemskapMapper
 import no.nav.familie.ef.sak.repository.VilkårVurderingRepository
+import no.nav.familie.ef.sak.repository.domain.VilkårResultat
 import no.nav.familie.ef.sak.repository.domain.VilkårType
 import no.nav.familie.ef.sak.repository.domain.VilkårVurdering
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
@@ -73,6 +74,17 @@ class VurderingService(private val behandlingService: BehandlingService,
         vilkårVurderingRepository.insertAll(nyeVilkårVurderinger)
 
         return lagredeVilkårVurderinger + nyeVilkårVurderinger
+    }
+
+    fun hentInngangsvilkårSomManglerVurdering(behandlingId: UUID): List<VilkårType> {
+        val lagredeVilkårVurderinger = vilkårVurderingRepository.findByBehandlingId(behandlingId)
+        val inngangsvilkår = VilkårType.hentInngangsvilkår()
+
+        return inngangsvilkår.filter {
+            lagredeVilkårVurderinger.find {
+                vurdering -> vurdering.type == it && vurdering.resultat == VilkårResultat.IKKE_VURDERT } !== null ||
+            lagredeVilkårVurderinger.none { vurdering -> vurdering.type == it }
+        }
     }
 
     private fun behandlingErLåstForVidereRedigering(behandlingId: UUID) =

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårSteg.kt
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Service
 class InngangsvilkårSteg(private val vurderingService: VurderingService): BehandlingSteg<String> {
 
     override fun utførStegOgAngiNeste(behandling: Behandling, data: String): StegType {
-        //TODO skal vi gjøre noe her?
         return hentNesteSteg(behandling)
     }
 
@@ -27,6 +26,6 @@ class InngangsvilkårSteg(private val vurderingService: VurderingService): Behan
         if (vilkårSomManglerVurdering.isNotEmpty())
             throw Feil(frontendFeilmelding = lagFrontendMelding("Følgende inngangsvilkår mangler vurdering: ",
                                                                 vilkårSomManglerVurdering.map { it.beskrivelse }),
-                       message = "Validering av vilkårsvurdering feilet for behandling ${behandling.id}")
+                       message = "Validering av inngangsvilkår feilet for behandling ${behandling.id}")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårSteg.kt
@@ -1,0 +1,32 @@
+package no.nav.familie.ef.sak.service.steg
+
+import no.nav.familie.ef.sak.api.Feil
+import no.nav.familie.ef.sak.repository.domain.Behandling
+import no.nav.familie.ef.sak.repository.domain.BehandlingType
+import no.nav.familie.ef.sak.service.VurderingService
+import no.nav.familie.ef.sak.util.RessursUtils.lagFrontendMelding
+import org.springframework.stereotype.Service
+
+@Service
+class InngangsvilkårSteg(private val vurderingService: VurderingService): BehandlingSteg<String> {
+
+    override fun utførStegOgAngiNeste(behandling: Behandling, data: String): StegType {
+        //TODO skal vi gjøre noe her?
+        return hentNesteSteg(behandling)
+    }
+
+    override fun stegType(): StegType {
+        return StegType.VILKÅRSVURDERE_INNGANGSVILKÅR
+    }
+
+    override fun postValiderSteg(behandling: Behandling) {
+        if (behandling.type == BehandlingType.TEKNISK_OPPHØR) return
+
+        val vilkårSomManglerVurdering = vurderingService.hentInngangsvilkårSomManglerVurdering(behandling.id)
+
+        if (vilkårSomManglerVurdering.isNotEmpty())
+            throw Feil(frontendFeilmelding = lagFrontendMelding("Følgende inngangsvilkår mangler vurdering: ",
+                                                                vilkårSomManglerVurdering.map { it.beskrivelse }),
+                       message = "Validering av vilkårsvurdering feilet for behandling ${behandling.id}")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Metrics
 import no.nav.familie.ef.sak.repository.domain.Behandling
 import no.nav.familie.ef.sak.service.BehandlingService
 import no.nav.familie.ef.sak.service.steg.StegType.BEHANDLING_FERDIGSTILT
+import no.nav.familie.ef.sak.service.steg.StegType.VILKÅRSVURDERE_INNGANGSVILKÅR
 import no.nav.familie.ef.sak.sikkerhet.SikkerhetContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -26,6 +27,13 @@ class StegService(
         val behandlingSteg: RegistrereOpplysningerSteg = hentBehandlingSteg(StegType.REGISTRERE_OPPLYSNINGER) as RegistrereOpplysningerSteg
         return håndterSteg(behandling, behandlingSteg) {
             behandlingSteg.utførStegOgAngiNeste(behandling, søknad)
+        }
+    }
+
+    fun håndterInngangsvilkår(behandling: Behandling): Behandling {
+        val behandlingSteg: InngangsvilkårSteg = hentBehandlingSteg(VILKÅRSVURDERE_INNGANGSVILKÅR) as InngangsvilkårSteg
+        return håndterSteg(behandling, behandlingSteg) {
+            behandlingSteg.utførStegOgAngiNeste(behandling, "")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
@@ -30,6 +30,7 @@ class StegService(
         }
     }
 
+    @Transactional
     fun håndterInngangsvilkår(behandling: Behandling): Behandling {
         val behandlingSteg: InngangsvilkårSteg = hentBehandlingSteg(VILKÅRSVURDERE_INNGANGSVILKÅR) as InngangsvilkårSteg
         return håndterSteg(behandling, behandlingSteg) {

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -14,6 +14,7 @@ fun main(args: Array<String>) {
             .profiles("local",
                       "mock-integrasjoner",
                       "mock-pdl",
+                      "mock-oauth",
                       "mock-kodeverk")
             .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -14,7 +14,6 @@ fun main(args: Array<String>) {
             .profiles("local",
                       "mock-integrasjoner",
                       "mock-pdl",
-                      "mock-oauth",
                       "mock-kodeverk")
             .run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/TestSakController.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/TestSakController.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.api
 
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.Testsøknad
 import no.nav.familie.ef.sak.service.BehandlingService
+import no.nav.familie.ef.sak.service.steg.StegService
 import no.nav.familie.kontrakter.ef.sak.SakRequest
 import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.security.token.support.core.api.Unprotected
-import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,12 +16,16 @@ import java.util.*
 @RequestMapping(path = ["/api/external/sak/"])
 @Unprotected
 @Validated
-class TestSakController(private val behandlingService: BehandlingService) {
+class TestSakController(private val behandlingService: BehandlingService, private val stegService: StegService) {
 
     @PostMapping("dummy")
     fun dummy(): UUID {
         val sak = SakRequest(SøknadMedVedlegg(Testsøknad.søknad, emptyList()), "123", "321")
-        return behandlingService.mottaSakOvergangsstønad(sak, emptyMap())
+        //TODO Dette steget må trigges et annet sted når vi har satt flyten for opprettelse av behandling.
+        // Trigger den her midlertidig for å kunne utføre inngangsvilkår-steget
+        val behandling = behandlingService.mottaSakOvergangsstønad(sak, emptyMap())
+        stegService.håndterRegistrerOpplysninger(behandling, "")
+        return behandling.id
     }
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
@@ -61,7 +61,7 @@ internal class VurderingControllerTest : OppslagSpringRunnerTest() {
 
     private fun opprettInngangsvilkår(): ResponseEntity<Ressurs<InngangsvilkårDto>> {
         val sak = SakRequest(SøknadMedVedlegg(Testsøknad.søknad, emptyList()), "123", "321")
-        val behandlingId = behandlingService.mottaSakOvergangsstønad(sak, emptyMap())
+        val behandlingId = behandlingService.mottaSakOvergangsstønad(sak, emptyMap()).id
 
         return restTemplate.exchange(localhost("/api/vurdering/$behandlingId/inngangsvilkar"),
                                      HttpMethod.GET,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
@@ -167,6 +167,22 @@ internal class VurderingServiceTest {
         assertThat(vilkårTyperUtenVurdering.first()).isEqualTo(VilkårType.FORUTGÅENDE_MEDLEMSKAP)
     }
 
+    @Test
+    fun `skal hente vilkårtyper for inngangsvilkår som ikke finnes`() {
+        val behandling = behandling(fagsak(), true, BehandlingStatus.UTREDES)
+        every { behandlingService.hentBehandling(BEHANDLING_ID) } returns behandling
+        val vurdertVilkår = vilkårVurdering(BEHANDLING_ID,
+                                                resultat = VilkårResultat.NEI,
+                                                VilkårType.FORUTGÅENDE_MEDLEMSKAP)
+
+        every { vilkårVurderingRepository.findByBehandlingId(BEHANDLING_ID) } returns listOf(vurdertVilkår)
+
+        val vilkårTyperUtenVurdering = vurderingService.hentInngangsvilkårSomManglerVurdering(BEHANDLING_ID)
+
+        assertThat(vilkårTyperUtenVurdering.size).isEqualTo(1)
+        assertThat(vilkårTyperUtenVurdering.first()).isEqualTo(VilkårType.LOVLIG_OPPHOLD)
+    }
+
     companion object {
 
         private val BEHANDLING_ID = UUID.randomUUID()

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
@@ -149,6 +149,24 @@ internal class VurderingServiceTest {
         verify(exactly = 0) { vilkårVurderingRepository.insertAll(any()) }
     }
 
+    @Test
+    fun `skal hente vilkårtyper for inngangsvilkår som mangler vurdering`() {
+        val behandling = behandling(fagsak(), true, BehandlingStatus.UTREDES)
+        every { behandlingService.hentBehandling(BEHANDLING_ID) } returns behandling
+        val ikkeVurdertVilkår = vilkårVurdering(BEHANDLING_ID,
+                                              resultat = VilkårResultat.IKKE_VURDERT,
+                                              VilkårType.FORUTGÅENDE_MEDLEMSKAP)
+        val vurdertVilkår = vilkårVurdering(BEHANDLING_ID,
+                                            resultat = VilkårResultat.JA,
+                                            VilkårType.LOVLIG_OPPHOLD)
+        every { vilkårVurderingRepository.findByBehandlingId(BEHANDLING_ID) } returns listOf(ikkeVurdertVilkår, vurdertVilkår)
+
+        val vilkårTyperUtenVurdering = vurderingService.hentInngangsvilkårSomManglerVurdering(BEHANDLING_ID)
+
+        assertThat(vilkårTyperUtenVurdering.size).isEqualTo(1)
+        assertThat(vilkårTyperUtenVurdering.first()).isEqualTo(VilkårType.FORUTGÅENDE_MEDLEMSKAP)
+    }
+
     companion object {
 
         private val BEHANDLING_ID = UUID.randomUUID()

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/InngangsvilkårStegTest.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ef.sak.service.steg
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.api.Feil
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.domain.VilkårType
+import no.nav.familie.ef.sak.service.VurderingService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+internal class InngangsvilkårStegTest {
+
+    private val vurderingService = mockk<VurderingService>()
+    private val inngangsvilkårSteg = InngangsvilkårSteg(vurderingService)
+
+    @Test
+    fun `skal feile validering når inngangsvilkår ikke er vurdert`() {
+        val behandling = behandling(fagsak())
+        every { vurderingService.hentInngangsvilkårSomManglerVurdering(behandling.id) } returns
+                listOf(VilkårType.FORUTGÅENDE_MEDLEMSKAP)
+
+        val exception = assertThrows<Feil> {  inngangsvilkårSteg.postValiderSteg(behandling) }
+        assertEquals("Følgende inngangsvilkår mangler vurdering: \n${VilkårType.FORUTGÅENDE_MEDLEMSKAP.beskrivelse}",
+                     exception.frontendFeilmelding)
+    }
+}


### PR DESCRIPTION
Satt opp validering av inngangsvilkår som gir feil dersom det finnes inngangsvilkår som ikke er vurdert eller hvis det er inngangsvilkår som ikke har noen vurdering. Kobler det på stegservicen, så det er litt herk her med å få behandlingen i riktig steg før inngangsvilkår-steget kjører. Lagt inn en todo for det, så får vi se på registrering av personopplysninger ganske snart tenker jeg. 

Er nok behov for å utvide Ressurs med en "Valideringsfeil"-status + exception som ikke trigger alarmer, ref [denne slack-tråden](https://nav-it.slack.com/archives/CJN0STWB0/p1602052711069000). Men det får bli en "del 2" da det krever oppdatering av fellesbibliotek.  