### PR TITLE
Legger til ingress som gjør sak tilgjengelig fra familie-prosessering…

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -42,6 +42,7 @@ spec:
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-sak.nais.preprod.local
     - https://familie-ef-sak.dev-fss.nais.io
+    - https://familie-ef-sak.dev-fss-pub.nais.io
   secureLogs:
     enabled: true
   env:

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -44,6 +44,7 @@ spec:
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-ef-sak.nais.adeo.no
     - https://familie-ef-sak.prod-fss.nais.io
+    - https://familie-ef-sak.prod-fss-pub.nais.io
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod


### PR DESCRIPTION
… som ligger i GCP

Familie-prosessering kjører i GCP og for å få tilgang til ef-sak må man ha en gcp-vennelig url https://doc.nais.io/clusters/on-premises/#dev-fss