### PR TITLE
lagt til sortering av adresser

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/PersonopplysningerMapper.kt
@@ -80,9 +80,18 @@ class PersonopplysningerMapper(private val adresseMapper: AdresseMapper,
                 søker.bostedsadresse.map(adresseMapper::tilAdresse) +
                 søker.kontaktadresse.map(adresseMapper::tilAdresse) +
                 søker.oppholdsadresse.map(adresseMapper::tilAdresse)
-        return adresser.sortedWith(compareByDescending<AdresseDto>
-                                   { it.gyldigFraOgMed ?: LocalDate.MAX }
-                                           .thenBy(AdresseDto::type))
+
+        return sorterAdresser(adresser)
+    }
+
+    fun sorterAdresser(adresser: List<AdresseDto>): List<AdresseDto> {
+        val (historiskeAdresser, aktiveAdresser) = adresser
+                .sortedWith(compareByDescending<AdresseDto> { it.gyldigFraOgMed ?: LocalDate.MAX }.thenBy(AdresseDto::type))
+                .partition { it.gyldigTilOgMed != null }
+
+        val (bostedsadresse, aktivUtenBostedsadresse) = aktiveAdresser.partition { it.type == AdresseType.BOSTEDADRESSE }
+
+        return bostedsadresse + aktivUtenBostedsadresse + historiskeAdresser
     }
 
     fun mapBarn(personIdent: String,
@@ -134,5 +143,4 @@ class PersonopplysningerMapper(private val adresseMapper: AdresseMapper,
             && (it.sluttdatoForKontrakt == null || it.sluttdatoForKontrakt.isAfter(LocalDateTime.now()))
         }
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/PersonopplysningerMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/PersonopplysningerMapperTest.kt
@@ -1,9 +1,12 @@
 package no.nav.familie.ef.sak.mapper
 
 import io.mockk.mockk
+import no.nav.familie.ef.sak.api.dto.AdresseDto
+import no.nav.familie.ef.sak.api.dto.AdresseType
 import no.nav.familie.ef.sak.integration.dto.pdl.*
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalDateTime.now
 
@@ -135,6 +138,21 @@ internal class PersonopplysningerMapperTest {
         Assertions.assertThat(personopplysningerMapper.borPåSammeAdresse(pdlBarn, forelderAdresser)).isTrue()
     }
 
+    @Test
+    internal fun `sorter adresser`() {
+
+        val aktivBostedsadresse = lagAdresseDto(AdresseType.BOSTEDADRESSE, LocalDate.now().minusDays(5))
+        val historiskBostedsadresse = lagAdresseDto(
+                AdresseType.BOSTEDADRESSE, LocalDate.now().minusYears(1), LocalDate.now().minusDays(5))
+        val aktivOppholdsadresse = lagAdresseDto(AdresseType.OPPHOLDSADRESSE, LocalDate.now())
+        val historiskKontaktadresse = lagAdresseDto(
+                AdresseType.KONTAKTADRESSE, LocalDate.now().minusDays(15), LocalDate.now().minusDays(14))
+
+        val adresser = listOf(historiskBostedsadresse, aktivOppholdsadresse, historiskKontaktadresse, aktivBostedsadresse)
+
+        Assertions.assertThat(personopplysningerMapper.sorterAdresser(adresser))
+                .containsExactly(aktivBostedsadresse, aktivOppholdsadresse, historiskKontaktadresse, historiskBostedsadresse)
+    }
 
     fun lagAdresse(vegadresse: Vegadresse?,
                    gyldighetstidspunkt: LocalDateTime?,
@@ -150,6 +168,17 @@ internal class PersonopplysningerMapperTest {
                 utenlandskAdresse = null,
                 ukjentBosted = null,
                 matrikkeladresse = matrikkeladresse
+        )
+    }
+
+    private fun lagAdresseDto(type: AdresseType,
+                              gyldigFraOgMed: LocalDate?,
+                              gyldigTilOgMed: LocalDate? = null): AdresseDto {
+        return AdresseDto(
+                visningsadresse = "Oslogata 1",
+                type = type,
+                gyldigFraOgMed = gyldigFraOgMed,
+                gyldigTilOgMed = gyldigTilOgMed
         )
     }
 }


### PR DESCRIPTION
Har lagt til sortering av adresser i PersonopplysningerMapper.
Oppdatert 'mapper pdlsøker til PersonopplysningerDto' test slik at rekkefølge på adresser blir også testet. 