### PR TITLE
Lagrer NavIdent i stedet for epost til saksbehandlaren. Gjør det muli…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/BehandlingHistorikkDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/BehandlingHistorikkDto.kt
@@ -8,7 +8,7 @@ import java.util.*
 data class BehandlingshistorikkDto(val behandlingId: UUID,
                                    var steg: StegType,
                                    val endretAvNavn: String,
-                                   val endretAvMail: String,
+                                   val endretAv: String,
                                    val endretTid: LocalDateTime = LocalDateTime.now(),
                                    val utfall: StegUtfall? = null,
                                    val metadata: Map<String, Any>? = null)

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandlingshistorikk.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandlingshistorikk.kt
@@ -24,7 +24,7 @@ inline fun Behandlingshistorikk.tilDto(): BehandlingshistorikkDto {
     return BehandlingshistorikkDto(behandlingId = this.behandlingId,
                                    steg = this.steg,
                                    endretAvNavn = this.opprettetAvNavn,
-                                   endretAvMail = this.opprettetAv,
+                                   endretAv = this.opprettetAv,
                                    endretTid = this.endretTid,
                                    utfall = this.utfall,
                                    metadata = this.metadata.tilJson())

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
@@ -24,8 +24,11 @@ class TotrinnskontrollService(private val behandlingshistorikkService: Behandlin
                               private val behandlingService: BehandlingService,
                               private val tilgangService: TilgangService) {
 
+    /**
+     * Lagrer data om besluttning av totrinnskontroll og returnerer saksbehandleren som sendte behandling til beslutter
+     */
     @Transactional
-    fun lagreTotrinnskontroll(behandling: Behandling, beslutteVedtak: BeslutteVedtakDto) {
+    fun lagreTotrinnskontrollOgReturnerBehandler(behandling: Behandling, beslutteVedtak: BeslutteVedtakDto): String {
         val sisteBehandlingshistorikk = behandlingshistorikkService.finnSisteBehandlingshistorikk(behandlingId = behandling.id)
 
         if (sisteBehandlingshistorikk.steg != StegType.SEND_TIL_BESLUTTER) {
@@ -46,6 +49,7 @@ class TotrinnskontrollService(private val behandlingshistorikkService: Behandlin
                                                             metadata = beslutteVedtak)
 
         behandlingService.oppdaterStatusPåBehandling(behandling.id, nyStatus)
+        return sisteBehandlingshistorikk.opprettetAv
     }
 
     fun hentTotrinnskontrollStatus(behandlingId: UUID): TotrinnskontrollStatusDto {

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
@@ -25,7 +25,7 @@ class TotrinnskontrollService(private val behandlingshistorikkService: Behandlin
                               private val tilgangService: TilgangService) {
 
     /**
-     * Lagrer data om besluttning av totrinnskontroll og returnerer saksbehandleren som sendte behandling til beslutter
+     * Lagrer data om besluttning av totrinnskontroll og returnerer navIdent til saksbehandleren som sendte behandling til beslutter
      */
     @Transactional
     fun lagreTotrinnskontrollOgReturnerBehandler(behandling: Behandling, beslutteVedtak: BeslutteVedtakDto): String {

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.repository.domain.Behandling
 import no.nav.familie.ef.sak.service.FagsakService
 import no.nav.familie.ef.sak.service.OppgaveService
 import no.nav.familie.ef.sak.service.TotrinnskontrollService
-import no.nav.familie.ef.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.task.FerdigstillOppgaveTask
 import no.nav.familie.ef.sak.task.IverksettMotOppdragTask
 import no.nav.familie.ef.sak.task.OpprettOppgaveTask
@@ -29,7 +28,7 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
     }
 
     override fun utførOgReturnerNesteSteg(behandling: Behandling, data: BeslutteVedtakDto): StegType {
-        totrinnskontrollService.lagreTotrinnskontroll(behandling, data)
+        val saksbehandler = totrinnskontrollService.lagreTotrinnskontrollOgReturnerBehandler(behandling, data)
 
         ferdigstillOppgave(behandling)
 
@@ -38,7 +37,7 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
             opprettTaskForIverksettMotOppdrag(behandling)
             stegType().hentNesteSteg(behandling.type)
         } else {
-            opprettBehandleUnderkjentVedtakOppgave(behandling)
+            opprettBehandleUnderkjentVedtakOppgave(behandling, saksbehandler)
             StegType.SEND_TIL_BESLUTTER
         }
     }
@@ -50,12 +49,12 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
         }
     }
 
-    private fun opprettBehandleUnderkjentVedtakOppgave(behandling: Behandling) {
+    private fun opprettBehandleUnderkjentVedtakOppgave(behandling: Behandling, saksbehandler: String) {
         taskRepository.save(OpprettOppgaveTask.opprettTask(
                 OpprettOppgaveTaskData(behandlingId = behandling.id,
                                        oppgavetype = Oppgavetype.BehandleUnderkjentVedtak,
                                        fristForFerdigstillelse = LocalDate.now(),
-                                       tilordnetNavIdent = SikkerhetContext.hentSaksbehandler())))
+                                       tilordnetNavIdent = saksbehandler)))
     }
 
     private fun opprettTaskForIverksettMotOppdrag(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
@@ -49,12 +49,12 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
         }
     }
 
