### PR TITLE
Tar i bruk gyldigFraOgMed/gyldigTilOgMed i stedet for folkeregisterme…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlPerson.kt
@@ -104,9 +104,9 @@ data class DeltBosted(val startdatoForKontrakt: LocalDate,
 data class Folkeregistermetadata(val gyldighetstidspunkt: LocalDateTime?,
                                  @JsonProperty("opphoerstidspunkt") val opphørstidspunkt: LocalDateTime?)
 
-data class Bostedsadresse(val angittFlyttedato: LocalDate?,
+data class Bostedsadresse(val gyldigFraOgMed: LocalDate?,
+                          val gyldigTilOgMed: LocalDate?,
                           val coAdressenavn: String?,
-                          val folkeregistermetadata: Folkeregistermetadata,
                           val utenlandskAdresse: UtenlandskAdresse?,
                           val vegadresse: Vegadresse?,
                           val ukjentBosted: UkjentBosted?,

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
@@ -40,14 +40,14 @@ class AdresseMapper(private val kodeverkService: KodeverkService) {
     }
 
     fun tilAdresse(adresse: Bostedsadresse): AdresseDto {
-        return AdresseDto(visningsadresse = tilFormatertAdresse(adresse, datoEllerIdag(adresse.angittFlyttedato)),
+        return AdresseDto(visningsadresse = tilFormatertAdresse(adresse, datoEllerIdag(adresse.gyldigFraOgMed)),
                           type = AdresseType.BOSTEDADRESSE,
-                          gyldigFraOgMed = adresse.angittFlyttedato,
-                          gyldigTilOgMed = adresse.folkeregistermetadata.opphørstidspunkt?.toLocalDate())
+                          gyldigFraOgMed = adresse.gyldigFraOgMed,
+                          gyldigTilOgMed = adresse.gyldigTilOgMed)
     }
 
     private fun tilFormatertAdresse(bostedsadresse: Bostedsadresse, gjeldendeDato: LocalDate): String? {
-        val (_, coAdressenavn, _, utenlandskAdresse, vegadresse, ukjentBosted, matrikkeladresse, _) = bostedsadresse
+        val (_, _, coAdressenavn, utenlandskAdresse, vegadresse, ukjentBosted, matrikkeladresse, _) = bostedsadresse
         val formattertAdresse: String? = when {
             vegadresse != null -> tilFormatertAdresse(vegadresse, gjeldendeDato)
             matrikkeladresse != null -> tilFormatertAdresse(matrikkeladresse, gjeldendeDato)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/Medlemskapshistorikk.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/Medlemskapshistorikk.kt
@@ -101,8 +101,8 @@ class Medlemskapshistorikk(pdlPerson: PdlPerson, medlemskapsinfo: Medlemskapsinf
 
     private fun mapTilBosattperioder(bostedsadresser: List<Bostedsadresse>): List<Periode> {
         val bosattAdresser = bostedsadresser
-                .filter { it.angittFlyttedato != null || it.folkeregistermetadata.gyldighetstidspunkt != null }
-                .sortedBy { it.angittFlyttedato ?: it.folkeregistermetadata.gyldighetstidspunkt!!.toLocalDate() }
+                .filter { it.gyldigFraOgMed != null }
+                .sortedBy { it.gyldigFraOgMed ?: it.gyldigFraOgMed }
 
 
         var periode: Periode? = null
@@ -144,9 +144,9 @@ class Medlemskapshistorikk(pdlPerson: PdlPerson, medlemskapsinfo: Medlemskapsinf
         return bosattperioder.toList()
     }
 
-    private fun tildato(it: Bostedsadresse) = it.folkeregistermetadata.opphørstidspunkt?.toLocalDate() ?: LocalDate.MAX
+    private fun tildato(it: Bostedsadresse) = it.gyldigTilOgMed ?: LocalDate.MAX
 
-    private fun fradato(it: Bostedsadresse) = it.angittFlyttedato ?: it.folkeregistermetadata.gyldighetstidspunkt!!.toLocalDate()
+    private fun fradato(it: Bostedsadresse) = it.gyldigFraOgMed ?: LocalDate.MIN
 
 }
 

--- a/src/main/resources/pdl/andreForeldre.graphql
+++ b/src/main/resources/pdl/andreForeldre.graphql
@@ -10,12 +10,9 @@ query($identer: [ID!]!){
                 }
             }
             bostedsadresse(historikk: true) {
-                angittFlyttedato
+                gyldigFraOgMed
+                gyldigTilOgMed
                 coAdressenavn
-                folkeregistermetadata {
-                    gyldighetstidspunkt
-                    opphoerstidspunkt
-                }
                 utenlandskAdresse {
                     adressenavnNummer
                     bySted

--- a/src/main/resources/pdl/barn.graphql
+++ b/src/main/resources/pdl/barn.graphql
@@ -10,14 +10,11 @@ query($identer: [ID!]!){
                 }
             }
             bostedsadresse {
-                angittFlyttedato
+                gyldigFraOgMed
+                gyldigTilOgMed
                 coAdressenavn
                 metadata {
                     historisk
-                }
-                folkeregistermetadata {
-                    gyldighetstidspunkt
-                    opphoerstidspunkt
                 }
                 utenlandskAdresse {
                     adressenavnNummer

--- a/src/main/resources/pdl/søk_person.graphql
+++ b/src/main/resources/pdl/søk_person.graphql
@@ -9,12 +9,9 @@ query ($paging:Paging, $criteria:[Criterion]) {
                     identifikasjonsnummer
                 }
                 bostedsadresse(historikk: false) {
-                    angittFlyttedato
+                    gyldigFraOgMed
+                    gyldigTilOgMed
                     coAdressenavn
-                    folkeregistermetadata {
-                        gyldighetstidspunkt
-                        opphoerstidspunkt
-                    }
                     utenlandskAdresse {
                         adressenavnNummer
                         bySted

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -7,14 +7,11 @@ query($ident: ID!){
             }
         }
         bostedsadresse(historikk: true) {
-            angittFlyttedato
+            gyldigFraOgMed
+            gyldigTilOgMed
             coAdressenavn
             metadata {
                 historisk
-            }
-            folkeregistermetadata {
-                gyldighetstidspunkt
-                opphoerstidspunkt
             }
             utenlandskAdresse {
                 adressenavnNummer

--- a/src/test/kotlin/no/nav/familie/ef/sak/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/config/PdlClientConfig.kt
@@ -202,10 +202,8 @@ class PdlClientConfig {
                                 omraader = listOf()))
 
         private fun bostedsadresse(): List<Bostedsadresse> =
-                listOf(Bostedsadresse(angittFlyttedato = startdato,
-                                      folkeregistermetadata = Folkeregistermetadata(gyldighetstidspunkt = LocalDateTime.now(),
-                                                                                    opphørstidspunkt = LocalDate.of(2199, 1, 1)
-                                                                                            .atStartOfDay()),
+                listOf(Bostedsadresse(gyldigFraOgMed = startdato,
+                                      gyldigTilOgMed = LocalDate.of(2199, 1, 1),
                                       utenlandskAdresse = null,
                                       coAdressenavn = "CONAVN",
                                       vegadresse = vegadresse(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlClientTest.kt
@@ -69,7 +69,7 @@ class PdlClientTest {
 
         val response = pdlClient.hentAndreForeldre(listOf("11111122222"))
 
-        assertThat(response["11111122222"]?.bostedsadresse?.get(0)?.angittFlyttedato).isEqualTo(LocalDate.of(1966, 11, 18))
+        assertThat(response["11111122222"]?.bostedsadresse?.get(0)?.gyldigFraOgMed).isEqualTo(LocalDate.of(1966, 11, 18))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlPersonSøkHjelperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlPersonSøkHjelperTest.kt
@@ -82,11 +82,11 @@ internal class PdlPersonSøkHjelperTest {
 
     private fun lagAdresse(vegadresse: Vegadresse?, matrikkeladresse: Matrikkeladresse?): Bostedsadresse {
         return Bostedsadresse(
+                gyldigFraOgMed = null,
+                gyldigTilOgMed = null,
                 vegadresse = vegadresse,
                 matrikkeladresse = matrikkeladresse,
-                angittFlyttedato = null,
                 coAdressenavn = null,
-                folkeregistermetadata = Folkeregistermetadata(null, null),
                 utenlandskAdresse = null,
                 ukjentBosted = null,
                 metadata = Metadata(false)

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlSaksbehandlerClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/PdlSaksbehandlerClientTest.kt
@@ -65,9 +65,9 @@ internal class PdlSaksbehandlerClientTest {
                                                                     tilleggsnavn = null,
                                                                     koordinater = null),
                                             matrikkeladresse = null,
-                                            angittFlyttedato = null,
+                                            gyldigFraOgMed = null,
+                                            gyldigTilOgMed = null,
                                             coAdressenavn = null,
-                                            folkeregistermetadata = Folkeregistermetadata(null, null),
                                             utenlandskAdresse = null,
                                             ukjentBosted = null,
                                             metadata = Metadata(false))

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlPersonUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlPersonUtilTest.kt
@@ -68,7 +68,7 @@ internal class PdlPersonUtilTest {
         return Bostedsadresse(
                 null,
                 null,
-                Folkeregistermetadata(null, null),
+                null,
                 null,
                 Vegadresse(nr, null, null, gate, null, null, null, null, null),
                 null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/integration/dto/pdl/PdlTestdata.kt
@@ -34,8 +34,8 @@ object PdlTestdata {
     private val adressebeskyttelse = listOf(Adressebeskyttelse(AdressebeskyttelseGradering.FORTROLIG, metadataGjeldende))
 
     private val bostedsadresse = listOf(Bostedsadresse(LocalDate.now(),
+                                                       LocalDate.now(),
                                                        "",
-                                                       folkeregistermetadata,
                                                        utenlandskAdresse,
                                                        vegadresse,
                                                        UkjentBosted(""),

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseHjelperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseHjelperTest.kt
@@ -6,8 +6,7 @@ import no.nav.familie.ef.sak.integration.dto.pdl.*
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalDateTime.now
+import java.time.LocalDate.now
 
 internal class AdresseHjelperTest {
 
@@ -155,17 +154,15 @@ internal class AdresseHjelperTest {
     }
 
     private fun lagAdresse(vegadresse: Vegadresse?,
-                           gyldighetstidspunkt: LocalDateTime? = null,
-                           opphørstidspunkt: LocalDateTime? = null,
+                           gyldighetstidspunkt: LocalDate? = null,
+                           opphørstidspunkt: LocalDate? = null,
                            matrikkeladresse: Matrikkeladresse? = null,
                            metadata: Metadata? = null): Bostedsadresse {
         return Bostedsadresse(
                 vegadresse = vegadresse,
-                angittFlyttedato = null,
+                gyldigFraOgMed = gyldighetstidspunkt,
+                gyldigTilOgMed = opphørstidspunkt,
                 coAdressenavn = null,
-                folkeregistermetadata = Folkeregistermetadata(
-                        gyldighetstidspunkt = gyldighetstidspunkt,
-                        opphørstidspunkt = opphørstidspunkt),
                 utenlandskAdresse = null,
                 ukjentBosted = null,
                 matrikkeladresse = matrikkeladresse,

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
@@ -1,11 +1,21 @@
 package no.nav.familie.ef.sak.mapper
 
-import no.nav.familie.ef.sak.integration.dto.pdl.*
+import no.nav.familie.ef.sak.integration.dto.pdl.Bostedsadresse
+import no.nav.familie.ef.sak.integration.dto.pdl.Kontaktadresse
+import no.nav.familie.ef.sak.integration.dto.pdl.KontaktadresseType
+import no.nav.familie.ef.sak.integration.dto.pdl.Matrikkeladresse
+import no.nav.familie.ef.sak.integration.dto.pdl.Metadata
+import no.nav.familie.ef.sak.integration.dto.pdl.Oppholdsadresse
+import no.nav.familie.ef.sak.integration.dto.pdl.PostadresseIFrittFormat
+import no.nav.familie.ef.sak.integration.dto.pdl.Postboksadresse
+import no.nav.familie.ef.sak.integration.dto.pdl.UkjentBosted
+import no.nav.familie.ef.sak.integration.dto.pdl.UtenlandskAdresse
+import no.nav.familie.ef.sak.integration.dto.pdl.UtenlandskAdresseIFrittFormat
+import no.nav.familie.ef.sak.integration.dto.pdl.Vegadresse
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.config.KodeverkServiceMock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 internal class AdresseMapperTest {
 
@@ -18,11 +28,9 @@ internal class AdresseMapperTest {
     @Test
     internal fun `Bostedsadresse formatert adresse`() {
         val bostedsadresse =
-                Bostedsadresse(angittFlyttedato = startdato,
+                Bostedsadresse(gyldigFraOgMed = startdato,
+                               gyldigTilOgMed = startdato.plusDays(1),
                                coAdressenavn = null,
-                               folkeregistermetadata = Folkeregistermetadata(gyldighetstidspunkt = LocalDateTime.now(),
-                                                                             opphørstidspunkt = startdato.plusDays(1)
-                                                                                     .atStartOfDay()),
                                utenlandskAdresse = utenlandskAdresse(),
                                vegadresse = vegadresse(),
                                ukjentBosted = UkjentBosted(bostedskommune = "ukjentBostedKommune"),

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -49,8 +49,8 @@ internal class SøkServiceTest {
                                     1L)
 
         val bostedsadresseFraPdl = listOf(Bostedsadresse(LocalDate.now(),
+                                                         LocalDate.now(),
                                                          null,
-                                                         Folkeregistermetadata(LocalDateTime.now(), LocalDateTime.now()),
                                                          null,
                                                          vegadresse,
                                                          UkjentBosted(""),

--- a/src/test/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/MedlemskapRegelsettTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/MedlemskapRegelsettTest.kt
@@ -1,7 +1,11 @@
 package no.nav.familie.ef.sak.vurdering.medlemskap
 
 import io.mockk.mockk
-import no.nav.familie.ef.sak.integration.dto.pdl.*
+import no.nav.familie.ef.sak.integration.dto.pdl.Bostedsadresse
+import no.nav.familie.ef.sak.integration.dto.pdl.Folkeregisterpersonstatus
+import no.nav.familie.ef.sak.integration.dto.pdl.Fødsel
+import no.nav.familie.ef.sak.integration.dto.pdl.Metadata
+import no.nav.familie.ef.sak.integration.dto.pdl.Statsborgerskap
 import no.nav.familie.ef.sak.nare.evaluations.Resultat
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vurdering.medlemskap.pdlSøker
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vurdering.medlemskap.søknad
@@ -12,7 +16,6 @@ import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.Month
 
 internal class MedlemskapRegelsettTest {
@@ -54,10 +57,9 @@ internal class MedlemskapRegelsettTest {
         val medlemskapsinfoUtenUnntak = Medlemskapsinfo("3213213", emptyList(), emptyList(), emptyList())
         val pdlSøker = pdlSøker(fødsel = listOf(Fødsel(null, LocalDate.of(1999, 4, 5), null, null, null, metadataGjeldende)),
                                 folkeregisterpersonstatus = listOf(Folkeregisterpersonstatus("bosatt", "bo", metadataGjeldende)),
-                                bostedsadresse = listOf(Bostedsadresse(null,
+                                bostedsadresse = listOf(Bostedsadresse(LocalDate.of(1999, 4, 5),
                                                                        null,
-                                                                       Folkeregistermetadata(LocalDateTime.of(1999, 4, 5, 0, 0),
-                                                                                             null),
+                                                                       null,
                                                                        null,
                                                                        null,
                                                                        null,
@@ -94,10 +96,9 @@ internal class MedlemskapRegelsettTest {
         val medlemskapsinfoUtenUnntak = Medlemskapsinfo("3213213", emptyList(), emptyList(), emptyList())
         val pdlSøker = pdlSøker(fødsel = listOf(Fødsel(null, LocalDate.of(1999, 4, 5), null, null, null, metadataGjeldende)),
                                 folkeregisterpersonstatus = listOf(Folkeregisterpersonstatus("bosatt", "bo", metadataGjeldende)),
-                                bostedsadresse = listOf(Bostedsadresse(null,
+                                bostedsadresse = listOf(Bostedsadresse(LocalDate.of(1999, 4, 5),
                                                                        null,
-                                                                       Folkeregistermetadata(LocalDateTime.of(1999, 4, 5, 0, 0),
-                                                                                             null),
+                                                                       null,
                                                                        null,
                                                                        null,
                                                                        null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/TestdataHelper.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vurdering/medlemskap/TestdataHelper.kt
@@ -13,7 +13,14 @@ fun pdlPerson(vararg perioder: Pair<LocalDate, LocalDateTime?>) = object : PdlPe
     override val fødsel: List<Fødsel> = listOf(Fødsel(null, null, null, null, null, Metadata(false)))
 
     override val bostedsadresse: List<Bostedsadresse> = perioder.map {
-        Bostedsadresse(it.first, null, Folkeregistermetadata(null, it.second), null, null, null, null, Metadata(false))
+        Bostedsadresse(gyldigFraOgMed = it.first,
+                       gyldigTilOgMed = it.second?.toLocalDate(),
+                       coAdressenavn = null,
+                       utenlandskAdresse = null,
+                       vegadresse = null,
+                       ukjentBosted = null,
+                       matrikkeladresse = null,
+                       metadata = Metadata(false))
     }
 }
 

--- a/src/test/resources/json/andreForeldre.json
+++ b/src/test/resources/json/andreForeldre.json
@@ -18,12 +18,9 @@
               "metadata":  {
                 "historisk": false
               },
-              "angittFlyttedato": "1966-11-18",
+              "gyldigFraOgMed": "1966-11-18",
+              "gyldigTilOgMed": null,
               "coAdressenavn": null,
-              "folkeregistermetadata": {
-                "gyldighetstidspunkt": "2020-05-29T12:09:02",
-                "opphoerstidspunkt": null
-              },
               "vegadresse": {
                 "husnummer": "77",
                 "husbokstav": null,

--- a/src/test/resources/json/barn.json
+++ b/src/test/resources/json/barn.json
@@ -23,12 +23,9 @@
               "metadata":  {
                 "historisk": false
               },
-              "angittFlyttedato": "1966-11-18",
+              "gyldigFraOgMed": "1966-11-18",
+              "gyldigTilOgMed": null,
               "coAdressenavn": null,
-              "folkeregistermetadata": {
-                "gyldighetstidspunkt": "2020-05-29T12:09:02",
-                "opphoerstidspunkt": null
-              },
               "vegadresse": {
                 "husnummer": "77",
                 "husbokstav": null,

--- a/src/test/resources/json/person_søk.json
+++ b/src/test/resources/json/person_søk.json
@@ -14,12 +14,9 @@
             ],
             "bostedsadresse": [
               {
-                "angittFlyttedato": "1988-07-15",
+                "gyldigFraOgMed": "1988-07-15",
+                "gyldigTilOgMed": null,
                 "coAdressenavn": null,
-                "folkeregistermetadata": {
-                  "gyldighetstidspunkt": "1988-07-15T00:00",
-                  "opphoerstidspunkt": null
-                },
                 "utenlandskAdresse": null,
                 "vegadresse": {
                   "husnummer": "1",

--- a/src/test/resources/json/søker.json
+++ b/src/test/resources/json/søker.json
@@ -14,12 +14,9 @@
           "metadata":  {
             "historisk": false
           },
-          "angittFlyttedato": "1966-11-18",
+          "gyldigFraOgMed": "1966-11-18",
+          "gyldigTilOgMed": null,
           "coAdressenavn": null,
-          "folkeregistermetadata": {
-            "gyldighetstidspunkt": "2020-05-29T12:09:02",
-            "opphoerstidspunkt": null
-          },
           "vegadresse": {
             "husnummer": "77",
             "husbokstav": null,


### PR DESCRIPTION
…tadata som inneholder de samme datoene.

Mulig angittFlyttedato blir lagt til i en ny PR, men att det brukes til noe annet enn "fra"-dato.
Dette gjøres fordi feil dato vises som fra-dato i personopplysninger
https://nav-it.slack.com/archives/C84H68ESC/p1619790606355200

Denne er koblet til https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4388 som, pga att vi viser feil dato, ikke får hentet riktig poststed. Mulig man burde ha en fallback på 
`return kodeverkService.hentPoststed(postnummer, gjeldendeDato)` som henter siste/første poststed for det angitte postnumret 🤨 

Så sammenfatting: 
- folkeregistermetadata erstattetes med gyldigFraOgMed/gyldigTilOgMed
- Fjerner angittFlyttedato som tidligere ble brukt som gyldigFraOgMed

Ønsker innspill på min kommentar https://github.com/navikt/familie-ef-sak/pull/644#discussion_r623924486