### PR TITLE
Endrer cpu limits til 1.5 CPU for raskere oppstart

### DIFF
--- a/.deploy/nais.yaml
+++ b/.deploy/nais.yaml
@@ -28,7 +28,7 @@ spec:
   resources:
     limits:
       memory: 1024Mi
-      cpu: "1"
+      cpu: 1500m
     requests:
       memory: 512Mi
       cpu: 500m


### PR DESCRIPTION
Dette gjør det mulig for applikasjonen å bruke mer CPU hvis det trengs, hvilket den trenger spesielt ved oppstart, ellers ligger den relativt lågt på ca 200m.
Hvis applikasjonen ikke får tilsrekkelig CPU blir den throttled, og blir langsammere, man kan se denne throttle på https://grafana.adeo.no/d/mWq3qJwMz/familie-ef-sak-svarstider?orgId=1&from=now-3h&to=now

```
Apr 6, 2021 @ 11:41:28.893 | Started ApplicationKt in 25.197 seconds (JVM running for 26.385)
-- | --

  | Apr 6, 2021 @ 11:41:17.273 | Started ApplicationKt in 28.638 seconds (JVM running for 30.048)

  | Apr 6, 2021 @ 11:40:00.421 | Started ApplicationKt in 23.36 seconds (JVM running for 24.571)

  | Apr 6, 2021 @ 11:35:21.681 | Started ApplicationKt in 41.422 seconds (JVM running for 43.654)

  | Apr 6, 2021 @ 11:34:20.919 | Started ApplicationKt in 36.375 seconds (JVM running for 38.097)

  | Apr 6, 2021 @ 11:33:57.638 | Started ApplicationKt in 36.327 seconds (JVM running for 38.197)

  | Apr 6, 2021 @ 11:31:52.249 | Started ApplicationKt in 37.032 seconds (JVM running for 39.018)

  | Apr 6, 2021 @ 11:30:54.712 | Started ApplicationKt in 44.111 seconds (JVM running for 46.167)

  | Apr 6, 2021 @ 10:04:35.083 | Started ApplicationKt in 41.01 seconds (JVM running for 43.289)

  | Apr 6, 2021 @ 10:03:19.510 | Started ApplicationKt in 39.071 seconds (JVM running for 40.951)


```