-    private fun opprettBehandleUnderkjentVedtakOppgave(behandling: Behandling, saksbehandler: String) {
+    private fun opprettBehandleUnderkjentVedtakOppgave(behandling: Behandling, navIdent: String) {
         taskRepository.save(OpprettOppgaveTask.opprettTask(
                 OpprettOppgaveTaskData(behandlingId = behandling.id,
                                        oppgavetype = Oppgavetype.BehandleUnderkjentVedtak,
                                        fristForFerdigstillelse = LocalDate.now(),
-                                       tilordnetNavIdent = saksbehandler)))
+                                       tilordnetNavIdent = navIdent)))
     }
 
     private fun opprettTaskForIverksettMotOppdrag(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sikkerhet/SikkerhetContext.kt
@@ -12,6 +12,14 @@ object SikkerhetContext {
     fun hentSaksbehandler(): String {
         return Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
                 .fold(onSuccess = {
+                    it.getClaims("azuread")?.get("NAVident")?.toString() ?: SYSTEM_FORKORTELSE
+                },
+                      onFailure = { SYSTEM_FORKORTELSE })
+    }
+
+    fun hentSaksbehandlerMail(): String {
+        return Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
+                .fold(onSuccess = {
                     it.getClaims("azuread")?.get("preferred_username")?.toString() ?: SYSTEM_FORKORTELSE
                 },
                       onFailure = { SYSTEM_FORKORTELSE })

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingshistorikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingshistorikkControllerTest.kt
@@ -57,7 +57,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
         leggInnHistorikk(behandling, "3", LocalDateTime.now().plusDays(1))
 
         val respons = hentHistorikk(behandling.id)
-        assertThat(respons.body.data!!.map { it.endretAvMail }).containsExactly("3", "1", "2")
+        assertThat(respons.body.data!!.map { it.endretAv }).containsExactly("3", "1", "2")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -247,7 +247,7 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
         val rolle = if (saksbehandler.beslutter) rolleConfig.beslutterRolle else rolleConfig.saksbehandlerRolle
         var claimsSet = JwtTokenGenerator.createSignedJWT("subject").jwtClaimsSet
         claimsSet = JWTClaimsSet.Builder(claimsSet)
-                .claim("preferred_username", saksbehandler)
+                .claim("NAVident", saksbehandler)
                 .claim("groups", listOf(rolle))
                 .build()
         val createSignedJWT = JwtTokenGenerator.createSignedJWT(JwkGenerator.getDefaultRSAKey(), claimsSet)

--- a/src/test/kotlin/no/nav/familie/ef/sak/util/BrukerContextUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/util/BrukerContextUtil.kt
@@ -25,5 +25,6 @@ object BrukerContextUtil {
         } returns tokenValidationContext
         every { tokenValidationContext.getClaims("azuread") } returns jwtTokenClaims
         every { jwtTokenClaims.get("preferred_username") } returns preferredUsername
+        every { jwtTokenClaims.get("NAVident") } returns preferredUsername
     }
 }


### PR DESCRIPTION
…g å opprette oppgaver med tilordnetRessurs

På slack så anbefales det att man bruker NavIdent for lagring om hvem som har endret/opprettet. 
Dette gjør det også mulig å opprette en oppgave tildelt en saksehandler, i tilfellet med BeslutteVedtak - hvis man underkjenner ønsker vi å opprette en oppgave til den saksbehandler som sendte oppgaven til underkjennelse.

Testad i preprod ✅ 