### PR TITLE
Legger til uthenting av perioder fra vår base til arena

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/arena/ArenaPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/arena/ArenaPeriodeUtil.kt
@@ -1,0 +1,81 @@
+package no.nav.familie.ef.sak.arena
+
+import no.nav.familie.ef.sak.repository.domain.AndelTilkjentYtelse
+import no.nav.familie.ef.sak.util.isEqualOrAfter
+import no.nav.familie.ef.sak.util.isEqualOrBefore
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeOvergangsstønad
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadResponse
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad.Datakilde
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.Stack
+
+object ArenaPeriodeUtil {
+
+    /**
+     * Skal filtrere bort de som har beløp = 0
+     * Skal filtere bort de som har tomdato < fomDato || opphørdato < tomDato
+     */
+    fun mapOgFiltrer(infotrygdPerioder: InfotrygdPerioderOvergangsstønadResponse) =
+            infotrygdPerioder.perioder.filter { it.beløp > 0 }.map {
+                PeriodeOvergangsstønad(personIdent = it.personIdent,
+                                       fomDato = it.fomDato,
+                                       tomDato = it.opphørsdatoEllerTomDato(),
+                                       datakilde = Datakilde.INFOTRYGD)
+            }.filterNot { it.tomDato.isBefore(it.fomDato) }
+
+    fun mapOgFiltrer(andeler: List<AndelTilkjentYtelse>) =
+            andeler.filter { it.beløp > 0 }.map {
+                PeriodeOvergangsstønad(personIdent = it.personIdent,
+                                       fomDato = it.stønadFom,
+                                       tomDato = it.stønadTom,
+                                       datakilde = Datakilde.EF)
+            }
+
+    private fun InfotrygdPeriodeOvergangsstønad.opphørsdatoEllerTomDato(): LocalDate {
+        val opphørsdato = this.opphørsdato
+        return if (opphørsdato != null && opphørsdato.isBefore(tomDato)) {
+            opphørsdato
+        } else {
+            tomDato
+        }
+    }
+
+    /**
+     * Slår sammen perioder som er sammenhengende og overlappende.
+     * Dette er noe som idag gjøres i infotrygd men er ikke sikkert burde gjøres når vi henter perioder fra vår egen database
+     */
+    fun slåSammenPerioder(perioder: List<PeriodeOvergangsstønad>): List<PeriodeOvergangsstønad> {
+        val mergedePerioder = Stack<PeriodeOvergangsstønad>()
+        perioder.sortedBy { it.fomDato }.forEach { period ->
+            if (mergedePerioder.isEmpty()) {
+                mergedePerioder.push(period)
+            }
+            val last = mergedePerioder.peek()
+            if (erSammenhengendeEllerOverlappende(last, period)) {
+                mergedePerioder.push(mergedePerioder.pop().copy(fomDato = minOf(last.fomDato, period.fomDato),
+                                                                tomDato = maxOf(last.tomDato, period.tomDato)))
+            } else {
+                mergedePerioder.push(period)
+            }
+        }
+        return mergedePerioder
+    }
+
+    private fun erSammenhengendeEllerOverlappende(last: PeriodeOvergangsstønad,
+                                                  period: PeriodeOvergangsstønad) =
+            sammenhengendePeriode(last, period) || erOverlappende(last, period)
+
+    /**
+     * En periode er sammenhengende hvis perioden er i den samme måneden, eller om måned + 1 er lik
+     */
+    private fun sammenhengendePeriode(first: PeriodeOvergangsstønad, second: PeriodeOvergangsstønad): Boolean {
+        val firstTomDato = YearMonth.from(first.tomDato)
+        val secondFom = YearMonth.from(second.fomDato)
+        return firstTomDato == secondFom || firstTomDato.plusMonths(1) == secondFom
+    }
+
+    private fun erOverlappende(mergedPeriode: PeriodeOvergangsstønad, period: PeriodeOvergangsstønad) =
+            mergedPeriode.fomDato.isEqualOrBefore(period.tomDato) && mergedPeriode.tomDato.isEqualOrAfter(period.fomDato)
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
@@ -42,11 +42,28 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         FROM behandling b
         JOIN fagsak f ON f.id = b.fagsak_id
         JOIN fagsak_person fp ON b.fagsak_id = fp.fagsak_id
-        WHERE fp.ident IN (:personidenter) AND f.stonadstype = :stonadstype AND b.type != 'BLANKETT'
+        WHERE fp.ident IN (:personidenter) AND f.stonadstype = :stønadstype AND b.type != 'BLANKETT'
         ORDER BY b.opprettet_tid DESC
         LIMIT 1)
     """)
-    fun eksistererBehandlingSomIkkeErBlankett(@Param("stonadstype") stønadstype: Stønadstype, personidenter: Set<String>): Boolean
+    fun eksistererBehandlingSomIkkeErBlankett(stønadstype: Stønadstype, personidenter: Set<String>): Boolean
+
+    // language=PostgreSQL
+    @Query("""
+        SELECT b.*, be.id as eksternid_id
+        FROM behandling b
+        JOIN behandling_ekstern be ON b.id = be.behandling_id
+        JOIN fagsak f ON f.id = b.fagsak_id
+        JOIN fagsak_person fp ON b.fagsak_id = fp.fagsak_id
+        WHERE fp.ident IN (:personidenter)
+         AND f.stonadstype = :stønadstype
+         AND b.type != 'BLANKETT'
+         AND b.resultat != 'ANNULERT'
+         AND b.status = 'FERDIGSTILT'
+        ORDER BY b.opprettet_tid DESC
+        LIMIT 1
+    """)
+    fun finnSisteIverksatteBehandling(stønadstype: Stønadstype, personidenter: Set<String>): Behandling?
 
     // language=PostgreSQL
     @Query("""
