### PR TITLE
Bug/deserialisering av søknad feiler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/config/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/config/DatabaseConfiguration.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.sak.repository.domain.DelvilkårsvurderingWrapper
 import no.nav.familie.ef.sak.repository.domain.Endret
 import no.nav.familie.ef.sak.repository.domain.TilkjentYtelseStatus
 import no.nav.familie.ef.sak.repository.domain.søknad.Dokumentasjon
+import no.nav.familie.ef.sak.repository.domain.søknad.UnderUtdanning
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.prosessering.PropertiesWrapperTilStringConverter

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapper.kt
@@ -215,7 +215,8 @@ object SøknadsskjemaMapper {
                       underUtdanning = tilDomene(aktivitet.underUtdanning?.verdi),
                       aksjeselskap = tilAksjeselskap(aktivitet.aksjeselskap?.verdi),
                       erIArbeid = aktivitet.erIArbeid?.verdi,
-                      erIArbeidDokumentasjon = tilDomene(aktivitet.erIArbeidDokumentasjon?.verdi))
+                      erIArbeidDokumentasjon = tilDomene(aktivitet.erIArbeidDokumentasjon?.verdi),
+                      tidligereUtdanninger = tilTidligereUtdanninger(aktivitet.underUtdanning?.verdi?.tidligereUtdanninger?.verdi))
 
     private fun tilFirmaer(list: List<KontraktSelvstendig>?): Set<Selvstendig>? =
             list?.map {
@@ -242,13 +243,12 @@ object SøknadsskjemaMapper {
                                hvorMyeSkalDuStudere = it.hvorMyeSkalDuStudere?.verdi,
                                hvaErMåletMedUtdanningen = it.hvaErMåletMedUtdanningen?.verdi,
                                utdanningEtterGrunnskolen = it.utdanningEtterGrunnskolen.verdi,
-                               tidligereUtdanninger = tilTidligereUtdanninger(it.tidligereUtdanninger?.verdi),
                                semesteravgift = it.semesteravgift?.verdi?.roundToInt(),
                                studieavgift = it.studieavgift?.verdi?.roundToInt(),
                                eksamensgebyr = it.eksamensgebyr?.verdi?.roundToInt())
             }
 
