### PR TITLE
start blankettbehandling -> hvis det finnes en ef-oppgave(i vår db) f…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettController.kt
@@ -44,10 +44,9 @@ class BlankettController(private val tilgangService: TilgangService,
     }
 
     @PostMapping("/oppgave/{oppgaveId}")
-    fun opprettBlankettBehandling(@PathVariable oppgaveId: Long): Ressurs<UUID> {
+    fun startBlankettBehandling(@PathVariable oppgaveId: Long): Ressurs<UUID> {
         oppgaveService.hentEfOppgave(oppgaveId)?.let {
-            throw ApiFeil("Det finnes allerede en behandling for denne oppgaven - kan ikke opprettes på nytt",
-                          HttpStatus.BAD_REQUEST)
+            return Ressurs.success(it.behandlingId)
         }
         val oppgave = oppgaveService.hentOppgave(oppgaveId)
         val journalpostId = oppgave.journalpostId

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BlankettControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BlankettControllerTest.kt
@@ -18,7 +18,7 @@ import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import java.util.UUID
+import java.util.*
 
 class BlankettControllerTest : OppslagSpringRunnerTest() {
 
@@ -43,14 +43,14 @@ class BlankettControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    internal fun `Oppgave finnes allerede i db returner 400 BadRequestException`() {
+    internal fun `Oppgave finnes allerede i db returner eksisterende bahandlingsid`() {
 
         val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val oppgave = oppgaveRepository.insert(oppgave(behandling, false))
         val respons: ResponseEntity<Ressurs<UUID>> = opprettBlankettBehandling(oppgave.gsakOppgaveId)
 
-        assertThat(respons.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
+        assertThat(respons.body.data).isEqualTo(behandling.id)
     }
 
     @Test


### PR DESCRIPTION
…or oppgaveId returner behandlingsid for denne. Hvis ikke opprett behandling og returner ny behandlingsid.


Bugfix: Følg lenke (knapp) i oppgavebenk "lag blankett" to ganger. (Fungerer ikke andre gang da vi forsøker å opprette en blankettbehandling som allerede er opprettet.)

Ikke en kjempevakker fiks, men blankettbehandling er heller ikke noe som skal vare evig. 

 
 