### PR TITLE
Kjør integrasjonstester i felles spring context for å unngå å ta ned/…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -10,17 +10,20 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.client.TestRestTemplate
 import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.cache.CacheManager
 import org.springframework.context.ApplicationContext
 import org.springframework.data.jdbc.core.JdbcAggregateOperations
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(classes = [ApplicationLocal::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integrasjonstest", "mock-oauth", "mock-pdl", "mock-integrasjoner")
 abstract class OppslagSpringRunnerTest {
 
     protected val listAppender = initLoggingEventListAppender()
@@ -30,6 +33,7 @@ abstract class OppslagSpringRunnerTest {
 
     @Autowired private lateinit var jdbcAggregateOperations: JdbcAggregateOperations
     @Autowired private lateinit var applicationContext: ApplicationContext
+    @Autowired private lateinit var cachemanager: CacheManager
 
     @LocalServerPort
     private var port: Int? = 0
@@ -38,11 +42,8 @@ abstract class OppslagSpringRunnerTest {
     fun reset() {
         loggingEvents.clear()
         resetDatabase()
-        stoppWireMockServers()
-    }
-
-    private fun stoppWireMockServers() {
-        applicationContext.getBeansOfType(WireMockServer::class.java).values.forEach(WireMockServer::stop)
+        cachemanager.cacheNames.forEach({cachemanager?.getCache(it)?.clear()})
+        applicationContext.getBeansOfType(WireMockServer::class.java).values.forEach(WireMockServer::resetRequests)
     }
 
     private fun resetDatabase() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -33,7 +33,7 @@ abstract class OppslagSpringRunnerTest {
 
     @Autowired private lateinit var jdbcAggregateOperations: JdbcAggregateOperations
     @Autowired private lateinit var applicationContext: ApplicationContext
-    @Autowired private lateinit var cachemanager: CacheManager
+    @Autowired private lateinit var cacheManager: CacheManager
 
     @LocalServerPort
     private var port: Int? = 0
@@ -42,8 +42,19 @@ abstract class OppslagSpringRunnerTest {
     fun reset() {
         loggingEvents.clear()
         resetDatabase()
-        cachemanager.cacheNames.forEach({cachemanager?.getCache(it)?.clear()})
+        clearCaches()
+        resetWiremockServers()
+    }
+
+    private fun resetWiremockServers() {
         applicationContext.getBeansOfType(WireMockServer::class.java).values.forEach(WireMockServer::resetRequests)
+    }
+
+    private fun clearCaches() {
+        cacheManager.cacheNames
+                .map { cacheManager.getCache(it) }
+                .filterNotNull()
+                .forEach { it.clear() }
     }
 
     private fun resetDatabase() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/fagsak/FagsakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/fagsak/FagsakControllerTest.kt
@@ -11,9 +11,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("integrasjonstest", "mock-oauth", "mock-integrasjoner", "mock-pdl")
 internal class FagsakControllerTest : OppslagSpringRunnerTest() {
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadMedVedlegg
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.exchange
@@ -18,10 +17,8 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
-@ActiveProfiles("integrasjonstest", "mock-oauth", "mock-integrasjoner", "mock-pdl")
 internal class VurderingControllerTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var behandlingService: BehandlingService
@@ -31,9 +28,7 @@ internal class VurderingControllerTest : OppslagSpringRunnerTest() {
         headers.setBearerAuth(lokalTestToken)
     }
 
-    //Klarer ikke kjøre flere integrasjonstester i samme testklasse da familie-integrasjoner er mocket ut med wiremock og ikke klarer å starte/stoppe slik vi ønsker
     @Test
-    @Disabled
     internal fun `skal hente inngangsvilkår`() {
         val respons: ResponseEntity<Ressurs<InngangsvilkårDto>> = opprettInngangsvilkår()
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -7,10 +7,8 @@ import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
-@ActiveProfiles("local", "mock-oauth")
 internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var fagsakRepository: FagsakRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
@@ -7,9 +7,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("local", "mock-oauth")
 internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var fagsakRepository: FagsakRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/InsertUpdateRepositoryImplTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/InsertUpdateRepositoryImplTest.kt
@@ -8,9 +8,7 @@ import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.relational.core.conversion.DbActionExecutionException
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("local", "mock-oauth")
 internal class InsertUpdateRepositoryImplTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var fagsakRepository: FagsakRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/OppgaveRepositoryTest.kt
@@ -8,10 +8,8 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
-@ActiveProfiles("local", "mock-oauth")
 internal class OppgaveRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var oppgaveRepository: OppgaveRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/RepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/RepositoryTest.kt
@@ -9,10 +9,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDateTime
 
-@ActiveProfiles("integrasjonstest")
 internal class RepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var fagsakRepository: FagsakRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadRepositoryTest.kt
@@ -11,14 +11,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.h2.util.MathUtils
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
-@ActiveProfiles("local", "mock-oauth")
-@TestPropertySource(properties = ["FAMILIE_INTEGRASJONER_URL=http://localhost:28085"])
 internal class SøknadRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var søknadRepository: SøknadRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårVurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårVurderingRepositoryTest.kt
@@ -9,10 +9,8 @@ import no.nav.familie.ef.sak.repository.domain.VilkårType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 import java.util.*
 
-@ActiveProfiles("local", "mock-oauth")
 internal class VilkårVurderingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var vilkårVurderingRepository: VilkårVurderingRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
@@ -11,9 +11,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("integrasjonstest")
 internal class FagsakServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var fagsakService: FagsakService

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/KodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/KodeverkServiceTest.kt
@@ -7,10 +7,8 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.config.IntegrasjonerConfig
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 
-@ActiveProfiles("local", "mock-oauth", "mock-integrasjoner")
 internal class KodeverkServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var kodeverkService: KodeverkService

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/StegServiceTest.kt
@@ -8,9 +8,7 @@ import no.nav.familie.ef.sak.repository.FagsakRepository
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("integrasjonstest")
 internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var stegService: StegService

--- a/src/test/kotlin/no/nav/familie/ef/sak/økonomi/TilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/økonomi/TilkjentYtelseRepositoryTest.kt
@@ -4,14 +4,10 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.repository.TilkjentYtelseRepository
 import no.nav.familie.ef.sak.økonomi.Utbetalingsoppdrag.lagUtbetalingsoppdrag
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.test.context.ActiveProfiles
 
-@ActiveProfiles("local", "mock-oauth")
-@Tag("integration")
 internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired


### PR DESCRIPTION
Felles spring context for integrasjonstester:
- Unngår at testene tar unødvendig lang tid på kjøring
- Unngår at wiremock prøver å starte før den rekker å stoppe (må isåfall legge på sleep på oppstart dersom det er reellt behov for diff på context)
- Samle det som kan samles...