### PR TITLE
Kontraktoppdatering - feedhendelser med liste av personens alle identer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>1.20210114091432_ef96974</felles.version>
         <prosessering.version>1.20210112120136_9956e1e</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20210114082116_8e47040</kontrakter.version>
+        <kontrakter.version>2.0_20210115120711_1c93af9</kontrakter.version>
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->
         <sonar.projectKey>${SONAR_PROJECTKEY}</sonar.projectKey>
         <sonar.organization>navit</sonar.organization>

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/InfotrygdFeedClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/InfotrygdFeedClientTest.kt
@@ -55,7 +55,7 @@ internal class InfotrygdFeedClientTest {
         wiremockServerItem.stubFor(
                 WireMock.post(WireMock.urlPathMatching(client.opprettPeriodeUri.path))
                         .willReturn(WireMock.ok()))
-        client.opprettPeriodeHendelse(OpprettPeriodeHendelseDto("", StønadType.BARNETILSYN, emptyList()))
+        client.opprettPeriodeHendelse(OpprettPeriodeHendelseDto(setOf(""), StønadType.BARNETILSYN, emptyList()))
     }
 
     @Test
@@ -63,7 +63,7 @@ internal class InfotrygdFeedClientTest {
         wiremockServerItem.stubFor(
                 WireMock.post(WireMock.urlPathMatching(client.opprettStartBehandlingUri.path))
                         .willReturn(WireMock.ok()))
-        client.opprettStartBehandlingHendelse(OpprettStartBehandlingHendelseDto("", StønadType.BARNETILSYN))
+        client.opprettStartBehandlingHendelse(OpprettStartBehandlingHendelseDto(setOf(""), StønadType.BARNETILSYN))
     }
 
     @Test
@@ -71,6 +71,6 @@ internal class InfotrygdFeedClientTest {
         wiremockServerItem.stubFor(
                 WireMock.post(WireMock.urlPathMatching(client.opprettVedtakUri.path))
                         .willReturn(WireMock.ok()))
-        client.opprettVedtakHendelse(OpprettVedtakHendelseDto("", StønadType.BARNETILSYN, LocalDate.now()))
+        client.opprettVedtakHendelse(OpprettVedtakHendelseDto(setOf(""), StønadType.BARNETILSYN, LocalDate.now()))
     }
 }


### PR DESCRIPTION
Infotrygd ønsker att vi oppretter hendelser for alle identer til en person. Kommer en PR i ef-infotrygd-feed og
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-3344
https://github.com/navikt/familie-kontrakter/pull/264