### PR TITLE
Bugfix/co adresse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
@@ -87,8 +87,19 @@ class AdresseMapper(private val kodeverkService: KodeverkService) {
     }
 
     private fun coAdresse(coAdressenavn: String?): String? {
-        if (coAdressenavn.isNullOrBlank()) return null
+        if (coAdressenavn.isNullOrBlank()) {
+            return null
+        } else if (harPrefiks(coAdressenavn)) {
+            return coAdressenavn
+        }
         return "c/o $coAdressenavn"
+    }
+
+    private fun harPrefiks(coAdressenavn: String): Boolean {
+        return coAdressenavn.startsWith("c/o", true)
+               || coAdressenavn.startsWith("V/", true)
+               || coAdressenavn.startsWith("DBO v/", true)
+               || coAdressenavn.startsWith("v/DBO", true)
     }
 
     //må feltet "postboks" ha med "postboks" i strengen? "postboks ${postboks}" ?

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapper.kt
@@ -86,7 +86,10 @@ class AdresseMapper(private val kodeverkService: KodeverkService) {
         return join(coAdresse(kontaktadresse.coAdressenavn), adresse)
     }
 
-    private fun coAdresse(coAdressenavn: String?): String? = coAdressenavn?.let { "c/o $it" }
+    private fun coAdresse(coAdressenavn: String?): String? {
+        if (coAdressenavn.isNullOrBlank()) return null
+        return "c/o $coAdressenavn"
+    }
 
     //må feltet "postboks" ha med "postboks" i strengen? "postboks ${postboks}" ?
     private fun tilFormatertAdresse(postboksadresse: Postboksadresse, gjeldendeDato: LocalDate): String? =

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
@@ -68,6 +68,24 @@ internal class AdresseMapperTest {
     }
 
     @Test
+    internal fun `Skal ikke endre format på coAdresse hvis prefiks finnes fra før`() {
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "c/o co")).visningsadresse)
+                .isEqualTo("c/o co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "C/O co")).visningsadresse)
+                .isEqualTo("C/O co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "V/ co")).visningsadresse)
+                .isEqualTo("V/ co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "v/DBO co")).visningsadresse)
+                .isEqualTo("v/DBO co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "DBO v/ co")).visningsadresse)
+                .isEqualTo("DBO v/ co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+    }
+
+    @Test
     internal fun `Skal kalle på hentPoststed med gyldigFraOgMed når gyldigFraOgMed finnes`() {
         mapper.tilAdresse(bostedsadresse)
         verify { kodeverkService.hentPoststed(any(), bostedsadresse.gyldigFraOgMed!!) }
@@ -75,7 +93,7 @@ internal class AdresseMapperTest {
 
     @Test
     internal fun `skal håndtere feilregistrert dato som null`() {
-        val adresse = mapper.tilAdresse(bostedsadresse.copy(angittFlyttedato = LocalDate.of(1,1,1)))
+        val adresse = mapper.tilAdresse(bostedsadresse.copy(angittFlyttedato = LocalDate.of(1, 1, 1)))
         assertThat(adresse.angittFlyttedato).isNull()
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseMapperTest.kt
@@ -49,6 +49,9 @@ internal class AdresseMapperTest {
         assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "co")).visningsadresse)
                 .isEqualTo("c/o co, Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
 
+        assertThat(mapper.tilAdresse(bostedsadresse.copy(coAdressenavn = "")).visningsadresse)
+                .isEqualTo("Charlies vei 13 b, tilleggsnavn, 0575 Oslo")
+
         assertThat(mapper.tilAdresse(bostedsadresse.copy(vegadresse = null)).visningsadresse)
                 .withFailMessage("Skal skrive ut matrikkeladresse når vegadresse er null")
                 .isEqualTo("tilleggsnavn, bruksenhet, Oslo")


### PR DESCRIPTION
favro oppgave: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4985

Har avklart med Mirja at det er feil i visning av coAdresse.

Legger til sjekk på tom streng og prefiks.  