### PR TITLE
Legger til att dependabot ikke skal bygge med sonar sånn att byggene …

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -22,7 +22,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
+      - name: Bygg (dependabot)
+        if: github.actor == 'dependabot[bot]'
+        env:
+          GITHUB_USERNAME: x-access-token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
       - name: Bygg og SonarCloud
+        if: github.actor != 'dependabot[bot]'
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
…kan kjøre uten problemer

Ett av problemene med dependabot native er att den ikke har tilgang til noen secrets. Den har tilgang til en GITHUB_TOKEN med read rights.
Jeg trodde att den skulle ha tilgang til https://github.com/navikt/familie-ef-sak/settings/secrets/dependabot også, men disse er kun tilgjengelige fra selve dependabot-jobbet som analyserer dependencies, ikke action triggered by dependabot

Av den grunnen tenker jeg det er helt greit att github actions triggered by dependabot kan kjøre uten sonar. Hvis vi skulle trigge en action i en dependabot-PR så kommer sonar å kjøre.

Mer lektyr for den som er ekstra interessert
https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions