### PR TITLE
bruker forrigebehandlingId i simuleringDto

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringDto.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 
 data class SimuleringDto(
         val nyTilkjentYtelseMedMetaData: TilkjentYtelseForIverksettMedMetadata,
-        val forrigeTilkjentYtelse: TilkjentYtelseForIverksett?
+        val forrigeBehandlingId: UUID?
 )
 
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.api.beregning.VedtakDto
 import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.api.beregning.tilInntektsperioder
 import no.nav.familie.ef.sak.api.beregning.tilPerioder
+import no.nav.familie.ef.sak.repository.BehandlingRepository
 import no.nav.familie.ef.sak.repository.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.repository.domain.Behandling
 import no.nav.familie.ef.sak.repository.domain.BehandlingType
@@ -54,12 +55,11 @@ class SimuleringService(private val iverksettClient: IverksettClient,
                                                        eksternFagsakId = fagsak.eksternId.id
 
                 )
-        val forrigeTilkjentYtelse = tilkjentYtelseService.finnSisteTilkjentYtelse(fagsakId = behandling.fagsakId)?.tilIverksett()
+        val forrigeBehandlingId = behandlingService.hentForrigeBehandlingId(behandling.fagsakId)
 
         return iverksettClient.simuler(SimuleringDto(
                 nyTilkjentYtelseMedMetaData = tilkjentYtelseMedMedtadata,
-                forrigeTilkjentYtelse = forrigeTilkjentYtelse
-
+                forrigeBehandlingId = forrigeBehandlingId
         ))
     }
 
@@ -68,7 +68,7 @@ class SimuleringService(private val iverksettClient: IverksettClient,
         val tilkjentYtelseForBlankett = genererTilkjentYtelseForBlankett(vedtak, behandling, fagsak)
         val simuleringDto = SimuleringDto(
                 nyTilkjentYtelseMedMetaData = tilkjentYtelseForBlankett,
-                forrigeTilkjentYtelse = null
+                forrigeBehandlingId = null
 
         )
         return iverksettClient.simuler(simuleringDto)

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringService.kt
@@ -42,10 +42,6 @@ class SimuleringService(private val iverksettClient: IverksettClient,
     }
 
     private fun simulerMedTilkjentYtelse(behandling: Behandling, fagsak: Fagsak): DetaljertSimuleringResultat {
-        if (behandling.type == BehandlingType.BLANKETT) {
-            return simulerUtenTilkjentYtelse(behandling, fagsak)
-        }
-
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandling.id)
 
         val tilkjentYtelseMedMedtadata =

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -42,6 +42,8 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
     fun finnSisteIverksatteBehandlinger(stønadstype: Stønadstype) =
             behandlingRepository.finnSisteIverksatteBehandlingerSomIkkeErTekniskOpphør(stønadstype)
 
+    fun hentForrigeBehandlingId(fagsakId: UUID) = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
+
     @Transactional
     fun opprettBehandling(behandlingType: BehandlingType,
                           fagsakId: UUID,

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
@@ -63,8 +63,8 @@ internal class SimuleringServiceTest {
             tilkjentYtelseService.hentForBehandling(any())
         } returns tilkjentYtelse
         every {
-            tilkjentYtelseService.finnSisteTilkjentYtelse(any())
-        } returns null
+            behandlingService.hentForrigeBehandlingId(any())
+        } returns behandling.id
 
         val simulerSlot = slot<SimuleringDto>()
         every {
@@ -79,7 +79,7 @@ internal class SimuleringServiceTest {
                 tilkjentYtelse.andelerTilkjentYtelse.first().stønadFom)
         assertThat(simulerSlot.captured.nyTilkjentYtelseMedMetaData.tilkjentYtelse.andelerTilkjentYtelse.first().tilOgMed).isEqualTo(
                 tilkjentYtelse.andelerTilkjentYtelse.first().stønadTom)
-
+        assertThat(simulerSlot.captured.forrigeBehandlingId).isEqualTo(behandling.id)
     }
 
     @Test


### PR DESCRIPTION
Endrer kode til å sende simuleringDto med forrigeBehandlingId. 
Har oppdatert behandlingService med hentForrigeBehandlingId slik at vi kunne kalle service i stedet for repository