### PR TITLE
Oppdaterer steg og status på behandling uten å oppdatere hele behandl…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningController.kt
@@ -43,15 +43,16 @@ class BeregningController(private val stegService: StegService,
                                            personIdent = fagsak.hentAktivIdent())
                 }
         )
-        return Ressurs.success(stegService.håndterBeregnYtelseForStønad(behandling, tilkjentYtelse).id)
+        stegService.håndterBeregnYtelseForStønad(behandling, tilkjentYtelse)
+        return Ressurs.success(behandlingId)
     }
 
     @PostMapping("/{behandlingId}/lagre-vedtak")
     fun lagreVedtak(@PathVariable behandlingId: UUID, @RequestBody vedtak: VedtakDto): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
-
-        return Ressurs.success(stegService.håndterVedtaBlankett(behandling, vedtak).id)
+        stegService.håndterVedtakBlankett(behandling, vedtak)
+        return Ressurs.success(behandlingId)
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtakController.kt
@@ -29,7 +29,8 @@ class VedtakController(private val stegService: StegService,
     fun sendTilBeslutter(@PathVariable behandlingId: UUID): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId)
         val behandling = behandlingService.hentBehandling(behandlingId)
-        return Ressurs.success(stegService.håndterSendTilBeslutter(behandling).id)
+        stegService.håndterSendTilBeslutter(behandling)
+        return Ressurs.success(behandlingId)
     }
 
     @PostMapping("/{behandlingId}/beslutte-vedtak")
@@ -40,7 +41,8 @@ class VedtakController(private val stegService: StegService,
             throw ApiFeil("Mangler begrunnelse", HttpStatus.BAD_REQUEST)
         }
         val behandling = behandlingService.hentBehandling(behandlingId)
-        return Ressurs.success(stegService.håndterBeslutteVedtak(behandling, request).id)
+        stegService.håndterBeslutteVedtak(behandling, request)
+        return Ressurs.success(behandlingId)
     }
 
     @GetMapping("{behandlingId}/totrinnskontroll")

