### PR TITLE
Lagre saksbehandler og beslutter på vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/beregning/VedtakService.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ef.sak.repository.domain.Vedtak
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
-import java.util.*
+import java.util.UUID
 
 @Service
 class VedtakService(private val vedtakRepository: VedtakRepository) {
@@ -26,5 +26,17 @@ class VedtakService(private val vedtakRepository: VedtakRepository) {
     fun hentVedtakHvisEksisterer(behandlingId: UUID): VedtakDto? {
         return vedtakRepository.findByIdOrNull(behandlingId)
                 ?.tilVedtakDto()
+    }
+
+    fun oppdaterSaksbehandler(behandlingId: UUID, saksbehandlerIdent: String) {
+        val vedtak = hentVedtak(behandlingId)
+        vedtak.copy(saksbehandlerIdent = saksbehandlerIdent)
+        vedtakRepository.update(vedtak)
+    }
+
+    fun oppdaterBeslutter(behandlingId: UUID, beslutterIdent: String) {
+        val vedtak = hentVedtak(behandlingId)
+        vedtak.copy(beslutterIdent = beslutterIdent)
+        vedtakRepository.update(vedtak)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Vedtak.kt
@@ -16,7 +16,9 @@ data class Vedtak(@Id
                   @Column("avsla_begrunnelse")
                   val avslåBegrunnelse: String? = null,
                   val perioder: PeriodeWrapper? = null,
-                  val inntekter: InntektWrapper? = null)
+                  val inntekter: InntektWrapper? = null,
+                  val saksbehandlerIdent: String? = null,
+                  val beslutterIdent: String? = null)
 
 data class Vedtaksperiode(
         val datoFra: LocalDate,

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Vedtak.kt
@@ -5,7 +5,7 @@ import no.nav.familie.ef.sak.api.beregning.ResultatType
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDate
-import java.util.*
+import java.util.UUID
 
 
 data class Vedtak(@Id

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.service.steg
 
 import no.nav.familie.ef.sak.api.Feil
+import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.api.dto.BeslutteVedtakDto
 import no.nav.familie.ef.sak.blankett.JournalførBlankettTask
 import no.nav.familie.ef.sak.featuretoggle.FeatureToggleService
@@ -33,7 +34,8 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
                          private val iverksettClient: IverksettClient,
                          private val iverksettingDtoMapper: IverksettingDtoMapper,
                          private val totrinnskontrollService: TotrinnskontrollService,
-                         private val vedtaksbrevRepository: VedtaksbrevRepository) : BehandlingSteg<BeslutteVedtakDto> {
+                         private val vedtaksbrevRepository: VedtaksbrevRepository,
+                         private val vedtakService: VedtakService) : BehandlingSteg<BeslutteVedtakDto> {
 
     override fun validerSteg(behandling: Behandling) {
         if (behandling.steg != stegType()) {
@@ -50,6 +52,7 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
 
         return if (data.godkjent) {
             if (behandling.type != BehandlingType.BLANKETT) {
+                vedtakService.oppdaterBeslutter(behandling.id, SikkerhetContext.hentSaksbehandler())
                 val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(behandling.id)
                 val fil = utledVedtaksbrev(vedtaksbrev)
                 val iverksettDto = iverksettingDtoMapper.tilDto(behandling, beslutter)
@@ -79,7 +82,10 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
         val oppgavetype = Oppgavetype.GodkjenneVedtak
         val aktivIdent = fagsakService.hentAktivIdent(behandling.fagsakId)
         oppgaveService.hentOppgaveSomIkkeErFerdigstilt(oppgavetype, behandling)?.let {
-            taskRepository.save(FerdigstillOppgaveTask.opprettTask(behandlingId = behandling.id, oppgavetype, it.gsakOppgaveId, aktivIdent))
+            taskRepository.save(FerdigstillOppgaveTask.opprettTask(behandlingId = behandling.id,
+                                                                   oppgavetype,
+                                                                   it.gsakOppgaveId,
+                                                                   aktivIdent))
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
@@ -52,7 +52,7 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
 
         return if (data.godkjent) {
             if (behandling.type != BehandlingType.BLANKETT) {
-                vedtakService.oppdaterBeslutter(behandling.id, SikkerhetContext.hentSaksbehandler())
+                vedtakService.oppdaterBeslutter(behandling.id, SikkerhetContext.hentSaksbehandler(strict = true))
                 val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(behandling.id)
                 val fil = utledVedtaksbrev(vedtaksbrev)
                 val iverksettDto = iverksettingDtoMapper.tilDto(behandling, beslutter)

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakSteg.kt
@@ -51,8 +51,8 @@ class BeslutteVedtakSteg(private val taskRepository: TaskRepository,
         ferdigstillOppgave(behandling)
 
         return if (data.godkjent) {
+            vedtakService.oppdaterBeslutter(behandling.id, SikkerhetContext.hentSaksbehandler(strict = true))
             if (behandling.type != BehandlingType.BLANKETT) {
-                vedtakService.oppdaterBeslutter(behandling.id, SikkerhetContext.hentSaksbehandler(strict = true))
                 val vedtaksbrev = vedtaksbrevRepository.findByIdOrThrow(behandling.id)
                 val fil = utledVedtaksbrev(vedtaksbrev)
                 val iverksettDto = iverksettingDtoMapper.tilDto(behandling, beslutter)

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/SendTilBeslutterSteg.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.service.steg
 
 import no.nav.familie.ef.sak.api.Feil
+import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.repository.VedtaksbrevRepository
 import no.nav.familie.ef.sak.repository.domain.Behandling
 import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
@@ -8,6 +9,7 @@ import no.nav.familie.ef.sak.repository.domain.BehandlingType
 import no.nav.familie.ef.sak.service.BehandlingService
 import no.nav.familie.ef.sak.service.FagsakService
 import no.nav.familie.ef.sak.service.OppgaveService
+import no.nav.familie.ef.sak.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.task.FerdigstillOppgaveTask
 import no.nav.familie.ef.sak.task.OpprettOppgaveTask
 import no.nav.familie.ef.sak.task.OpprettOppgaveTask.OpprettOppgaveTaskData
@@ -20,20 +22,22 @@ class SendTilBeslutterSteg(private val taskRepository: TaskRepository,
                            private val oppgaveService: OppgaveService,
                            private val fagsakService: FagsakService,
                            private val behandlingService: BehandlingService,
-                           private val vedtaksbrevRepository: VedtaksbrevRepository) : BehandlingSteg<Void?> {
+                           private val vedtaksbrevRepository: VedtaksbrevRepository,
+                           private val vedtakService: VedtakService) : BehandlingSteg<Void?> {
 
     override fun validerSteg(behandling: Behandling) {
         if (behandling.steg != stegType()) {
             throw Feil("Behandling er i feil steg=${behandling.steg}")
         }
 
-        if (behandling.type !== BehandlingType.BLANKETT && !vedtaksbrevRepository.existsById(behandling.id) ) {
+        if (behandling.type !== BehandlingType.BLANKETT && !vedtaksbrevRepository.existsById(behandling.id)) {
             throw Feil("Brev mangler for behandling=${behandling.id}")
         }
     }
 
     override fun utførSteg(behandling: Behandling, data: Void?) {
         behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FATTER_VEDTAK)
+        vedtakService.oppdaterSaksbehandler(behandling.id, SikkerhetContext.hentSaksbehandler(strict = true))
         opprettGodkjennVedtakOppgave(behandling)
 
         ferdigstillOppgave(behandling, Oppgavetype.BehandleSak)

--- a/src/main/resources/db/migration/V51__saksbehandler_og_beslutter_ident_vedtak.sql
+++ b/src/main/resources/db/migration/V51__saksbehandler_og_beslutter_ident_vedtak.sql
@@ -1,0 +1,2 @@
+ALTER TABLE vedtak ADD COLUMN saksbehandler_ident VARCHAR DEFAULT NULL;
+ALTER TABLE vedtak ADD COLUMN beslutter_ident VARCHAR DEFAULT NULL;

--- a/src/main/resources/db/migration/V52__migrer_vedtak_uten_saksbehandler_og_beslutter_ident.sql
+++ b/src/main/resources/db/migration/V52__migrer_vedtak_uten_saksbehandler_og_beslutter_ident.sql
@@ -1,0 +1,9 @@
+UPDATE vedtak
+SET saksbehandler_ident = subquery.opprettet_av
+FROM (SELECT opprettet_av, behandling_id FROM behandlingshistorikk WHERE steg = 'SEND_TIL_BESLUTTER') as subquery
+WHERE vedtak.behandling_id = subquery.behandling_id;
+
+UPDATE vedtak
+SET beslutter_ident = subquery.opprettet_av
+FROM (SELECT opprettet_av, behandling_id FROM behandlingshistorikk WHERE steg = 'BESLUTTE_VEDTAK') as subquery
+WHERE vedtak.behandling_id = subquery.behandling_id;

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) {
                       "mock-infotrygd-replika",
                       "mock-kodeverk",
                       "mock-blankett",
-                      "mock-iverksett")
-
+                      "mock-iverksett",
+                      "mock-brev")
             .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -19,7 +19,7 @@ fun main(args: Array<String>) {
                       "mock-infotrygd-replika",
                       "mock-kodeverk",
                       "mock-blankett",
-                      "mock-iverksett",
-                      "mock-brev")
+                      "mock-iverksett")
+            herskalmockbrevvære
             .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -20,6 +20,6 @@ fun main(args: Array<String>) {
                       "mock-kodeverk",
                       "mock-blankett",
                       "mock-iverksett")
-            herskalmockbrevvære
+
             .run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeslutteVedtakStegTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.api.dto.BeslutteVedtakDto
 import no.nav.familie.ef.sak.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
@@ -51,6 +52,7 @@ internal class BeslutteVedtakStegTest {
     private val featureToggleService = mockk<FeatureToggleService>()
     private val iverksettingDtoMapper = mockk<IverksettingDtoMapper>()
     private val iverksett = mockk<IverksettClient>()
+    private val vedtakService = mockk<VedtakService>()
 
     private val beslutteVedtakSteg = BeslutteVedtakSteg(taskRepository,
                                                         fagsakService,
@@ -59,8 +61,8 @@ internal class BeslutteVedtakStegTest {
                                                         iverksett,
                                                         iverksettingDtoMapper,
                                                         totrinnskontrollService,
-                                                        vedtaksbrevRepository
-    )
+                                                        vedtaksbrevRepository,
+                                                        vedtakService)
     private val vedtaksbrev = Vedtaksbrev(UUID.randomUUID(),
                                           "123",
                                           "mal",
@@ -101,6 +103,7 @@ internal class BeslutteVedtakStegTest {
     @Test
     internal fun `skal opprette iverksettMotOppdragTask etter beslutte vedtak hvis godkjent`() {
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
+        every { vedtakService.oppdaterBeslutter(behandlingId, any()) } just Runs
         val nesteSteg = utførTotrinnskontroll(godkjent = true)
         assertThat(nesteSteg).isEqualTo(StegType.VENTE_PÅ_STATUS_FRA_IVERKSETT)
         assertThat(taskSlot.captured.type).isEqualTo(PollStatusFraIverksettTask.TYPE)


### PR DESCRIPTION
Vi har pr. nå ingen god måte å sjekke hvem som står som saksbehandler eller beslutter på et vedtak, uten å utlede det fra behandlingsshistorikk. Legger derfor til to felter på vedtaket for å ha dette eksplisitt. 

Dette skal bl.a. brukes for å vise brev uten å generere beslutter-signatur først.