### PR TITLE
"Hent brev" skal hente brev for saksbehandlere uten beslutterrolle 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtaksbrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtaksbrevController.kt
@@ -22,9 +22,9 @@ class VedtaksbrevController(private val brevService: VedtaksbrevService,
                             private val tilgangService: TilgangService) {
 
     @GetMapping("/{behandlingId}")
-    fun hentEllerRekonstruerSaksbehandlerBrevrequest(@PathVariable behandlingId: UUID): Ressurs<ByteArray> {
+    fun hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(@PathVariable behandlingId: UUID): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilBehandling(behandlingId)
-        return Ressurs.success(brevService.hentEllerRekonstruerSaksbehandlerBrevrequest(behandlingId))
+        return Ressurs.success(brevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId))
     }
 
     @PostMapping("/{behandlingId}/{brevMal}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtaksbrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/api/gui/VedtaksbrevController.kt
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 import java.util.UUID
 
 @RestController
@@ -23,9 +22,9 @@ class VedtaksbrevController(private val brevService: VedtaksbrevService,
                             private val tilgangService: TilgangService) {
 
     @GetMapping("/{behandlingId}")
-    fun hentBrev(@PathVariable behandlingId: UUID): Ressurs<ByteArray> {
+    fun hentEllerRekonstruerSaksbehandlerBrevrequest(@PathVariable behandlingId: UUID): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilBehandling(behandlingId)
-        return Ressurs.success(brevService.hentBrev(behandlingId))
+        return Ressurs.success(brevService.hentEllerRekonstruerSaksbehandlerBrevrequest(behandlingId))
     }
 
     @PostMapping("/{behandlingId}/{brevMal}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
@@ -19,7 +19,7 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                          private val brevRepository: VedtaksbrevRepository,
                          private val behandlingService: BehandlingService) {
 
-    fun hentBrev(behandlingId: UUID): ByteArray {
+    fun hentEllerRekonstruerSaksbehandlerBrevrequest(behandlingId: UUID): ByteArray {
         val vedtaksbrev = brevRepository.findByIdOrThrow(behandlingId)
         return if (vedtaksbrev.beslutterPdf != null) {
             vedtaksbrev.beslutterPdf.bytes

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
@@ -19,9 +19,14 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                          private val brevRepository: VedtaksbrevRepository,
                          private val behandlingService: BehandlingService) {
 
-    fun hentBrev(behandlingId: UUID) =
-            brevRepository.findByIdOrThrow(behandlingId).beslutterPdf?.bytes
-            ?: error("Mangler beslutterPdf for behandling=$behandlingId")
+    fun hentBrev(behandlingId: UUID): ByteArray {
+        val vedtaksbrev = brevRepository.findByIdOrThrow(behandlingId)
+        return if (vedtaksbrev.beslutterPdf != null) {
+            vedtaksbrev.beslutterPdf.bytes
+        } else {
+            brevClient.genererBrev(vedtaksbrev)
+        }
+    }
 
     fun lagBeslutterBrev(behandlingId: UUID): ByteArray {
         val behandling = behandlingService.hentBehandling(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevService.kt
@@ -19,7 +19,7 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                          private val brevRepository: VedtaksbrevRepository,
                          private val behandlingService: BehandlingService) {
 
-    fun hentEllerRekonstruerSaksbehandlerBrevrequest(behandlingId: UUID): ByteArray {
+    fun hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId: UUID): ByteArray {
         val vedtaksbrev = brevRepository.findByIdOrThrow(behandlingId)
         return if (vedtaksbrev.beslutterPdf != null) {
             vedtaksbrev.beslutterPdf.bytes


### PR DESCRIPTION
Hent brev:

Hvis beslutterbrev er generert vis fram dette. Hvis beslutterbrev ikke er lagret - bruk opprinnelig saksbehandler request, lag brev, vis fram.

Dette for at saksbehandler 1, eller andre saksbehandlere uten beslutter-rolle skal kunne se hele behandlingen, inkludert brevet som er laget, også før beslutter har laget det endelige brevet. 