-    private fun tilTidligereUtdanninger(list: List<KontraktTidligereUtdanning>?): Set<TidligereUtdanning>? =
+    private fun tilTidligereUtdanninger(list: List<KontraktTidligereUtdanning>?): Set<TidligereUtdanning> =
             list?.map {
                 TidligereUtdanning(linjeKursGrad = it.linjeKursGrad.verdi,
                                    fra = YearMonth.of(it.nårVarSkalDuVæreElevStudent.verdi.fraÅr,

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/søknad/Aktivitet.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/søknad/Aktivitet.kt
@@ -18,7 +18,10 @@ data class Aktivitet(val hvordanErArbeidssituasjonen: String,
                      @MappedCollection(idColumn = "soknadsskjema_id")
                      val aksjeselskap: Set<Aksjeselskap>? = emptySet(),
                      val erIArbeid: String? = null,
-                     val erIArbeidDokumentasjon: Dokumentasjon? = null)
+                     val erIArbeidDokumentasjon: Dokumentasjon? = null,
+                     @MappedCollection(idColumn = "soknadsskjema_id")
+                     val tidligereUtdanninger: Set<TidligereUtdanning> = emptySet()
+)
 
 data class Arbeidsgiver(val arbeidsgivernavn: String,
                         val arbeidsmengde: Int? = null,

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/søknad/UnderUtdanning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/søknad/UnderUtdanning.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.sak.repository.domain.søknad
 
 import org.springframework.data.relational.core.mapping.Column
-import org.springframework.data.relational.core.mapping.MappedCollection
 import java.time.LocalDate
 import java.time.YearMonth
 
@@ -15,8 +14,6 @@ data class UnderUtdanning(val skoleUtdanningssted: String,
                           @Column("hva_er_malet_med_utdanningen")
                           val hvaErMåletMedUtdanningen: String?,
                           val utdanningEtterGrunnskolen: Boolean,
-                          @MappedCollection(idColumn = "soknadsskjema_id")
-                          val tidligereUtdanninger: Set<TidligereUtdanning>? = emptySet(),
                           val semesteravgift: Int? = null,
                           val studieavgift: Int? = null,
                           val eksamensgebyr: Int? = null)

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadsskjemaOvergangsstønadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadsskjemaOvergangsstønadRepositoryTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.repository.SøknadBarnetilsynRepository
 import no.nav.familie.ef.sak.repository.SøknadOvergangsstønadRepository
 import no.nav.familie.ef.sak.repository.SøknadSkolepengerRepository
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -38,14 +39,21 @@ internal class SøknadsskjemaOvergangsstønadRepositoryTest : OppslagSpringRunne
     internal fun `søknad om overgangsstønad uten utdanning lagres korrekt`() {
 
         val aktivitet = Testsøknad.søknadOvergangsstønad.aktivitet
+        val barn = Testsøknad.søknadOvergangsstønad.barn
+        val barnUtenBarnepass = barn.verdi.map { it.copy(barnepass = null) }
         val aktivitetUtenUtdanning = aktivitet.verdi.copy(underUtdanning = null)
-        val søknadTilLagring = SøknadsskjemaMapper.tilDomene(Testsøknad.søknadOvergangsstønad.copy(aktivitet = aktivitet.copy(verdi = aktivitetUtenUtdanning)))
+        val søknadTilLagring = SøknadsskjemaMapper.tilDomene(Testsøknad.søknadOvergangsstønad.copy(
+                aktivitet = aktivitet.copy(verdi = aktivitetUtenUtdanning),
+                barn = Søknadsfelt("", barnUtenBarnepass)))
 
         søknadOvergangsstønadRepository.insert(søknadTilLagring)
         val søknadFraDatabase = søknadOvergangsstønadRepository.findByIdOrThrow(søknadTilLagring.id)
 
-        // Jdbc returnerer tomt objekt for barnepass selv om Embedded.OnEmpty.USE_NULL er satt
-        assertThat(søknadFraDatabase).isEqualToIgnoringGivenFields(søknadTilLagring, "barn")
+        assertThat(søknadFraDatabase.aktivitet.underUtdanning).isNull()
+        assertThat(søknadFraDatabase.aktivitet.tidligereUtdanninger).isEmpty()
+        assertThat(søknadFraDatabase.barn.first().barnepass!!.årsakBarnepass).isNull()
+        assertThat(søknadFraDatabase.barn.first().barnepass!!.barnepassordninger).isEmpty()
+
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadsskjemaOvergangsstønadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadsskjemaOvergangsstønadRepositoryTest.kt
@@ -35,6 +35,20 @@ internal class SøknadsskjemaOvergangsstønadRepositoryTest : OppslagSpringRunne
     }
 
     @Test
+    internal fun `søknad om overgangsstønad uten utdanning lagres korrekt`() {
+
+        val aktivitet = Testsøknad.søknadOvergangsstønad.aktivitet
+        val aktivitetUtenUtdanning = aktivitet.verdi.copy(underUtdanning = null)
+        val søknadTilLagring = SøknadsskjemaMapper.tilDomene(Testsøknad.søknadOvergangsstønad.copy(aktivitet = aktivitet.copy(verdi = aktivitetUtenUtdanning)))
+
+        søknadOvergangsstønadRepository.insert(søknadTilLagring)
+        val søknadFraDatabase = søknadOvergangsstønadRepository.findByIdOrThrow(søknadTilLagring.id)
+
+        // Jdbc returnerer tomt objekt for barnepass selv om Embedded.OnEmpty.USE_NULL er satt
+        assertThat(søknadFraDatabase).isEqualToIgnoringGivenFields(søknadTilLagring, "barn")
+    }
+
+    @Test
     internal fun `søknad om skolepenger lagres korrekt`() {
         val søknadTilLagring = SøknadsskjemaMapper.tilDomene(Testsøknad.søknadSkolepenger)
 


### PR DESCRIPTION
Embedded nullable db-objekter som inneholder collections vil smelle i deserialisering. Dette fordi collections blir en tom liste/set og derfor er ikke objektet null og "Kotlin blir sinna". Vi må følgelig trekke ut `tidligereUtdanning´ fra `UnderUtdanning` for at sistnevnte skal oppføre seg som vi ønsker mtp null/ikke-null. 

Samme utfordring finnes i Barnepass, men der er årsak nullable og vi får deserialisert Barnepass som et objekt med tom liste av banepassordninger og null i årsak. Ikke helt riktig oppførsel, men det smeller ikke. 

Andre/bedre løsningsforslag tas imot hvis noen brenner inne med en god idé. 