--- a/src/main/kotlin/no/nav/familie/ef/sak/dummy/TestTilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/dummy/TestTilkjentYtelseService.kt
@@ -32,7 +32,7 @@ class TestTilkjentYtelseService(private val behandlingService: BehandlingService
         val tilkjentYtelseDTO = tilkjentYtelseTestDTO.nyTilkjentYtelse.copy(id = UUID.randomUUID(),
                                                                             behandlingId = behandling.id)
         val opprettTilkjentYtelse = tilkjentYtelseService.opprettTilkjentYtelse(tilkjentYtelseDTO)
-        behandlingService.oppdaterStatusPåBehandling(behandlingId = behandling.id,
+        behandlingService.oppdaterStatusPåBehandling(behandling = behandling,
                                                      status = BehandlingStatus.FERDIGSTILT)
         return opprettTilkjentYtelse
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.repository.domain.Behandling
 import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
+import no.nav.familie.ef.sak.service.steg.StegType
+import org.springframework.data.jdbc.repository.query.Modifying
 import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 import java.util.*
@@ -32,5 +34,23 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
                     LIMIT 1
                     """)
     fun finnAktivIdent(behandlingId: UUID): String
+
+    // language=PostgreSQL
+    @Query("SELECT status FROM behandling WHERE id = :behandlingId")
+    fun finnStatus(behandlingId: UUID): BehandlingStatus
+
+    // language=PostgreSQL
+    @Modifying
+    @Query("""UPDATE behandling 
+                    SET status = :status, versjon = (versjon + 1)
+                    WHERE id = :behandlingId AND status = :tidligereStatus""")
+    fun oppdaterStatus(behandlingId: UUID, status: BehandlingStatus, tidligereStatus: BehandlingStatus): Boolean
+
+    // language=PostgreSQL
+    @Modifying
+    @Query("""UPDATE behandling 
+                    SET steg = :steg, versjon = (versjon + 1)
+                    WHERE id = :behandlingId and steg = :tidligereSteg""")
+    fun oppdaterSteg(behandlingId: UUID, steg: StegType, tidligereSteg: StegType): Boolean
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandling.kt
@@ -1,29 +1,30 @@
 package no.nav.familie.ef.sak.repository.domain
 
-import no.nav.familie.ef.sak.api.Feil
 import no.nav.familie.ef.sak.service.steg.StegType
 import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.Version
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
-import java.util.*
+import java.util.UUID
 
 data class Behandling(@Id
                       val id: UUID = UUID.randomUUID(),
                       val fagsakId: UUID,
                       @MappedCollection(idColumn = "behandling_id")
                       val eksternId: EksternBehandlingId = EksternBehandlingId(),
+                      @Version
                       val versjon: Int = 0,
                       val aktiv: Boolean = true,
 
                       val type: BehandlingType,
-                      var status: BehandlingStatus,
-                      var steg: StegType,
+                      val status: BehandlingStatus,
+                      val steg: StegType,
                       @MappedCollection(idColumn = "behandling_id")
                       var journalposter: Set<Behandlingsjournalpost> = setOf(),
 
                       @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
                       val sporbar: Sporbar = Sporbar(),
-                      var resultat: BehandlingResultat) {
+                      val resultat: BehandlingResultat) {
 
     fun kanAnnulleres(): Boolean = !status.behandlingErLåstForVidereRedigering() && type == BehandlingType.BLANKETT
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollService.kt
@@ -48,7 +48,7 @@ class TotrinnskontrollService(private val behandlingshistorikkService: Behandlin
                                                             utfall = utfall,
                                                             metadata = beslutteVedtak)
 
-        behandlingService.oppdaterStatusPåBehandling(behandling.id, nyStatus)
+        behandlingService.oppdaterStatusPåBehandling(behandling, nyStatus)
         return sisteBehandlingshistorikk.opprettetAv
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VurderingService.kt
@@ -176,7 +176,7 @@ class VurderingService(private val behandlingService: BehandlingService,
         val vilkårUtenVurdering = hentVilkårSomManglerVurdering(behandlingId)
 
         if (skalFerdigstilleVilkårSteg(vilkårUtenVurdering, behandling)) {
-            stegService.håndterVilkår(behandling).id
+            stegService.håndterVilkår(behandling)
         } else if (skalTilbakestilleTilVilkårSteg(vilkårUtenVurdering, behandling)) {
             stegService.resetSteg(behandling.id, StegType.VILKÅR)
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
@@ -15,7 +15,7 @@ class FerdigstillBehandlingSteg(private val behandlingService: BehandlingService
 
     override fun utførSteg(behandling: Behandling, data: Void?) {
         logger.info("Ferdigstiller behandling [${behandling.id}]")
-        behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FERDIGSTILT)
+        behandlingService.oppdaterStatusPåBehandling(behandling, BehandlingStatus.FERDIGSTILT)
     }
 
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterSteg.kt
@@ -28,7 +28,7 @@ class SendTilBeslutterSteg(private val taskRepository: TaskRepository,
     }
 
     override fun utførSteg(behandling: Behandling, data: Void?) {
-        behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FATTER_VEDTAK)
+        behandlingService.oppdaterStatusPåBehandling(behandling, BehandlingStatus.FATTER_VEDTAK)
         opprettGodkjennVedtakOppgave(behandling)
 
         ferdigstillOppgave(behandling, Oppgavetype.BehandleSak)

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/StegService.kt
@@ -45,77 +45,69 @@ class StegService(private val behandlingSteg: List<BehandlingSteg<*>>,
     private val stegFeiletMetrics: Map<StegType, Counter> = initStegMetrikker("feil")
 
     @Transactional
-    fun håndterVilkår(behandling: Behandling): Behandling {
+    fun håndterVilkår(behandling: Behandling) {
         val behandlingSteg: VilkårSteg = hentBehandlingSteg(StegType.VILKÅR)
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterBeregnYtelseForStønad(behandling: Behandling, tilkjentYtelse: TilkjentYtelseDTO): Behandling {
+    fun håndterBeregnYtelseForStønad(behandling: Behandling, tilkjentYtelse: TilkjentYtelseDTO) {
         val behandlingSteg: BeregnYtelseSteg = hentBehandlingSteg(BEREGNE_YTELSE)
-        return håndterSteg(behandling, behandlingSteg, tilkjentYtelse)
+        håndterSteg(behandling, behandlingSteg, tilkjentYtelse)
     }
 
     @Transactional
-    fun håndterVedtaBlankett(behandling: Behandling, vedtak: VedtakDto): Behandling {
+    fun håndterVedtakBlankett(behandling: Behandling, vedtak: VedtakDto) {
         val behandlingSteg: VedtaBlankettSteg = hentBehandlingSteg(VEDTA_BLANKETT)
-        return håndterSteg(behandling, behandlingSteg, vedtak)
+        håndterSteg(behandling, behandlingSteg, vedtak)
     }
 
     @Transactional
-    fun håndterSendTilBeslutter(behandling: Behandling): Behandling {
+    fun håndterSendTilBeslutter(behandling: Behandling) {
         val behandlingSteg: SendTilBeslutterSteg = hentBehandlingSteg(SEND_TIL_BESLUTTER)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterBeslutteVedtak(behandling: Behandling, data: BeslutteVedtakDto): Behandling {
+    fun håndterBeslutteVedtak(behandling: Behandling, data: BeslutteVedtakDto) {
         val behandlingSteg: BeslutteVedtakSteg = hentBehandlingSteg(BESLUTTE_VEDTAK)
-
-        return håndterSteg(behandling, behandlingSteg, data)
+        håndterSteg(behandling, behandlingSteg, data)
     }
 
     @Transactional
-    fun håndterBlankett(behandling: Behandling): Behandling {
+    fun håndterBlankett(behandling: Behandling) {
         val behandlingSteg: BlankettSteg = hentBehandlingSteg(JOURNALFØR_BLANKETT)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterIverksettingOppdrag(behandling: Behandling): Behandling {
+    fun håndterIverksettingOppdrag(behandling: Behandling) {
         val behandlingSteg: IverksettMotOppdragSteg = hentBehandlingSteg(IVERKSETT_MOT_OPPDRAG)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterStatusPåOppdrag(behandling: Behandling): Behandling {
+    fun håndterStatusPåOppdrag(behandling: Behandling) {
         val behandlingSteg: VentePåStatusFraØkonomi = hentBehandlingSteg(VENTE_PÅ_STATUS_FRA_ØKONOMI)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterJournalførVedtaksbrev(behandling: Behandling): Behandling {
+    fun håndterJournalførVedtaksbrev(behandling: Behandling) {
         val behandlingSteg: JournalførVedtaksbrevSteg = hentBehandlingSteg(JOURNALFØR_VEDTAKSBREV)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
     @Transactional
-    fun håndterDistribuerVedtaksbrev(behandling: Behandling, journalpostId: String): Behandling {
+    fun håndterDistribuerVedtaksbrev(behandling: Behandling, journalpostId: String) {
         val behandlingSteg: DistribuerVedtaksbrevSteg = hentBehandlingSteg(DISTRIBUER_VEDTAKSBREV)
-
-        return håndterSteg(behandling, behandlingSteg, journalpostId)
+        håndterSteg(behandling, behandlingSteg, journalpostId)
     }
 
     @Transactional
-    fun håndterFerdigsitllBehandling(behandling: Behandling): Behandling {
+    fun håndterFerdigsitllBehandling(behandling: Behandling) {
         val behandlingSteg: FerdigstillBehandlingSteg = hentBehandlingSteg(FERDIGSTILLE_BEHANDLING)
-
-        return håndterSteg(behandling, behandlingSteg, null)
+        håndterSteg(behandling, behandlingSteg, null)
     }
 
 
@@ -130,7 +122,7 @@ class StegService(private val behandlingSteg: List<BehandlingSteg<*>>,
         }
 
         validerAtStegKanResettes(behandling, steg)
-        behandlingService.oppdaterStegPåBehandling(behandlingId, steg)
+        behandlingService.oppdaterStegPåBehandling(behandling, steg)
     }
 
     private fun validerAtStegKanResettes(behandling: Behandling,
@@ -141,24 +133,24 @@ class StegService(private val behandlingSteg: List<BehandlingSteg<*>>,
             val saksbehandler = SikkerhetContext.hentSaksbehandler()
             error("$saksbehandler kan ikke endre" +
                   " fra steg=${behandling.steg.displayName()} til steg=${steg.displayName()}" +
-                  " pga manglende rolle på behandling=$behandling.id")
+                  " pga manglende rolle på behandling=${behandling.id}")
         }
     }
 
     // Generelle stegmetoder
     private fun <T> håndterSteg(behandling: Behandling,
                                 behandlingSteg: BehandlingSteg<T>,
-                                data: T): Behandling {
+                                data: T) {
         val stegType = behandlingSteg.stegType()
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
         try {
             valider(behandling, stegType, saksbehandlerIdent, behandlingSteg)
             val nesteSteg = behandlingSteg.utførOgReturnerNesteSteg(behandling, data)
             oppdaterHistorikk(behandlingSteg, behandling, saksbehandlerIdent)
-            oppdaterMetrikk(stegType, stegSuksessMetrics)
             validerNesteSteg(nesteSteg, behandling)
             logger.info("$stegType på behandling ${behandling.id} er håndtert")
-            return behandlingService.oppdaterStegPåBehandling(behandlingId = behandling.id, steg = nesteSteg)
+            behandlingService.oppdaterStegPåBehandling(behandling = behandling, steg = nesteSteg)
+            oppdaterMetrikk(stegType, stegSuksessMetrics)
         } catch (exception: Exception) {
             oppdaterMetrikk(stegType, stegFeiletMetrics)
             logger.error("Håndtering av stegtype '$stegType' feilet på behandling ${behandling.id}.")
@@ -167,7 +159,7 @@ class StegService(private val behandlingSteg: List<BehandlingSteg<*>>,
     }
 
     private fun validerNesteSteg(nesteSteg: StegType, behandling: Behandling) {
-        if (!nesteSteg.erGyldigIKombinasjonMedStatus(behandlingService.hentBehandling(behandling.id).status)) {
+        if (!nesteSteg.erGyldigIKombinasjonMedStatus(behandlingService.hentBehandlingStatus(behandling.id))) {
             error("Steg '${nesteSteg.displayName()}' kan ikke settes " +
                   "på behandling i kombinasjon med status ${behandling.status}")
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/VilkårSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/VilkårSteg.kt
@@ -15,7 +15,7 @@ class VilkårSteg(private val behandlingService: BehandlingService) : Behandling
 
     override fun utførSteg(behandling: Behandling, data: String?) {
         // TODO: Søknad og behandling kan kobles sammen her
-        behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.UTREDES)
+        behandlingService.oppdaterStatusPåBehandling(behandling, BehandlingStatus.UTREDES)
     }
 
     override fun stegType(): StegType {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterStegTest.kt
@@ -75,7 +75,7 @@ internal class SendTilBeslutterStegTest {
 
         utførSteg()
 
-        verify { behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FATTER_VEDTAK) }
+        verify { behandlingService.oppdaterStatusPåBehandling(behandling, BehandlingStatus.FATTER_VEDTAK) }
 
         assertThat(taskSlot[0].type).isEqualTo(OpprettOppgaveTask.TYPE)
         assertThat(objectMapper.readValue<OpprettOppgaveTaskData>(taskSlot[0].payload).oppgavetype)


### PR DESCRIPTION
…ingen

For å unngå å oppdatere hele behandlingen samt slette/opprette eksternId, så tenker jeg att vi burde oppdatere status og steg gjennom egne kall mot databasen.

Er ikke helt sikker på denne endringen.
Jeg oppdaterer versjon og har lagt til '@Version' på versjon på behandling for å få optimistic locking. Dette for å unngå att man først oppdaterer status, og sen oppdaterer en gammel versjon av behandling.
Man hadde kunnet returnere en behandling fra disse 2 metodene, `oppdaterStatusPåBehandling` og `oppdaterStegPåBehandling`.

Kanskje dette er unødvendig optimering, tenker vi burde uansett sette `@Version` på behandling får å unngå feil ved oppdatering mot databasen