### PR TITLE
Sett behandlingsresultat til Innvilget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -2,9 +2,6 @@ package no.nav.familie.ef.sak.service
 
 import no.nav.familie.ef.sak.api.Feil
 import no.nav.familie.ef.sak.api.beregning.ResultatType
-import no.nav.familie.ef.sak.api.beregning.VedtakService
-import no.nav.familie.ef.sak.api.dto.BehandlingDto
-import no.nav.familie.ef.sak.api.dto.tilDto
 import no.nav.familie.ef.sak.repository.BehandlingRepository
 import no.nav.familie.ef.sak.repository.BehandlingsjournalpostRepository
 import no.nav.familie.ef.sak.repository.domain.Behandling
@@ -31,8 +28,7 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad as SøknadOv
 class BehandlingService(private val behandlingsjournalpostRepository: BehandlingsjournalpostRepository,
                         private val behandlingRepository: BehandlingRepository,
                         private val behandlingshistorikkService: BehandlingshistorikkService,
-                        private val søknadService: SøknadService,
-                        private val vedtakService: VedtakService) {
+                        private val søknadService: SøknadService) {
 
     val logger: Logger = LoggerFactory.getLogger(this.javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -133,15 +129,10 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
         }
     }
 
-    fun oppdaterResultatPåBehandling(behandlingId: UUID) {
+    fun oppdaterResultatPåBehandling(behandlingId: UUID, behandlingResultat: BehandlingResultat) {
         val behandling = hentBehandling(behandlingId)
-        val vedtak = vedtakService.hentVedtak(behandlingId)
-        when (vedtak.resultatType) {
-            ResultatType.INNVILGE -> {
-                behandling.resultat = BehandlingResultat.INNVILGET
-                behandlingRepository.update(behandling)
-            }
-        }
+        behandling.resultat = behandlingResultat
+        behandlingRepository.update(behandling)
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ef.sak.service
 
 import no.nav.familie.ef.sak.api.Feil
+import no.nav.familie.ef.sak.api.beregning.ResultatType
+import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.api.dto.BehandlingDto
 import no.nav.familie.ef.sak.api.dto.tilDto
 import no.nav.familie.ef.sak.repository.BehandlingRepository
@@ -29,7 +31,8 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad as SøknadOv
 class BehandlingService(private val behandlingsjournalpostRepository: BehandlingsjournalpostRepository,
                         private val behandlingRepository: BehandlingRepository,
                         private val behandlingshistorikkService: BehandlingshistorikkService,
-                        private val søknadService: SøknadService) {
+                        private val søknadService: SøknadService,
+                        private val vedtakService: VedtakService) {
 
     val logger: Logger = LoggerFactory.getLogger(this.javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -127,6 +130,17 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
                     httpStatus = HttpStatus.BAD_REQUEST,
                     throwable = null
             )
+        }
+    }
+
+    fun oppdaterResultatPåBehandling(behandlingId: UUID) {
+        val behandling = hentBehandling(behandlingId)
+        val vedtak = vedtakService.hentVedtak(behandlingId)
+        when (vedtak.resultatType) {
+            ResultatType.INNVILGE -> {
+                behandling.resultat = BehandlingResultat.INNVILGET
+                behandlingRepository.update(behandling)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.ef.sak.service.steg
 
+import no.nav.familie.ef.sak.api.beregning.ResultatType
+import no.nav.familie.ef.sak.api.beregning.VedtakService
 import no.nav.familie.ef.sak.repository.domain.Behandling
+import no.nav.familie.ef.sak.repository.domain.BehandlingResultat
 import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
 import no.nav.familie.ef.sak.repository.domain.BehandlingType
 import no.nav.familie.ef.sak.service.BehandlingService
@@ -10,11 +13,13 @@ import no.nav.familie.prosessering.domene.TaskRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 
 @Service
 class FerdigstillBehandlingSteg(private val behandlingService: BehandlingService,
-                                private val taskRepository: TaskRepository) : BehandlingSteg<Void?> {
+                                private val taskRepository: TaskRepository,
+                                private val vedtakService: VedtakService) : BehandlingSteg<Void?> {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -23,7 +28,7 @@ class FerdigstillBehandlingSteg(private val behandlingService: BehandlingService
         behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FERDIGSTILT)
 
         if (behandling.type == BehandlingType.FØRSTEGANGSBEHANDLING || behandling.type == BehandlingType.REVURDERING) {
-            behandlingService.oppdaterResultatPåBehandling(behandling.id)
+            oppdaterResultatPåBehandling(behandling.id)
             taskRepository.save(PubliserVedtakshendelseTask.opprettTask(behandling.id))
             taskRepository.save(BehandlingsstatistikkTask.opprettFerdigTask(behandlingId = behandling.id))
         } else if (behandling.type == BehandlingType.BLANKETT || behandling.type == BehandlingType.TEKNISK_OPPHØR) {
@@ -36,5 +41,12 @@ class FerdigstillBehandlingSteg(private val behandlingService: BehandlingService
 
     override fun stegType(): StegType {
         return StegType.FERDIGSTILLE_BEHANDLING
+    }
+
+    fun oppdaterResultatPåBehandling(behandlingId: UUID) {
+        val vedtak = vedtakService.hentVedtak(behandlingId)
+        when (vedtak.resultatType) {
+            ResultatType.INNVILGE -> behandlingService.oppdaterResultatPåBehandling(behandlingId, BehandlingResultat.INNVILGET)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingSteg.kt
@@ -23,6 +23,7 @@ class FerdigstillBehandlingSteg(private val behandlingService: BehandlingService
         behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.FERDIGSTILT)
 
         if (behandling.type == BehandlingType.FØRSTEGANGSBEHANDLING || behandling.type == BehandlingType.REVURDERING) {
+            behandlingService.oppdaterResultatPåBehandling(behandling.id)
             taskRepository.save(PubliserVedtakshendelseTask.opprettTask(behandling.id))
             taskRepository.save(BehandlingsstatistikkTask.opprettFerdigTask(behandlingId = behandling.id))
         } else if (behandling.type == BehandlingType.BLANKETT || behandling.type == BehandlingType.TEKNISK_OPPHØR) {

--- a/src/main/resources/db/migration/V53__sett_behandlingsresultat_innvilget.sql
+++ b/src/main/resources/db/migration/V53__sett_behandlingsresultat_innvilget.sql
@@ -1,0 +1,7 @@
+with vedtakquery as (SELECT behandling_id FROM vedtak WHERE resultat_type = 'INNVILGE')
+UPDATE behandling
+SET resultat = 'INNVILGET'
+FROM vedtakquery
+WHERE behandling.id = vedtakquery.behandling_id AND behandling.status = 'FERDIGSTILT';
+
+

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
@@ -24,7 +24,7 @@ internal class BehandlingServiceTest {
 
     val behandlingRepository = mockk<BehandlingRepository>()
     val behandlingshistorikkService = mockk<BehandlingshistorikkService>()
-    val behandlingService = BehandlingService(mockk(), behandlingRepository, behandlingshistorikkService, mockk(), mockk())
+    val behandlingService = BehandlingService(mockk(), behandlingRepository, behandlingshistorikkService, mockk())
 
     @Test
     internal fun `skal annullere behandling som er blankett og status utredes`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
@@ -24,7 +24,7 @@ internal class BehandlingServiceTest {
 
     val behandlingRepository = mockk<BehandlingRepository>()
     val behandlingshistorikkService = mockk<BehandlingshistorikkService>()
-    val behandlingService = BehandlingService(mockk(), behandlingRepository, behandlingshistorikkService, mockk())
+    val behandlingService = BehandlingService(mockk(), behandlingRepository, behandlingshistorikkService, mockk(), mockk())
 
     @Test
     internal fun `skal annullere behandling som er blankett og status utredes`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/FerdigstillBehandlingStegTest.kt
@@ -21,14 +21,24 @@ internal class FerdigstillBehandlingStegTest {
 
     private val behandlingService = mockk<BehandlingService>(relaxed = true)
     private val taskRepository = mockk<TaskRepository>()
+    private val vedtakService = mockk<VedtakService>()
 
-    private val task = FerdigstillBehandlingSteg(behandlingService, taskRepository)
+    private val task = FerdigstillBehandlingSteg(behandlingService, taskRepository, vedtakService)
 
     private val fagsak = fagsak()
 
     @BeforeEach
     internal fun setUp() {
         every { taskRepository.save(any()) } answers { firstArg() }
+        every { vedtakService.hentVedtak(any()) } returns Vedtak(behandlingId = UUID.randomUUID(),
+                                                                 resultatType = ResultatType.INNVILGE,
+                                                                 periodeBegrunnelse = null,
+                                                                 inntektBegrunnelse = null,
+                                                                 avslåBegrunnelse = null,
+                                                                 perioder = null,
+                                                                 inntekter = null,
+                                                                 saksbehandlerIdent = null,
+                                                                 beslutterIdent = null)
     }
 
     @Test


### PR DESCRIPTION
Løser den lättare delen av denne [Vise korrekt behandlingsresultat](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-5360) som går ut på att oppdatere behandlingsresultat til `Innvilget` for alle behandlinger som har status `Ferdigstillt`og vedtaksresultat  `Innvilge`