### PR TITLE
Legg til Sivilstand inngangsvilkår mapper og Dto

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/InngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/InngangsvilkårDto.kt
@@ -1,3 +1,5 @@
 package no.nav.familie.ef.sak.api.dto
 
-data class InngangsvilkårDto(val medlemskap: MedlemskapDto, val vurderinger: List<VilkårsvurderingDto>)
+data class InngangsvilkårDto(val medlemskap: MedlemskapDto,
+                             val sivilstand: SivilstandInngangsvilkårDto,
+                             val vurderinger: List<VilkårsvurderingDto>)

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandInngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandInngangsvilkårDto.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ef.sak.api.dto
+
+import java.time.LocalDate
+
+data class SivilstandInngangsvilkårDto(val søknadsgrunnlag: SivilstandSøknadsgrunnlagDto,
+                                       val registergrunnlag: SivilstandRegistergrunnlagDto)
+
+data class SivilstandSøknadsgrunnlagDto(val samlivsbruddsdato: LocalDate?,
+                                        val endringSamværsordningDato: LocalDate?,
+                                        val fraflytningsdato: LocalDate?,
+                                        val erUformeltGift: Boolean?,
+                                        val erUformeltSeparertEllerSkilt: Boolean?,
+                                        val datoSøktSeparasjon: LocalDate?,
+                                        val søktOmSkilsmisseSeparasjon: Boolean?,
+                                        val årsakEnslig: String?)
+
+data class SivilstandRegistergrunnlagDto(val type: Sivilstandstype,
+                                         val gyldigFraOgMed: LocalDate?)

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandInngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandInngangsvilkårDto.kt
@@ -11,8 +11,7 @@ data class SivilstandSøknadsgrunnlagDto(val samlivsbruddsdato: LocalDate?,
                                         val erUformeltGift: Boolean?,
                                         val erUformeltSeparertEllerSkilt: Boolean?,
                                         val datoSøktSeparasjon: LocalDate?,
-                                        val søktOmSkilsmisseSeparasjon: Boolean?,
-                                        val årsakEnslig: String?)
+                                        val søktOmSkilsmisseSeparasjon: Boolean?)
 
 data class SivilstandRegistergrunnlagDto(val type: Sivilstandstype,
                                          val gyldigFraOgMed: LocalDate?)

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandMapper.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.sak.mapper
+
+import no.nav.familie.ef.sak.api.dto.SivilstandInngangsvilkårDto
+import no.nav.familie.ef.sak.api.dto.SivilstandRegistergrunnlagDto
+import no.nav.familie.ef.sak.api.dto.SivilstandSøknadsgrunnlagDto
+import no.nav.familie.ef.sak.api.dto.Sivilstandstype
+import no.nav.familie.ef.sak.integration.dto.pdl.PdlSøker
+import no.nav.familie.ef.sak.repository.domain.søknad.Sivilstand
+
+object SivilstandMapper {
+
+    fun tilDto(sivilstandsdetaljer: Sivilstand, pdlSøker: PdlSøker): SivilstandInngangsvilkårDto {
+        val sivilstand = pdlSøker.sivilstand.first()
+        val registergrunnlag = SivilstandRegistergrunnlagDto(type = Sivilstandstype.valueOf(sivilstand.type.name),
+                                                             gyldigFraOgMed = sivilstand.gyldigFraOgMed)
+
+        val søknadsgrunnlag =
+                SivilstandSøknadsgrunnlagDto(samlivsbruddsdato = sivilstandsdetaljer.samlivsbruddsdato,
+                                             endringSamværsordningDato = sivilstandsdetaljer.endringSamværsordningDato,
+                                             fraflytningsdato = sivilstandsdetaljer.fraflytningsdato,
+                                             erUformeltGift = sivilstandsdetaljer.erUformeltGift,
+                                             erUformeltSeparertEllerSkilt = sivilstandsdetaljer.erUformeltSeparertEllerSkilt,
+                                             datoSøktSeparasjon = sivilstandsdetaljer.datoSøktSeparasjon,
+                                             søktOmSkilsmisseSeparasjon = sivilstandsdetaljer.søktOmSkilsmisseSeparasjon,
+                                             årsakEnslig = sivilstandsdetaljer.årsakEnslig)
+
+        return SivilstandInngangsvilkårDto(
+                søknadsgrunnlag, registergrunnlag
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandMapper.kt
@@ -22,7 +22,7 @@ object SivilstandMapper {
                                              erUformeltSeparertEllerSkilt = sivilstandsdetaljer.erUformeltSeparertEllerSkilt,
                                              datoSøktSeparasjon = sivilstandsdetaljer.datoSøktSeparasjon,
                                              søktOmSkilsmisseSeparasjon = sivilstandsdetaljer.søktOmSkilsmisseSeparasjon,
-                                             årsakEnslig = sivilstandsdetaljer.årsakEnslig)
+                )
 
         return SivilstandInngangsvilkårDto(
                 søknadsgrunnlag, registergrunnlag

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.integration.PdlClient
 import no.nav.familie.ef.sak.integration.dto.pdl.Familierelasjonsrolle
 import no.nav.familie.ef.sak.mapper.AleneomsorgMapper
 import no.nav.familie.ef.sak.mapper.MedlemskapMapper
+import no.nav.familie.ef.sak.mapper.SivilstandMapper
 import no.nav.familie.ef.sak.repository.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.repository.domain.*
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
@@ -66,6 +67,9 @@ class VurderingService(private val behandlingService: BehandlingService,
         val medlemskap = medlemskapMapper.tilDto(medlemskapsdetaljer = søknad.medlemskap,
                                                  pdlSøker = pdlSøker)
 
+        val sivilstand = SivilstandMapper.tilDto(sivilstandsdetaljer = søknad.sivilstand,
+                                                 pdlSøker = pdlSøker)
+
         val vurderinger = hentEllerOpprettVurderingerForInngangsvilkår(behandlingId)
                 .map {
                     VilkårsvurderingDto(id = it.id,
@@ -81,7 +85,7 @@ class VurderingService(private val behandlingService: BehandlingService,
                                                                    delvurdering.resultat)
                                         })
                 }
-        return InngangsvilkårDto(medlemskap = medlemskap, vurderinger = vurderinger)
+        return InngangsvilkårDto(medlemskap = medlemskap, sivilstand = sivilstand, vurderinger = vurderinger)
     }
 
     private fun hentEllerOpprettVurderingerForInngangsvilkår(behandlingId: UUID): List<Vilkårsvurdering> {
@@ -113,8 +117,10 @@ class VurderingService(private val behandlingService: BehandlingService,
         val inngangsvilkår = VilkårType.hentInngangsvilkår()
 
         return inngangsvilkår.filter {
-            lagredeVilkårsvurderinger.any { vurdering -> vurdering.type == it
-                                                         && vurdering.resultat == Vilkårsresultat.IKKE_VURDERT }
+            lagredeVilkårsvurderinger.any { vurdering ->
+                vurdering.type == it
+                && vurdering.resultat == Vilkårsresultat.IKKE_VURDERT
+            }
             || lagredeVilkårsvurderinger.none { vurdering -> vurdering.type == it }
         }
     }


### PR DESCRIPTION


**Innhold:**
- Legger til mapper og Dto for å kunne hente ut og vise data i `ef-sak-frontend`. Er en del av [denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2195) oppgaven.
- Fjernet ÅrsakEnslig siden vi ikke trengte det i første omgang ref diskusjon på [Slack](https://nav-it.slack.com/archives/C01087QRJ2U/p1605533030088300)


![image](https://user-images.githubusercontent.com/8249453/99263393-69db2980-281f-11eb-8373-3ce7b9a68da3.png)
![image](https://user-images.githubusercontent.com/8249453/99263556-ab6bd480-281f-11eb-88b5-485fe9582596.png)

