### PR TITLE
map sivilstandsplaner

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/InngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/InngangsvilkårDto.kt
@@ -8,5 +8,6 @@ data class InngangsvilkårDto(val vurderinger: List<VilkårsvurderingDto>,
 data class InngangsvilkårGrunnlagDto(val medlemskap: MedlemskapDto,
                                      val sivilstand: SivilstandInngangsvilkårDto,
                                      val bosituasjon: BosituasjonDto,
-                                     val barnMedSamvær: List<BarnMedSamværDto>
+                                     val barnMedSamvær: List<BarnMedSamværDto>,
+                                     val sivilstandsplaner: SivilstandsplanerDto
                                     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandsplanerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/SivilstandsplanerDto.kt
@@ -1,0 +1,8 @@
+package no.nav.familie.ef.sak.api.dto
+
+import java.time.LocalDate
+
+data class SivilstandsplanerDto(val harPlaner: Boolean?,
+                                val fraDato: LocalDate?,
+                                val vordendeSamboerEktefelle: PersonMinimumDto?
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/TestSaksbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/TestSaksbehandlingController.kt
@@ -10,10 +10,7 @@ import no.nav.familie.ef.sak.service.BehandlingshistorikkService
 import no.nav.familie.ef.sak.service.FagsakService
 import no.nav.familie.ef.sak.service.PersonService
 import no.nav.familie.ef.sak.service.steg.StegType
-import no.nav.familie.kontrakter.ef.søknad.Barn
-import no.nav.familie.kontrakter.ef.søknad.Fødselsnummer
-import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
-import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
+import no.nav.familie.kontrakter.ef.søknad.*
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.context.annotation.Profile
@@ -77,6 +74,12 @@ class TestSaksbehandlingController(private val fagsakService: FagsakService,
         val søknad: SøknadOvergangsstønad = TestsøknadBuilder.Builder()
                 .setPersonalia(søkerMedBarn.søker.navn.gjeldende().visningsnavn(), søkerMedBarn.søkerIdent)
                 .setBarn(barneListe)
+                .setBosituasjon(delerDuBolig = EnumTekstverdiMedSvarId(verdi = "Nei, jeg bor alene med barn eller jeg er gravid og bor alene",
+                                                                   svarId = "borAleneMedBarnEllerGravid"))
+                .setSivilstandsplaner(harPlaner = true,
+                                      fraDato = LocalDate.of(2019, 9, 17),
+                                      vordendeSamboerEktefelle = TestsøknadBuilder.Builder().defaultPersonMinimum(navn = "Fyren som skal bli min samboer", fødselsdato = LocalDate.of(1979, 9, 17)),
+                )
                 .build().søknadOvergangsstønad
 
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandsplanerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/SivilstandsplanerMapper.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.ef.sak.mapper
+
+import no.nav.familie.ef.sak.api.dto.PersonMinimumDto
+import no.nav.familie.ef.sak.api.dto.SivilstandsplanerDto
+import no.nav.familie.ef.sak.repository.domain.søknad.Sivilstandsplaner
+
+object SivilstandsplanerMapper {
+
+    fun tilDto(sivilstandsplaner: Sivilstandsplaner): SivilstandsplanerDto {
+        val samboerDto = sivilstandsplaner.vordendeSamboerEktefelle?.let { PersonMinimumDto(it.navn, it.fødselsdato, it.fødselsnummer) }
+
+        return SivilstandsplanerDto(sivilstandsplaner.harPlaner,
+                                    sivilstandsplaner.fraDato,
+                                    samboerDto)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
@@ -8,10 +8,7 @@ import no.nav.familie.ef.sak.api.dto.VilkårsvurderingDto
 import no.nav.familie.ef.sak.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.integration.PdlClient
 import no.nav.familie.ef.sak.integration.dto.pdl.*
-import no.nav.familie.ef.sak.mapper.BarnMedSamværMapper
-import no.nav.familie.ef.sak.mapper.BosituasjonMapper
-import no.nav.familie.ef.sak.mapper.MedlemskapMapper
-import no.nav.familie.ef.sak.mapper.SivilstandMapper
+import no.nav.familie.ef.sak.mapper.*
 import no.nav.familie.ef.sak.repository.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.repository.domain.*
 import no.nav.familie.ef.sak.repository.domain.søknad.SøknadsskjemaOvergangsstønad
@@ -80,7 +77,9 @@ class VurderingService(private val behandlingService: BehandlingService,
 
         val barnMedSamvær = BarnMedSamværMapper.tilDto(pdlBarn, barneForeldre, søknad)
 
-        return InngangsvilkårGrunnlagDto(medlemskap, sivilstand, bosituasjon, barnMedSamvær)
+        val sivilstandsplaner = SivilstandsplanerMapper.tilDto(sivilstandsplaner = søknad.sivilstandsplaner)
+
+        return InngangsvilkårGrunnlagDto(medlemskap, sivilstand, bosituasjon, barnMedSamvær, sivilstandsplaner)
     }
 
     private fun hentVurderinger(behandlingId: UUID,


### PR DESCRIPTION
Et forsøk på å lage Dto og mapper slik at vi endelig kan vise sivilstandsplaner i appen (fikset tidligere en bug i frontend, men da brukte jeg frontend-mocken. Det viser seg at vi ikke mapper sivilstandsplaner i det hele tatt i backend.)

Jeg får en feilmelding i `VurderingsService` når jeg prøver å bruke mapperen min til å mappe over sivilstandsplaner til `inngangsvilkårGrunnlagDto`. Den klager over at sivilstandsplaner er optional. Brukte Bosituasjon som et eksempel, men ser ut som at det objektet er obligatorisk 🤷🏻‍♀️ Hva gjør man her? 

Sivilstandsplaner fra package no.nav.familie.ef.sak.repository.domain.søknad eksisterte fra før av. 
Inni `SøknadsskjemaOvergangsstønad` er sivilstandsplaner satt til optional:
```
 @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "sivilstandsplaner_")
                                        val sivilstandsplaner: Sivilstandsplaner? = null,
```
Skal jeg endre den her? Alle feltene inni Sivilstandsplaner er optional.


Signed-off-by: My Thao Nguyen <my.thao.nguyen@nav.no>