### PR TITLE
Scuttle verifiserer att sidecars, istio og cloud_sql_proxy, har start…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM navikt/java:11
+COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
+
+ENV ENVOY_ADMIN_API=http://127.0.0.1:15000
+ENV ISTIO_QUIT_API=http://127.0.0.1:15020
 
 ENV APP_NAME=familie-ef-sak
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75"
 COPY ./target/familie-ef-sak.jar "app.jar"
+
+ENTRYPOINT ["scuttle", "/dumb-init", "--", "/entrypoint.sh"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,8 +70,6 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 PDL_SCOPE: api://prod-fss:pdl:pdl-api/.default
 
-remove: ok
-
 spring:
   autoconfigure.exclude: org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
   data:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,8 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 PDL_SCOPE: api://prod-fss:pdl:pdl-api/.default
 
+remove: ok
+
 spring:
   autoconfigure.exclude: org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
   data:


### PR DESCRIPTION
…et opp før man starter applikasjonen

Når vi starter applikasjonen så har ikke cloud_sql_proxy startet opp ennå, så når applikasjonen starter opp og prøver å nå databasen feiler den alltid ved første oppstart. 
Scuttle ser til att sidecars har startet opp før den starter applikasjonen slik att vi unngår disse feilene i loggen

Feil pga dette: https://logs.adeo.no/goto/8da396636e7ca627929738b1efab0f25
Application run failed
HikariPool-1 - Exception during pool initialization.


https://doc.nais.io/clusters/gcp/#starting-application-when-istio-proxy-is-ready
https://nav-it.slack.com/archives/C0190SV7KSN/p1619074758242400