### PR TITLE
Fjern felt og ikke map fnr eller erBarnetFødt for BarnMedSamværSøknad…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/dto/BarnMedSamværDto.kt
@@ -13,9 +13,7 @@ data class BarnMedSamværDto(
 data class BarnMedSamværSøknadsgrunnlagDto(
         val id: UUID,
         val navn: String?,
-        val fødselsnummer: String?,
         val fødselTermindato: LocalDate?,
-        val erBarnetFødt: Boolean,
         val harSammeAdresse: Boolean?,
         val skalBoBorHosSøker: String?,
         val forelder: AnnenForelderDto?,

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/BarnMedSamværMapper.kt
@@ -37,9 +37,7 @@ object BarnMedSamværMapper {
         return BarnMedSamværSøknadsgrunnlagDto(
                 id = søknadsbarn.id,
                 navn = søknadsbarn.navn,
-                fødselsnummer = søknadsbarn.fødselsnummer,
                 fødselTermindato = søknadsbarn.fødselTermindato,
-                erBarnetFødt = søknadsbarn.erBarnetFødt,
                 harSammeAdresse = søknadsbarn.harSkalHaSammeAdresse,
                 skalBoBorHosSøker = søknadsbarn.skalBoHosSøker,
                 forelder = søknadsbarn.annenForelder?.let { tilAnnenForelderDto(it) },


### PR DESCRIPTION
…sgrunnlag

- Barn som legges til manuelt vil antas er ufødte og vil ikke ha/bli spurt om fnr. `erBarnetFødt` er det heller ikke lenger behov for. Relatert til denne FE PRen: https://github.com/navikt/familie-ef-sak-frontend/pull/232

Signed-off-by: My Thao Nguyen <my.thao.nguyen@nav.no>