### PR TITLE
Datoene i folkeregistermetadata er ikke dato for inn/utflytting er ik…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/MedlemskapMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/MedlemskapMapper.kt
@@ -64,7 +64,7 @@ class MedlemskapMapper(private val statsborgerskapMapper: StatsborgerskapMapper,
                 InnflyttingDto(fraflyttingsland = innflytting.fraflyttingsland?.let {
                     kodeverkService.hentLand(it, LocalDate.now()) ?: it
                 },
-                               dato = finnMinDatoRegistrert(innflytting.folkeregistermetadata)?.toLocalDate())
+                               dato = null)
             }
 
     private fun mapUtflytting(utflyttingFraNorge: List<UtflyttingFraNorge>): List<UtflyttingDto> =
@@ -72,10 +72,7 @@ class MedlemskapMapper(private val statsborgerskapMapper: StatsborgerskapMapper,
                 UtflyttingDto(tilflyttingsland = utflytting.tilflyttingsland?.let {
                     kodeverkService.hentLand(it, LocalDate.now()) ?: it
                 },
-                              dato = finnMinDatoRegistrert(utflytting.folkeregistermetadata)?.toLocalDate())
+                              dato = null)
             }
-
-    private fun finnMinDatoRegistrert(folkeregistermetadata: Folkeregistermetadata) =
-            min(folkeregistermetadata.gyldighetstidspunkt, folkeregistermetadata.opphørstidspunkt)
 
 }


### PR DESCRIPTION
…ke dato for når det skjedde og kan då bli missvisende for saksbehandlarne. Blir fjernet for å unngå forvirring. Blir opprettet en oppgave for å analysere hvordan den burde bli løst

Liten hotfix etter diskusjon med Mirja og Lars. Noen bruker datoet her fast de ikke burde. Av den grunnen fjerner vi den nå. 