### PR TITLE
Refaktorering av finnStartDatoOgSluttDatoForBeløpsperiode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/Beregning.kt
@@ -1,32 +1,13 @@
 package no.nav.familie.ef.sak.api.beregning
 
-import no.nav.familie.ef.sak.util.isEqualOrAfter
-import no.nav.familie.ef.sak.util.isEqualOrBefore
+import no.nav.familie.ef.sak.util.Periode
 import java.math.BigDecimal
 import java.time.LocalDate
 
-data class Beløpsperiode(val fraOgMedDato: LocalDate,
-                         val tilDato: LocalDate,
+data class Beløpsperiode(val periode: Periode,
                          val beregningsgrunnlag: Beregningsgrunnlag? = null,
                          val beløp: BigDecimal,
-                         val beløpFørSamordning: BigDecimal) {
-
-    fun starterEtterVedtaksperiodeOgOverlapper(
-            vedtaksperiodeFraOgmedDato: LocalDate,
-            vedtaksperiodeTilDato: LocalDate) =
-            this.fraOgMedDato.isEqualOrAfter(vedtaksperiodeFraOgmedDato) && this.fraOgMedDato.isBefore(
-                    vedtaksperiodeTilDato)
-
-    fun starterFørVedtaksperiodeOgOverlapper(
-            vedtaksperiodeFraOgmedDato: LocalDate,
-            vedtaksperiodeTilDato: LocalDate) =
-            this.tilDato.isEqualOrBefore(vedtaksperiodeTilDato) && this.tilDato.isAfter(vedtaksperiodeFraOgmedDato)
-
-    fun starterFørOgSlutterEtterVedtaksperiode(
-          vedtaksperiodeFraOgmedDato: LocalDate,
-          vedtaksperiodeTilDato: LocalDate) =
-            this.fraOgMedDato.isBefore(vedtaksperiodeFraOgmedDato) && this.tilDato.isAfter(vedtaksperiodeTilDato)
-}
+                         val beløpFørSamordning: BigDecimal)
 
 data class Beregningsgrunnlag(val inntekt: BigDecimal,
                               val samordningsfradrag: BigDecimal,
@@ -43,8 +24,8 @@ data class Grunnbeløp(val fraOgMedDato: LocalDate,
 fun finnGrunnbeløpsPerioder(fraOgMedDato: LocalDate, tilDato: LocalDate): List<Beløpsperiode> {
     return grunnbeløpsperioder
             .filter { overlapper(it, fraOgMedDato, tilDato) }
-            .map { Beløpsperiode(maxOf(it.fraOgMedDato, fraOgMedDato), minOf(it.tilDato, tilDato), beløp = it.grunnbeløp, beløpFørSamordning = it.grunnbeløp) }
-            .sortedBy { it.fraOgMedDato }
+            .map { Beløpsperiode(periode = Periode(fradato = maxOf(it.fraOgMedDato, fraOgMedDato), tildato = minOf(it.tilDato, tilDato)), beløp = it.grunnbeløp, beløpFørSamordning = it.grunnbeløp) }
+            .sortedBy { it.periode.fradato }
 }
 
 private fun overlapper(grunnbeløpsperiode: Grunnbeløp,

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningService.kt
@@ -6,86 +6,22 @@ import no.nav.familie.ef.sak.util.isEqualOrAfter
 import no.nav.familie.ef.sak.util.isEqualOrBefore
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.math.RoundingMode
-import java.time.LocalDate
 
 @Service
 class BeregningService {
 
-    private val REDUKSJONSFAKTOR = BigDecimal(0.45)
 
     fun beregnYtelse(vedtaksperioder: List<Periode>, inntektsperioder: List<Inntektsperiode>): List<Beløpsperiode> {
 
         validerInnteksperioder(inntektsperioder, vedtaksperioder)
         validerVedtaksperioder(vedtaksperioder)
 
-
-        val beløpForInnteksperioder = inntektsperioder.flatMap { beregnBeløpForInntekt(it) }
+        val beløpForInnteksperioder = inntektsperioder.flatMap { BeregningUtils.beregnStønadForInntekt(it) }
 
         return vedtaksperioder.flatMap {
-            finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder, it.fradato, it.tildato)
+            BeregningUtils.finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder, it)
         }
     }
-
-
-    private fun beregnBeløpForInntekt(inntektsperiode: Inntektsperiode): List<Beløpsperiode> {
-        val (startDato, sluttDato, inntekt, samordningsfradrag) = inntektsperiode
-        return finnGrunnbeløpsPerioder(startDato, sluttDato).map {
-            val avkortningPerMåned = beregnAvkortning(it.beløp, inntekt).divide(BigDecimal(12))
-                    .setScale(0, RoundingMode.HALF_DOWN)
-
-            val fullOvergangsStønadPerMåned =
-                    it.beløp.multiply(BigDecimal(2.25)).divide(BigDecimal(12)).setScale(0, RoundingMode.HALF_EVEN)
-
-            val beløpFørSamordning =
-                    fullOvergangsStønadPerMåned.subtract(avkortningPerMåned).setScale(0, RoundingMode.HALF_UP)
-
-            val utbetaling = beløpFørSamordning.subtract(samordningsfradrag).setScale(0, RoundingMode.HALF_UP)
-
-
-            val beløpTilUtbetalning = if (utbetaling <= BigDecimal.ZERO) BigDecimal.ZERO else utbetaling
-
-            Beløpsperiode(fraOgMedDato = it.fraOgMedDato,
-                          tilDato = it.tilDato,
-                          beløp = beløpTilUtbetalning,
-                          beløpFørSamordning = beløpFørSamordning,
-                          beregningsgrunnlag = Beregningsgrunnlag(samordningsfradrag = samordningsfradrag,
-                                                                  avkortningPerMåned = avkortningPerMåned,
-                                                                  fullOvergangsStønadPerMåned = fullOvergangsStønadPerMåned,
-                                                                  inntekt = inntekt,
-                                                                  grunnbeløp = it.beløp))
-        }
-    }
-
-
-    private fun beregnAvkortning(grunnbeløp: BigDecimal, inntekt: BigDecimal): BigDecimal {
-        val inntektOverHalveGrunnbeløp = inntekt.subtract(grunnbeløp.multiply(BigDecimal(0.5)))
-        return if (inntektOverHalveGrunnbeløp > BigDecimal.ZERO)
-            inntektOverHalveGrunnbeløp.multiply(REDUKSJONSFAKTOR).setScale(5, RoundingMode.HALF_DOWN) else BigDecimal.ZERO
-    }
-
-
-    private fun finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder: List<Beløpsperiode>,
-                                                         vedtaksperiodeFraOgmedDato: LocalDate,
-                                                         vedtaksperiodeTilDato: LocalDate): List<Beløpsperiode> {
-        return beløpForInnteksperioder.mapNotNull {
-            if (it.fraOgMedDato.isEqualOrAfter(vedtaksperiodeFraOgmedDato) && it.tilDato.isEqualOrBefore(vedtaksperiodeTilDato)) {
-                it
-            } else if (it.starterFørVedtaksperiodeOgOverlapper(vedtaksperiodeFraOgmedDato, vedtaksperiodeTilDato)) {
-                it.copy(fraOgMedDato = vedtaksperiodeFraOgmedDato)
-            } else if (it.starterEtterVedtaksperiodeOgOverlapper(
-                            vedtaksperiodeFraOgmedDato,
-                            vedtaksperiodeTilDato)) {
-                it.copy(tilDato = vedtaksperiodeTilDato)
-            } else if (it.starterFørOgSlutterEtterVedtaksperiode(vedtaksperiodeFraOgmedDato,
-                                                                 vedtaksperiodeTilDato)) {
-                it.copy(tilDato = vedtaksperiodeTilDato, fraOgMedDato = vedtaksperiodeFraOgmedDato)
-            } else {
-                null
-            }
-        }
-    }
-
 
     private fun validerVedtaksperioder(vedtaksperioder: List<Periode>) {
         feilHvis(vedtaksperioder.zipWithNext { a, b -> a.tildato.isEqualOrAfter(b.fradato) }

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningUtils.kt
@@ -1,0 +1,71 @@
+package no.nav.familie.ef.sak.api.beregning
+
+import no.nav.familie.ef.sak.util.Periode
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class BeregningUtils {
+    companion object {
+
+        val REDUKSJONSFAKTOR = BigDecimal(0.45)
+
+        fun beregnStønadForInntekt(inntektsperiode: Inntektsperiode): List<Beløpsperiode> {
+            val (startDato, sluttDato, inntekt, samordningsfradrag) = inntektsperiode
+            return finnGrunnbeløpsPerioder(startDato, sluttDato).map {
+                val avkortningPerMåned = beregnAvkortning(it.beløp, inntekt).divide(BigDecimal(12))
+                        .setScale(0, RoundingMode.HALF_DOWN)
+
+                val fullOvergangsStønadPerMåned =
+                        it.beløp.multiply(BigDecimal(2.25)).divide(BigDecimal(12)).setScale(0, RoundingMode.HALF_EVEN)
+
+                val beløpFørSamordning =
+                        fullOvergangsStønadPerMåned.subtract(avkortningPerMåned).setScale(0, RoundingMode.HALF_UP)
+
+                val utbetaling = beløpFørSamordning.subtract(samordningsfradrag).setScale(0, RoundingMode.HALF_UP)
+
+
+                val beløpTilUtbetalning = if (utbetaling <= BigDecimal.ZERO) BigDecimal.ZERO else utbetaling
+
+                Beløpsperiode(periode = it.periode,
+                              beløp = beløpTilUtbetalning,
+                              beløpFørSamordning = beløpFørSamordning,
+                              beregningsgrunnlag = Beregningsgrunnlag(samordningsfradrag = samordningsfradrag,
+                                                                      avkortningPerMåned = avkortningPerMåned,
+                                                                      fullOvergangsStønadPerMåned = fullOvergangsStønadPerMåned,
+                                                                      inntekt = inntekt,
+                                                                      grunnbeløp = it.beløp))
+            }
+        }
+
+
+        fun beregnAvkortning(grunnbeløp: BigDecimal, inntekt: BigDecimal): BigDecimal {
+            val inntektOverHalveGrunnbeløp = inntekt.subtract(grunnbeløp.multiply(BigDecimal(0.5)))
+            return if (inntektOverHalveGrunnbeløp > BigDecimal.ZERO)
+                inntektOverHalveGrunnbeløp.multiply(REDUKSJONSFAKTOR).setScale(5, RoundingMode.HALF_DOWN) else BigDecimal.ZERO
+        }
+
+        fun finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder: List<Beløpsperiode>,
+                                                             vedtaksperiode: Periode): List<Beløpsperiode> {
+            return beløpForInnteksperioder.mapNotNull {
+                when {
+                    it.periode.omsluttesAv(vedtaksperiode) -> {
+                        it
+                    }
+                    it.periode.overlapperIStartenAv(vedtaksperiode) -> {
+                        it.copy(periode = it.periode.copy(fradato = vedtaksperiode.fradato))
+                    }
+                    vedtaksperiode.overlapperIStartenAv(it.periode) -> {
+                        it.copy(periode = it.periode.copy(tildato = vedtaksperiode.tildato))
+                    }
+                    vedtaksperiode.omsluttesAv(it.periode) -> {
+                        it.copy(periode = it.periode.copy(fradato = vedtaksperiode.fradato, tildato = vedtaksperiode.tildato))
+                    }
+                    else -> {
+                        null
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
@@ -37,8 +37,8 @@ class BeregnYtelseSteg(private val tilkjentYtelseService: TilkjentYtelseService,
                 behandlingId = behandling.id,
                 andelerTilkjentYtelse = beløpsperioder.map {
                     AndelTilkjentYtelseDTO(beløp = it.beløp.toInt(),
-                                           stønadFom = it.fraOgMedDato,
-                                           stønadTom = it.tilDato,
+                                           stønadFom = it.periode.fradato,
+                                           stønadTom = it.periode.tildato,
                                            kildeBehandlingId = behandling.id,
                                            personIdent = aktivIdent)
                 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.service.steg
 
 import no.nav.familie.ef.sak.api.beregning.BeregningService
+import no.nav.familie.ef.sak.api.beregning.Innvilget
 import no.nav.familie.ef.sak.api.beregning.VedtakDto
 import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.api.beregning.tilInntektsperioder

--- a/src/main/kotlin/no/nav/familie/ef/sak/util/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/util/Periode.kt
@@ -17,5 +17,8 @@ data class Periode(val fradato: LocalDate, val tildato: LocalDate, val gyldig: B
         return (!periode.fradato.isAfter(this.fradato) && !periode.tildato.isBefore(this.tildato))
     }
 
+    fun overlapperIStartenAv(periode: Periode) =
+            this.fradato.isBefore(periode.fradato) && this.tildato.isAfter(periode.fradato) && this.tildato.isBefore(periode.tildato)
+
     val lengde: Period = Period.between(fradato, tildato)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningServiceTest.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
-import java.time.YearMonth
 
 internal class BeregningServiceTest {
 
@@ -42,18 +41,18 @@ internal class BeregningServiceTest {
                                                                                         LocalDate.parse("2022-04-30"))))
 
         assertThat(fullYtelse.size).isEqualTo(3)
-        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(LocalDate.parse("2019-04-30"),
-                                                          LocalDate.parse("2019-05-01"),
+        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2019-04-30"),
+                                                          LocalDate.parse("2019-05-01")),
                                                           beregningsgrunnlagG2018,
                                                           18166.toBigDecimal(),
                                                           18166.toBigDecimal()))
-        assertThat(fullYtelse[1]).isEqualTo(Beløpsperiode(LocalDate.parse("2019-05-01"),
-                                                          LocalDate.parse("2020-05-01"),
+        assertThat(fullYtelse[1]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2019-05-01"),
+                                                          LocalDate.parse("2020-05-01")),
                                                           beregningsgrunnlagG2019,
                                                           18723.toBigDecimal(),
                                                           18723.toBigDecimal()))
-        assertThat(fullYtelse[2]).isEqualTo(Beløpsperiode(LocalDate.parse("2020-05-01"),
-                                                          LocalDate.parse("2022-04-30"),
+        assertThat(fullYtelse[2]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2020-05-01"),
+                                                          LocalDate.parse("2022-04-30")),
                                                           beregningsgrunnlagG2020,
                                                           19003.toBigDecimal(),
                                                           19003.toBigDecimal()))
@@ -90,8 +89,8 @@ internal class BeregningServiceTest {
 
 
         assertThat(fullYtelse.size).isEqualTo(1)
-        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(LocalDate.parse("2019-06-01"),
-                                                          LocalDate.parse("2020-04-30"),
+        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2019-06-01"),
+                                                          LocalDate.parse("2020-04-30")),
                                                           beregningsgrunnlagG2019,
                                                           beløpTilUtbetalning,
                                                           beløpTilUtbetalning))
@@ -151,14 +150,14 @@ internal class BeregningServiceTest {
                                                  LocalDate.parse("2020-04-30")))
         )
         assertThat(fullYtelse.size).isEqualTo(2)
-        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(LocalDate.parse("2019-01-01"),
-                                                          LocalDate.parse("2019-02-28"),
+        assertThat(fullYtelse[0]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2019-01-01"),
+                                                          LocalDate.parse("2019-02-28")),
                                                           beregningsgrunnlagIFørstePerioden,
                                                           beløpTilUtbetalningIFørstePerioden,
                                                           beløpTilUtbetalningIFørstePerioden))
 
-        assertThat(fullYtelse[1]).isEqualTo(Beløpsperiode(LocalDate.parse("2019-06-01"),
-                                                          LocalDate.parse("2020-04-30"),
+        assertThat(fullYtelse[1]).isEqualTo(Beløpsperiode(Periode(LocalDate.parse("2019-06-01"),
+                                                          LocalDate.parse("2020-04-30")),
                                                           beregningsgrunnlagIAndrePerioden,
                                                           beløpTilUtbetalningIAndraPerioden,
                                                           beløpTilUtbetalningIAndraPerioden))

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningTest.kt
@@ -1,10 +1,10 @@
 package no.nav.familie.ef.sak.api.beregning
 
+import no.nav.familie.ef.sak.util.Periode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.TestFactory
-import java.math.BigDecimal
 import java.time.LocalDate
 
 internal class BeregningTest {
@@ -36,9 +36,9 @@ internal class BeregningTest {
                         assertThat(finnGrunnbeløpsPerioder(LocalDate.parse(periode.first),
                                                                       LocalDate.parse(periode.second)))
                                 .isEqualTo(fasit.map {
-                                    Beløpsperiode(LocalDate.parse(it.first),
-                                                  LocalDate.parse(it.second),
-                                                null,
+                                    Beløpsperiode(Periode(LocalDate.parse(it.first),
+                                                          LocalDate.parse(it.second)),
+                                                  null,
                                                   it.third.toBigDecimal(),
                                                   it.third.toBigDecimal())
                                 })

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/beregning/BeregningUtilsTest.kt
@@ -1,0 +1,78 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.api.beregning
+
+import no.nav.familie.ef.sak.api.beregning.Beløpsperiode
+import no.nav.familie.ef.sak.api.beregning.BeregningUtils.Companion.finnStartDatoOgSluttDatoForBeløpsperiode
+import no.nav.familie.ef.sak.util.Periode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class BeregningUtilsTest {
+
+    @Test
+    internal fun `hvis vedtaksperiode omsluttes av beløpsperiode skal datoerne for vedtaksperiode returneres `() {
+        val beløpsperiode =
+                Beløpsperiode(periode = Periode(fradato = LocalDate.parse("2020-05-01"), tildato = LocalDate.parse("2020-12-01")),
+                              beløp = 10_000.toBigDecimal(),
+                              beløpFørSamordning = 12_000.toBigDecimal())
+        val vedtaksperiode = Periode(fradato = LocalDate.parse("2020-07-01"), tildato = LocalDate.parse("2020-10-31"))
+        assertThat(finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder = listOf(beløpsperiode),
+                                                            vedtaksperiode = vedtaksperiode).first())
+                .isEqualTo(beløpsperiode.copy(periode = vedtaksperiode))
+    }
+
+    @Test
+    internal fun `hvis beløpsperiode omsluttes av vedtaksperiode skal datoerne for beløpsperiode være uforandrede`() {
+        val beløpsperiode =
+                Beløpsperiode(periode = Periode(fradato = LocalDate.parse("2020-07-01"), tildato = LocalDate.parse("2020-09-30")),
+                              beløp = 10_000.toBigDecimal(),
+                              beløpFørSamordning = 12_000.toBigDecimal())
+        val vedtaksperiode = Periode(fradato = LocalDate.parse("2020-05-01"), tildato = LocalDate.parse("2020-12-31"))
+        assertThat(finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder = listOf(beløpsperiode),
+                                                            vedtaksperiode = vedtaksperiode).first())
+                .isEqualTo(beløpsperiode)
+    }
+
+    @Test
+    internal fun `hvis beløpsperiode overlapper i starten av vedtaksperiode skal startdatoen for vedtaksperiode returneres sammen med sluttdato for beløpsperiode`() {
+        val beløpsperiode =
+                Beløpsperiode(periode = Periode(fradato = LocalDate.parse("2020-03-01"),
+                                                tildato = LocalDate.parse("2020-06-30")),
+                              beløp = 10_000.toBigDecimal(),
+                              beløpFørSamordning = 12_000.toBigDecimal())
+        val vedtaksperiode = Periode(fradato = LocalDate.parse("2020-05-01"),
+                                     tildato = LocalDate.parse("2020-12-31"))
+        assertThat(finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder = listOf(beløpsperiode),
+                                                            vedtaksperiode = vedtaksperiode).first())
+                .isEqualTo(beløpsperiode.copy(periode = vedtaksperiode.copy(fradato = LocalDate.parse("2020-05-01"),
+                                                                            tildato = LocalDate.parse("2020-06-30"))))
+    }
+
+    @Test
+    internal fun `hvis beløpsperiode overlapper i slutten av vedtaksperiode skal startdatoen for beløpsperiode returneres sammen med sluttdato for vedtaksperiode`() {
+        val beløpsperiode =
+                Beløpsperiode(periode = Periode(fradato = LocalDate.parse("2020-09-01"),
+                                                tildato = LocalDate.parse("2021-02-28")),
+                              beløp = 10_000.toBigDecimal(),
+                              beløpFørSamordning = 12_000.toBigDecimal())
+        val vedtaksperiode = Periode(fradato = LocalDate.parse("2020-05-01"),
+                                     tildato = LocalDate.parse("2020-12-31"))
+        assertThat(finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder = listOf(beløpsperiode),
+                                                            vedtaksperiode = vedtaksperiode).first())
+                .isEqualTo(beløpsperiode.copy(periode = vedtaksperiode.copy(fradato = LocalDate.parse("2020-09-01"),
+                                                                            tildato = LocalDate.parse("2020-12-31"))))
+    }
+    @Test
+    internal fun `hvis beløpsperiode har ingen overlapp med vedtaksperiode skal tom liste returneres`() {
+        val beløpsperiode =
+                Beløpsperiode(periode = Periode(fradato = LocalDate.parse("2020-01-01"),
+                                                tildato = LocalDate.parse("2020-04-30")),
+                              beløp = 10_000.toBigDecimal(),
+                              beløpFørSamordning = 12_000.toBigDecimal())
+        val vedtaksperiode = Periode(fradato = LocalDate.parse("2020-05-01"),
+                                     tildato = LocalDate.parse("2020-12-31"))
+        assertThat(finnStartDatoOgSluttDatoForBeløpsperiode(beløpForInnteksperioder = listOf(beløpsperiode),
+                                                            vedtaksperiode = vedtaksperiode))
+                .isEqualTo(emptyList<Beløpsperiode>())
+    }
+}


### PR DESCRIPTION
Tar i bruk Periode i Beløpsperiode
Omskrivning av finnStartDatoOgSluttDatoForBeløpsperiode gjennom å ta i bruk metoderne definert for `Periode`
Laget tester for finnStartDatoOgSluttDatoForBeløpsperiode