@@ -82,6 +99,6 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
                  AND b.resultat != 'ANNULLERT'
          ) q WHERE rn = 1 AND type != 'TEKNISK_OPPHØR'
         """)
-    fun finnSisteIverksatteBehandlinger(stønadstype: Stønadstype): Set<UUID>
+    fun finnSisteIverksatteBehandlingerSomIkkeErTekniskOpphør(stønadstype: Stønadstype): Set<UUID>
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -40,7 +40,7 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
     fun hentEksterneIder(behandlingIder: Set<UUID>) = behandlingRepository.finnEksterneIder(behandlingIder)
 
     fun finnSisteIverksatteBehandlinger(stønadstype: Stønadstype) =
-            behandlingRepository.finnSisteIverksatteBehandlinger(stønadstype)
+            behandlingRepository.finnSisteIverksatteBehandlingerSomIkkeErTekniskOpphør(stønadstype)
 
     @Transactional
     fun opprettBehandling(behandlingType: BehandlingType,

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/StønadsperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/StønadsperioderService.kt
@@ -2,24 +2,23 @@ package no.nav.familie.ef.sak.service
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import no.nav.familie.ef.sak.arena.ArenaPeriodeUtil.mapOgFiltrer
+import no.nav.familie.ef.sak.arena.ArenaPeriodeUtil.slåSammenPerioder
 import no.nav.familie.ef.sak.exception.PdlNotFoundException
 import no.nav.familie.ef.sak.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.integration.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.integration.PdlClient
 import no.nav.familie.ef.sak.integration.dto.pdl.identer
-import no.nav.familie.ef.sak.util.isEqualOrAfter
-import no.nav.familie.ef.sak.util.isEqualOrBefore
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeOvergangsstønad
+import no.nav.familie.ef.sak.repository.BehandlingRepository
+import no.nav.familie.ef.sak.repository.domain.BehandlingType
+import no.nav.familie.ef.sak.repository.domain.Stønadstype
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadRequest
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.time.YearMonth
-import java.util.Stack
 
 /**
  * Denne tjenesten henter perioder for andre typer stønader fra EF også
@@ -28,11 +27,12 @@ import java.util.Stack
  */
 @Service
 class StønadsperioderService(private val infotrygdReplikaClient: InfotrygdReplikaClient,
+                             private val behandlingRepository: BehandlingRepository,
+                             private val tilkjentYtelseService: TilkjentYtelseService,
                              private val familieIntegrasjonerClient: FamilieIntegrasjonerClient,
                              private val pdlClient: PdlClient) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     /**
      * Henter perioder fra infotrygd for en person
@@ -41,94 +41,41 @@ class StønadsperioderService(private val infotrygdReplikaClient: InfotrygdRepli
     fun hentPerioder(request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
         return runBlocking {
             val asyncResponse = async { familieIntegrasjonerClient.hentInfotrygdPerioder(request) }
-            val responseFraReplika = hentReplikaPerioder(request)
-            val response = asyncResponse.await()
-            sjekkOmDetFinnesDiffIPerioder(request.personIdent, response, responseFraReplika)
-            response
+
+            //val responseFraReplika = hentReplikaPerioder(request) // TODO ta i bruk når replikaen virker i prod
+            val perioderFraInfotrygd = asyncResponse.await()
+            val perioderFraEf = hentPerioderFraEf(request)
+            PerioderOvergangsstønadResponse(perioderFraInfotrygd.perioder + perioderFraEf)
         }
     }
 
-    fun hentReplikaPerioder(request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
+    fun hentReplikaPerioder(request: PerioderOvergangsstønadRequest): List<PeriodeOvergangsstønad> {
         val personIdenter = hentPersonIdenter(request)
         return hentPerioderFraReplika(personIdenter, request)
     }
 
-    private fun sjekkOmDetFinnesDiffIPerioder(fnr: String,
-                                              response: PerioderOvergangsstønadResponse,
-                                              responseFraReplika: PerioderOvergangsstønadResponse) {
-        val replikaPerioder = responseFraReplika.perioder.sortedBy { it.fomDato }.map { it.fomDato to it.tomDato }
-        val perioder = response.perioder.sortedBy { it.fomDato }.map { it.fomDato to it.tomDato }
-        if (perioder != replikaPerioder) {
-            logger.warn("Det finnes forskjell i periodene fra infotrygd og replika")
-            secureLogger.info("Diff i perioder for fnr=$fnr perioder=$perioder replikaPerioder=$replikaPerioder")
-        }
+    private fun hentPerioderFraEf(request: PerioderOvergangsstønadRequest): List<PeriodeOvergangsstønad> {
+        // det er slik Arena ønsker det, det er samme i appen infotrygd-enslig-forsoerger
+        val fom = request.fomDato ?: LocalDate.now()
+        val tom = request.tomDato ?: LocalDate.now()
+        val personIdenter = hentPersonIdenter(request)
+        return Stønadstype.values()
+                .mapNotNull { behandlingRepository.finnSisteIverksatteBehandling(it, personIdenter) }
+                .mapNotNull { if (it.type != BehandlingType.TEKNISK_OPPHØR) it else null }
+                .map { tilkjentYtelseService.hentForBehandling(it.id) }
+                .flatMap { it.andelerTilkjentYtelse }
+                .filter { it.stønadFom <= tom && it.stønadTom >= fom }
+                .let { mapOgFiltrer(it) }
+                .let { slåSammenPerioder(it) }
     }
 
     private fun hentPerioderFraReplika(personIdenter: Set<String>,
-                                       request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
+                                       request: PerioderOvergangsstønadRequest): List<PeriodeOvergangsstønad> {
         val infotrygdRequest = InfotrygdPerioderOvergangsstønadRequest(personIdenter, request.fomDato, request.tomDato)
         val infotrygdPerioder = infotrygdReplikaClient.hentPerioderOvergangsstønad(infotrygdRequest)
         val perioder = mapOgFiltrer(infotrygdPerioder)
-        return PerioderOvergangsstønadResponse(slåSammenPerioder(perioder))
+        return slåSammenPerioder(perioder)
     }
-
-    /**
-     * Skal filtrere bort de som har beløp = 0
-     * Skal filtere bort de som har tomdato < fomDato || opphørdato < tomDato
-     */
-    private fun mapOgFiltrer(infotrygdPerioder: InfotrygdPerioderOvergangsstønadResponse) =
-            infotrygdPerioder.perioder.filter { it.beløp > 0 }.map {
-                PeriodeOvergangsstønad(personIdent = it.personIdent,
-                                       fomDato = it.fomDato,
-                                       tomDato = it.opphørsdatoEllerTomDato(),
-                                       datakilde = PeriodeOvergangsstønad.Datakilde.INFOTRYGD)
-            }.filterNot { it.tomDato.isBefore(it.fomDato) }
-
-    fun InfotrygdPeriodeOvergangsstønad.opphørsdatoEllerTomDato(): LocalDate {
-        val opphørsdato = this.opphørsdato
-        return if (opphørsdato != null && opphørsdato.isBefore(tomDato)) {
-            opphørsdato
-        } else {
-            tomDato
-        }
-    }
-
-    /**
-     * Slår sammen perioder som er sammenhengende og overlappende.
-     * Dette er noe som idag gjøres i infotrygd men er ikke sikkert burde gjøres når vi henter perioder fra vår egen database
-     */
-    private fun slåSammenPerioder(perioder: List<PeriodeOvergangsstønad>): List<PeriodeOvergangsstønad> {
-        val mergedePerioder = Stack<PeriodeOvergangsstønad>()
-        perioder.sortedBy { it.fomDato }.forEach { period ->
-            if (mergedePerioder.isEmpty()) {
-                mergedePerioder.push(period)
-            }
-            val last = mergedePerioder.peek()
-            if (erSammenhengendeEllerOverlappende(last, period)) {
-                mergedePerioder.push(mergedePerioder.pop().copy(fomDato = minOf(last.fomDato, period.fomDato),
-                                                                tomDato = maxOf(last.tomDato, period.tomDato)))
-            } else {
-                mergedePerioder.push(period)
-            }
-        }
-        return mergedePerioder
-    }
-
-    private fun erSammenhengendeEllerOverlappende(last: PeriodeOvergangsstønad,
-                                                  period: PeriodeOvergangsstønad) =
-            sammenhengendePeriode(last, period) || erOverlappende(last, period)
-
-    /**
-     * En periode er sammenhengende hvis perioden er i den samme måneden, eller om måned + 1 er lik
-     */
-    private fun sammenhengendePeriode(first: PeriodeOvergangsstønad, second: PeriodeOvergangsstønad): Boolean {
-        val firstTomDato = YearMonth.from(first.tomDato)
-        val secondFom = YearMonth.from(second.fomDato)
-        return firstTomDato == secondFom || firstTomDato.plusMonths(1) == secondFom
-    }
-
-    private fun erOverlappende(mergedPeriode: PeriodeOvergangsstønad, period: PeriodeOvergangsstønad) =
-            mergedPeriode.fomDato.isEqualOrBefore(period.tomDato) && mergedPeriode.tomDato.isEqualOrAfter(period.fomDato)
 
     private fun hentPersonIdenter(request: PerioderOvergangsstønadRequest): Set<String> {
         return try {

--- a/src/test/kotlin/no/nav/familie/ef/sak/arena/ArenaPeriodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/arena/ArenaPeriodeUtilTest.kt
@@ -1,0 +1,191 @@
+package no.nav.familie.ef.sak.arena
+
+import no.nav.familie.ef.sak.arena.ArenaPeriodeUtil.mapOgFiltrer
+import no.nav.familie.ef.sak.arena.ArenaPeriodeUtil.slåSammenPerioder
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeOvergangsstønad
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadResponse
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class ArenaPeriodeUtilTest {
+
+    private val ident = "01234567890"
+
+    @Test
+    internal fun `skal slå sammen perioder til arena`() {
+        val infotrygPerioder = listOf(periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2018-04-30"), 1f,
+                                              LocalDate.parse("2018-07-31")),
+                                      periode(LocalDate.parse("2018-05-01"), LocalDate.parse("2020-07-31"), 1f,
+                                              LocalDate.parse("2018-07-31")),
+                                      periode(LocalDate.parse("2018-09-01"), LocalDate.parse("2018-12-31"), 1f),
+                                      periode(LocalDate.parse("2019-01-01"), LocalDate.parse("2019-04-30"), 1f),
+                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-30"), 1f),
+                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-08-31"), 1f))
+
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2017-08-01") to LocalDate.parse("2018-07-31"),
+                                  LocalDate.parse("2018-09-01") to LocalDate.parse("2020-08-31")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena 2`() {
+        val infotrygPerioder = listOf(periode(LocalDate.parse("2018-12-01"), LocalDate.parse("2019-04-30"), 1f),
+                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-12-31"), 1f),
+                                      periode(LocalDate.parse("2019-12-01"), LocalDate.parse("2020-02-29"), 1f),
+                                      periode(LocalDate.parse("2020-02-01"), LocalDate.parse("2020-04-30"), 1f),
+                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-10-31"), 1f),
+                                      periode(LocalDate.parse("2020-09-01"), LocalDate.parse("2020-12-31"), 1f),
+                                      periode(LocalDate.parse("2021-01-01"), LocalDate.parse("2022-01-31"), 1f))
+
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2018-12-01") to LocalDate.parse("2022-01-31")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena 3`() {
+        val infotrygPerioder = listOf(periode(LocalDate.parse("2017-06-01"),
+                                              LocalDate.parse("2017-10-31"), 1f,
+                                              LocalDate.parse("2018-07-31")),
+                                      periode(LocalDate.parse("2017-08-01"),
+                                              LocalDate.parse("2018-04-30"), 1f,
+                                              LocalDate.parse("2018-07-31")),
+                                      periode(LocalDate.parse("2018-05-01"),
+                                              LocalDate.parse("2020-07-31"), 1f,
+                                              LocalDate.parse("2018-07-31")),
+                                      periode(LocalDate.parse("2018-09-01"), LocalDate.parse("2018-12-31"), 1f),
+                                      periode(LocalDate.parse("2019-01-01"), LocalDate.parse("2019-04-30"), 1f),
+                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-30"), 1f),
+                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-08-31"), 1f))
+
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(
+                        LocalDate.parse("2017-06-01") to LocalDate.parse("2018-07-31"),
+                        LocalDate.parse("2018-09-01") to LocalDate.parse("2020-08-31")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena 4`() {
+        val infotrygPerioder =
+                listOf(periode(LocalDate.parse("2018-05-01"), LocalDate.parse("2018-05-31"), 1555f),
+                       periode(LocalDate.parse("2018-04-01"), LocalDate.parse("2018-05-31"), 2887f),
+                       periode(LocalDate.parse("2018-03-01"), LocalDate.parse("2018-05-31"), 0f),
+                       periode(LocalDate.parse("2018-02-01"), LocalDate.parse("2018-05-31"), 2024f),
+                       periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2018-05-31"), 3269f),
+                       periode(LocalDate.parse("2016-09-01"), LocalDate.parse("2018-05-31"), 869f),
+                       periode(LocalDate.parse("2016-04-01"), LocalDate.parse("2018-05-31"), 0f),
+                       periode(LocalDate.parse("2016-03-01"), LocalDate.parse("2018-05-31"), 0f),
+                       periode(LocalDate.parse("2018-01-01"), LocalDate.parse("2018-01-31"), 3299f),
+                       periode(LocalDate.parse("2017-12-01"), LocalDate.parse("2017-12-31"), 0f),
+                       periode(LocalDate.parse("2017-11-01"), LocalDate.parse("2017-12-31"), 1199f),
+                       periode(LocalDate.parse("2017-10-01"), LocalDate.parse("2017-12-31"), 1612f),
+                       periode(LocalDate.parse("2017-09-01"), LocalDate.parse("2017-12-31"), 0f),
+                       periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2017-12-31"), 1424f),
+                       periode(LocalDate.parse("2017-02-01"), LocalDate.parse("2017-12-31"), 306f),
+                       periode(LocalDate.parse("2017-05-01"), LocalDate.parse("2017-11-30"), 3269f),
+                       periode(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-30"), 2406f),
+                       periode(LocalDate.parse("2017-03-01"), LocalDate.parse("2017-04-30"), 0f),
+                       periode(LocalDate.parse("2017-02-01"), LocalDate.parse("2017-04-30"), 3006f),
+                       periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2017-02-28"), 2969f),
+                       periode(LocalDate.parse("2016-12-01"), LocalDate.parse("2017-02-28"), 0f),
+                       periode(LocalDate.parse("2016-11-01"), LocalDate.parse("2017-02-28"), 2256f),
+                       periode(LocalDate.parse("2016-10-01"), LocalDate.parse("2017-02-28"), 2069f),
+                       periode(LocalDate.parse("2016-09-01"), LocalDate.parse("2017-02-28"), 269f),
+                       periode(LocalDate.parse("2016-08-01"), LocalDate.parse("2016-08-31"), 2481f),
+                       periode(LocalDate.parse("2016-07-01"), LocalDate.parse("2016-07-31"), 3194f),
+                       periode(LocalDate.parse("2016-06-01"), LocalDate.parse("2016-06-30"), 0f),
+                       periode(LocalDate.parse("2016-05-01"), LocalDate.parse("2016-05-31"), 269f))
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(
+                        LocalDate.parse("2016-05-01") to LocalDate.parse("2016-05-31"),
+                        LocalDate.parse("2016-07-01") to LocalDate.parse("2018-05-31"))
+                )
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena 5 - perioder som har samme startdato og sluttdato`() {
+        val infotrygPerioder =
+                listOf(periode(LocalDate.parse("2017-01-01"),
+                               LocalDate.parse("2017-06-30"), 17358f,
+                               LocalDate.parse("2017-01-01")),
+                       periode(LocalDate.parse("2017-01-01"),
+                               LocalDate.parse("2017-01-31"), 17358f,
+                               LocalDate.parse("2017-01-01")),
+                       periode(LocalDate.parse("2017-01-01"),
+                               LocalDate.parse("2017-05-31"), 17358f,
+                               LocalDate.parse("2017-03-31")))
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2017-01-01") to LocalDate.parse("2017-03-31")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena - sammenhengende måneder`() {
+        val infotrygPerioder =
+                listOf(periode(LocalDate.parse("2011-08-01"), LocalDate.parse("2011-08-01"), 1f),
+                       periode(LocalDate.parse("2011-09-01"), LocalDate.parse("2017-02-28"), 1f))
+
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2011-08-01") to LocalDate.parse("2017-02-28")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder til arena - opphør før FOM`() {
+        val infotrygPerioder =
+                listOf(periode(LocalDate.parse("2013-04-01"), LocalDate.parse("2013-06-30"), 2013f),
+                       periode(LocalDate.parse("2009-02-01"),
+                               LocalDate.parse("2011-04-30"), 11534f,
+                               LocalDate.parse("2009-01-31")),
+                       periode(LocalDate.parse("2009-02-01"),
+                               LocalDate.parse("2011-04-30"), 11534f,
+                               LocalDate.parse("2009-02-28")),
+                       periode(LocalDate.parse("2008-12-01"),
+                               LocalDate.parse("2009-01-31"), 11534f,
+                               LocalDate.parse("2009-01-31")))
+
+
+        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2008-12-01") to LocalDate.parse("2009-02-28"),
+                                  LocalDate.parse("2013-04-01") to LocalDate.parse("2013-06-30")))
+    }
+
+    @Test
+    internal fun `skal slå sammen perioder fra ulike stønadstyper fra ef`() {
+        val perioder = slåSammenPerioder(mapOgFiltrer(listOf(
+                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-01-01"), LocalDate.parse("2021-01-31")),
+                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-03-01"), LocalDate.parse("2021-05-31")),
+                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-04-01"), LocalDate.parse("2021-07-31")),
+        )))
+
+        assertThat(perioder.tilFomTomDato())
+                .isEqualTo(listOf(LocalDate.parse("2021-01-01") to LocalDate.parse("2021-01-31"),
+                                  LocalDate.parse("2021-03-01") to LocalDate.parse("2021-07-31")))
+    }
+
+    fun List<PeriodeOvergangsstønad>.tilFomTomDato(): List<Pair<LocalDate, LocalDate>> = this.map { it.fomDato to it.tomDato }
+
+    private fun periode(fomDato: LocalDate, tomDato: LocalDate, beløp: Float, opphørsdato: LocalDate? = null) =
+            InfotrygdPeriodeOvergangsstønad(ident, fomDato, tomDato, beløp, opphørsdato)
+
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/StønadsperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/StønadsperioderServiceTest.kt
@@ -4,15 +4,26 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.exception.PdlNotFoundException
+import no.nav.familie.ef.sak.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.integration.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.integration.PdlClient
 import no.nav.familie.ef.sak.integration.dto.pdl.PdlIdent
 import no.nav.familie.ef.sak.integration.dto.pdl.PdlIdenter
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
+import no.nav.familie.ef.sak.repository.BehandlingRepository
+import no.nav.familie.ef.sak.repository.domain.Stønadstype
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeOvergangsstønad
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadRequest
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderOvergangsstønadResponse
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad.Datakilde
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
+import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDate.parse
@@ -21,10 +32,23 @@ internal class StønadsperioderServiceTest {
 
     private val pdlClient = mockk<PdlClient>()
     private val infotrygdReplikaClient = mockk<InfotrygdReplikaClient>(relaxed = true)
-    private val perioderOvergangsstønadService =
-            StønadsperioderService(infotrygdReplikaClient, mockk(relaxed = true), pdlClient)
+    private val behandlingRepository = mockk<BehandlingRepository>(relaxed = true)
+    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
+
+    private val service =
+            StønadsperioderService(infotrygdReplikaClient = infotrygdReplikaClient,
+                                   behandlingRepository = behandlingRepository,
+                                   pdlClient = pdlClient,
+                                   tilkjentYtelseService = tilkjentYtelseService,
+                                   familieIntegrasjonerClient = familieIntegrasjonerClient)
 
     private val ident = "01234567890"
+
+    @BeforeEach
+    internal fun setUp() {
+        every { behandlingRepository.finnSisteIverksatteBehandling(any(), any()) } returns null
+    }
 
     @Test
     internal fun `hentPerioder henter perioder fra infotrygd med alle identer fra pdl`() {
@@ -37,9 +61,9 @@ internal class StønadsperioderServiceTest {
         every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
                 infotrygdResponse(InfotrygdPeriodeOvergangsstønad(ident, LocalDate.now(), LocalDate.now(), 10f))
 
-        val hentPerioder = perioderOvergangsstønadService.hentReplikaPerioder(request)
+        val hentPerioder = service.hentReplikaPerioder(request)
 
-        assertThat(hentPerioder.perioder).hasSize(1)
+        assertThat(hentPerioder).hasSize(1)
 
         verify(exactly = 1) { pdlClient.hentPersonidenter(ident, true) }
         verify(exactly = 1) {
@@ -52,169 +76,37 @@ internal class StønadsperioderServiceTest {
     internal fun `skal kalle infotrygd hvis pdl ikke finner personIdent med personIdent i requesten`() {
         every { pdlClient.hentPersonidenter(any(), true) } throws PdlNotFoundException()
 
-        perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
+        service.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
         verify(exactly = 1) {
             infotrygdReplikaClient.hentPerioderOvergangsstønad(InfotrygdPerioderOvergangsstønadRequest(setOf(ident)))
         }
     }
 
     @Test
-    internal fun `skal slå sammen perioder til arena`() {
+    internal fun `skal returnere perioder fra både infotrygd og ef`() {
+        val behandlingOvergangsstønad = behandling(fagsak(stønadstype = Stønadstype.OVERGANGSSTØNAD))
+        val behandlingBarnetilsyn = behandling(fagsak(stønadstype = Stønadstype.BARNETILSYN))
+
         mockPdl()
-        val infotrygPerioder = listOf(periode(parse("2017-08-01"), parse("2018-04-30"), 1f, parse("2018-07-31")),
-                                      periode(parse("2018-05-01"), parse("2020-07-31"), 1f, parse("2018-07-31")),
-                                      periode(parse("2018-09-01"), parse("2018-12-31"), 1f),
-                                      periode(parse("2019-01-01"), parse("2019-04-30"), 1f),
-                                      periode(parse("2019-05-01"), parse("2020-04-30"), 1f),
-                                      periode(parse("2020-05-01"), parse("2020-08-31"), 1f))
+        every {
+            behandlingRepository.finnSisteIverksatteBehandling(Stønadstype.OVERGANGSSTØNAD,
+                                                               any())
+        } returns behandlingOvergangsstønad
+        every { behandlingRepository.finnSisteIverksatteBehandling(Stønadstype.BARNETILSYN, any()) } returns behandlingBarnetilsyn
 
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
+        every { familieIntegrasjonerClient.hentInfotrygdPerioder(any()) } returns PerioderOvergangsstønadResponse(listOf(
+                PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-01-31"), Datakilde.INFOTRYGD)))
+        every { tilkjentYtelseService.hentForBehandling(behandlingOvergangsstønad.id) } returns
+                lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(1, parse("2021-01-01"), parse("2021-01-31"), ident)))
+        every { tilkjentYtelseService.hentForBehandling(behandlingBarnetilsyn.id) } returns
+                lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(2, parse("2021-02-01"), parse("2021-03-31"), ident)))
 
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2017-08-01") to parse("2018-07-31"),
-                                                  parse("2018-09-01") to parse("2020-08-31")))
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena 2`() {
-        mockPdl()
-        val infotrygPerioder = listOf(periode(parse("2018-12-01"), parse("2019-04-30"), 1f),
-                                      periode(parse("2019-05-01"), parse("2019-12-31"), 1f),
-                                      periode(parse("2019-12-01"), parse("2020-02-29"), 1f),
-                                      periode(parse("2020-02-01"), parse("2020-04-30"), 1f),
-                                      periode(parse("2020-05-01"), parse("2020-10-31"), 1f),
-                                      periode(parse("2020-09-01"), parse("2020-12-31"), 1f),
-                                      periode(parse("2021-01-01"), parse("2022-01-31"), 1f))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2018-12-01") to parse("2022-01-31")))
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena 3`() {
-        mockPdl()
-        val infotrygPerioder = listOf(periode(parse("2017-06-01"), parse("2017-10-31"), 1f, parse("2018-07-31")),
-                                      periode(parse("2017-08-01"), parse("2018-04-30"), 1f, parse("2018-07-31")),
-                                      periode(parse("2018-05-01"), parse("2020-07-31"), 1f, parse("2018-07-31")),
-                                      periode(parse("2018-09-01"), parse("2018-12-31"), 1f),
-                                      periode(parse("2019-01-01"), parse("2019-04-30"), 1f),
-                                      periode(parse("2019-05-01"), parse("2020-04-30"), 1f),
-                                      periode(parse("2020-05-01"), parse("2020-08-31"), 1f))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2017-06-01") to parse("2018-07-31"),
-                                                  parse("2018-09-01") to parse("2020-08-31"))
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, parse("2020-01-01"), parse("2022-01-01")))
+        assertThat(perioder.perioder).containsExactly(
+                PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-01-31"), Datakilde.INFOTRYGD),
+                PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-03-31"), Datakilde.EF),
         )
-    }
 
-    @Test
-    internal fun `skal slå sammen perioder til arena 4`() {
-        mockPdl()
-        val infotrygPerioder =
-                listOf(periode(parse("2018-05-01"), parse("2018-05-31"), 1555f),
-                       periode(parse("2018-04-01"), parse("2018-05-31"), 2887f),
-                       periode(parse("2018-03-01"), parse("2018-05-31"), 0f),
-                       periode(parse("2018-02-01"), parse("2018-05-31"), 2024f),
-                       periode(parse("2017-08-01"), parse("2018-05-31"), 3269f),
-                       periode(parse("2016-09-01"), parse("2018-05-31"), 869f),
-                       periode(parse("2016-04-01"), parse("2018-05-31"), 0f),
-                       periode(parse("2016-03-01"), parse("2018-05-31"), 0f),
-                       periode(parse("2018-01-01"), parse("2018-01-31"), 3299f),
-                       periode(parse("2017-12-01"), parse("2017-12-31"), 0f),
-                       periode(parse("2017-11-01"), parse("2017-12-31"), 1199f),
-                       periode(parse("2017-10-01"), parse("2017-12-31"), 1612f),
-                       periode(parse("2017-09-01"), parse("2017-12-31"), 0f),
-                       periode(parse("2017-08-01"), parse("2017-12-31"), 1424f),
-                       periode(parse("2017-02-01"), parse("2017-12-31"), 306f),
-                       periode(parse("2017-05-01"), parse("2017-11-30"), 3269f),
-                       periode(parse("2017-04-01"), parse("2017-04-30"), 2406f),
-                       periode(parse("2017-03-01"), parse("2017-04-30"), 0f),
-                       periode(parse("2017-02-01"), parse("2017-04-30"), 3006f),
-                       periode(parse("2017-01-01"), parse("2017-02-28"), 2969f),
-                       periode(parse("2016-12-01"), parse("2017-02-28"), 0f),
-                       periode(parse("2016-11-01"), parse("2017-02-28"), 2256f),
-                       periode(parse("2016-10-01"), parse("2017-02-28"), 2069f),
-                       periode(parse("2016-09-01"), parse("2017-02-28"), 269f),
-                       periode(parse("2016-08-01"), parse("2016-08-31"), 2481f),
-                       periode(parse("2016-07-01"), parse("2016-07-31"), 3194f),
-                       periode(parse("2016-06-01"), parse("2016-06-30"), 0f),
-                       periode(parse("2016-05-01"), parse("2016-05-31"), 269f))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(
-                listOf(parse("2016-05-01") to parse("2016-05-31"),
-                       parse("2016-07-01") to parse("2018-05-31"))
-        )
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena 5 - perioder som har samme startdato og sluttdato`() {
-        mockPdl()
-        val infotrygPerioder =
-                listOf(periode(parse("2017-01-01"), parse("2017-06-30"), 17358f, parse("2017-01-01")),
-                       periode(parse("2017-01-01"), parse("2017-01-31"), 17358f, parse("2017-01-01")),
-                       periode(parse("2017-01-01"), parse("2017-05-31"), 17358f, parse("2017-03-31")))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2017-01-01") to parse("2017-03-31")))
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena - sammenhengende måneder`() {
-        mockPdl()
-        val infotrygPerioder =
-                listOf(periode(parse("2011-08-01"), parse("2011-08-01"), 1f),
-                       periode(parse("2011-09-01"), parse("2017-02-28"), 1f))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2011-08-01") to parse("2017-02-28")))
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena - opphør før FOM`() {
-        mockPdl()
-        val infotrygPerioder =
-                listOf(periode(parse("2013-04-01"), parse("2013-06-30"), 2013f),
-                       periode(parse("2009-02-01"), parse("2011-04-30"), 11534f, parse("2009-01-31")),
-                       periode(parse("2009-02-01"), parse("2011-04-30"), 11534f, parse("2009-02-28")),
-                       periode(parse("2008-12-01"), parse("2009-01-31"), 11534f, parse("2009-01-31")))
-
-        every { infotrygdReplikaClient.hentPerioderOvergangsstønad(any()) } returns
-                InfotrygdPerioderOvergangsstønadResponse(infotrygPerioder)
-
-        val perioder = perioderOvergangsstønadService.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident))
-
-        val fomTomDatoer = perioder.perioder.map { it.fomDato to it.tomDato }
-        assertThat(fomTomDatoer).isEqualTo(listOf(parse("2008-12-01") to parse("2009-02-28"),
-                                                  parse("2013-04-01") to parse("2013-06-30")))
     }
 
     private fun periode(fomDato: LocalDate, tomDato: LocalDate, beløp: Float, opphørsdato: LocalDate? = null) =

--- a/src/test/kotlin/no/nav/familie/ef/sak/økonomi/ØkonomiUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/økonomi/ØkonomiUtil.kt
@@ -1,8 +1,29 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.økonomi
 
 import no.nav.familie.ef.sak.repository.domain.AndelTilkjentYtelse
+import no.nav.familie.ef.sak.repository.domain.TilkjentYtelse
+import no.nav.familie.ef.sak.repository.domain.TilkjentYtelseStatus
+import no.nav.familie.ef.sak.repository.domain.TilkjentYtelseType
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import java.time.LocalDate
 import java.util.UUID
+
+fun lagTilkjentYtelse(andelerTilkjentYtelse: List<AndelTilkjentYtelse>,
+                      id: UUID = UUID.randomUUID(),
+                      behandlingId: UUID = UUID.randomUUID(),
+                      personident: String = "123",
+                      utbetalingsoppdrag: Utbetalingsoppdrag? = null,
+                      vedtaksdato: LocalDate? = null,
+                      status: TilkjentYtelseStatus = TilkjentYtelseStatus.IKKE_KLAR,
+                      type: TilkjentYtelseType = TilkjentYtelseType.FØRSTEGANGSBEHANDLING) =
+        TilkjentYtelse(id = id,
+                       behandlingId = behandlingId,
+                       personident = personident,
+                       utbetalingsoppdrag = utbetalingsoppdrag,
+                       vedtaksdato = vedtaksdato,
+                       status = status,
+                       type = type,
+                       andelerTilkjentYtelse = andelerTilkjentYtelse)
 
 fun lagAndelTilkjentYtelse(beløp: Int,
                            fraOgMed: LocalDate,


### PR DESCRIPTION
Litt den samme query som Alexa la inn i https://github.com/navikt/familie-ef-sak/pull/713
Ble litt oppsplitting av periodeservice og ArenaPeriodeUtil, med flytt av de samme testene til ArenaPeriodeUtil

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-3307

- [ ] Må rute om ef-proxy til ef-sak