### PR TITLE
Behandling forrige behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/IverksettingDtoMapper.kt
@@ -62,15 +62,13 @@ class IverksettingDtoMapper(private val arbeidsfordelingService: Arbeidsfordelin
 
         val fagsak = fagsakService.hentFaksakForBehandling(behandling.id)
         val vedtak = vedtakService.hentVedtak(behandling.id)
-        val forrigeBehandlingId = behandlingRepository.finnSisteIverksatteBehandling(behandling.fagsakId)
         val saksbehandler =
                 behandlinghistorikkService.finnSisteBehandlingshistorikk(behandling.id, StegType.SEND_TIL_BESLUTTER)?.opprettetAv
                 ?: error("Kan ikke finne saksbehandler på behandlingen")
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandling.id)
         val vilkårsvurderinger = vilkårsvurderingRepository.findByBehandlingId(behandling.id)
 
-
-        val behandlingsdetaljer = mapBehandlingsdetaljer(behandling, vilkårsvurderinger, forrigeBehandlingId)
+        val behandlingsdetaljer = mapBehandlingsdetaljer(behandling, vilkårsvurderinger, behandling.forrigeBehandlingId)
         val fagsakdetaljerDto = mapFagsakdetaljer(fagsak)
         val søkerDto = mapSøkerDto(fagsak, behandling)
         val vedtakDto = mapVedtaksdetaljerDto(vedtak, saksbehandler, beslutter, tilkjentYtelse)

--- a/src/main/kotlin/no/nav/familie/ef/sak/mapper/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/mapper/IverksettingDtoMapper.kt
@@ -68,7 +68,7 @@ class IverksettingDtoMapper(private val arbeidsfordelingService: Arbeidsfordelin
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandling.id)
         val vilkårsvurderinger = vilkårsvurderingRepository.findByBehandlingId(behandling.id)
 
-        val behandlingsdetaljer = mapBehandlingsdetaljer(behandling, vilkårsvurderinger, behandling.forrigeBehandlingId)
+        val behandlingsdetaljer = mapBehandlingsdetaljer(behandling, vilkårsvurderinger)
         val fagsakdetaljerDto = mapFagsakdetaljer(fagsak)
         val søkerDto = mapSøkerDto(fagsak, behandling)
         val vedtakDto = mapVedtaksdetaljerDto(vedtak, saksbehandler, beslutter, tilkjentYtelse)
@@ -86,14 +86,13 @@ class IverksettingDtoMapper(private val arbeidsfordelingService: Arbeidsfordelin
 
     @Improvement("Årsak og Type må utledes når vi støtter revurdering")
     private fun mapBehandlingsdetaljer(behandling: Behandling,
-                                       vilkårsvurderinger: List<Vilkårsvurdering>,
-                                       forrigeBehandlingId: UUID?) =
+                                       vilkårsvurderinger: List<Vilkårsvurdering>) =
             BehandlingsdetaljerDto(behandlingId = behandling.id,
                                    behandlingType = BehandlingType.valueOf(behandling.type.name),
                                    behandlingÅrsak = BehandlingÅrsak.SØKNAD,
                                    eksternId = behandling.eksternId.id,
                                    vilkårsvurderinger = vilkårsvurderinger.map { it.tilIverksettDto() },
-                                   forrigeBehandlingId = forrigeBehandlingId
+                                   forrigeBehandlingId = behandling.forrigeBehandlingId
             )
 
     @Improvement("Opphørårsak må utledes ved revurdering")

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepository.kt
@@ -67,19 +67,6 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
 
     // language=PostgreSQL
     @Query("""
-        SELECT b.id
-        FROM behandling b
-        WHERE b.fagsak_id = :fagsakId
-         AND b.type != 'BLANKETT'
-         AND b.resultat != 'ANNULLERT'
-         AND b.status = 'FERDIGSTILT'
-        ORDER BY b.opprettet_tid DESC
-        LIMIT 1
-    """)
-    fun finnSisteIverksatteBehandling(fagsakId: UUID): UUID?
-
-    // language=PostgreSQL
-    @Query("""
         SELECT b.id behandling_id, be.id ekstern_behandling_id, fe.id ekstern_fagsak_id
         FROM behandling b
             JOIN behandling_ekstern be ON b.id = be.behandling_id

--- a/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/repository/domain/Behandling.kt
@@ -6,9 +6,13 @@ import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.MappedCollection
 import java.util.UUID
 
+/**
+ * @param forrigeBehandlingId forrige iverksatte behandling
+ */
 data class Behandling(@Id
                       val id: UUID = UUID.randomUUID(),
                       val fagsakId: UUID,
+                      val forrigeBehandlingId: UUID? = null,
                       @MappedCollection(idColumn = "behandling_id")
                       val eksternId: EksternBehandlingId = EksternBehandlingId(),
                       val versjon: Int = 0,

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/BehandlingService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.sak.repository.domain.Stønadstype
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.service.steg.StegType
 import no.nav.familie.ef.sak.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.util.OpprettBehandlingUtil.sistIverksatteBehandling
 import no.nav.familie.ef.sak.util.OpprettBehandlingUtil.validerKanOppretteNyBehandling
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
@@ -41,8 +42,6 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
     fun finnSisteIverksatteBehandlinger(stønadstype: Stønadstype) =
             behandlingRepository.finnSisteIverksatteBehandlingerSomIkkeErTekniskOpphør(stønadstype)
 
-    fun finnSisteIverksatteBehandling(fagsakId: UUID) = behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
-
     @Transactional
     fun opprettBehandling(behandlingType: BehandlingType,
                           fagsakId: UUID,
@@ -66,8 +65,10 @@ class BehandlingService(private val behandlingsjournalpostRepository: Behandling
                           stegType: StegType = StegType.VILKÅR): Behandling {
         val tidligereBehandlinger = behandlingRepository.findByFagsakId(fagsakId)
         validerKanOppretteNyBehandling(behandlingType, tidligereBehandlinger)
+        val forrigeBehandlingId = sistIverksatteBehandling(tidligereBehandlinger)?.id
 
         return behandlingRepository.insert(Behandling(fagsakId = fagsakId,
+                                                      forrigeBehandlingId = forrigeBehandlingId,
                                                       type = behandlingType,
                                                       steg = stegType,
                                                       status = status,

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/RevurderingService.kt
@@ -20,17 +20,17 @@ class RevurderingService(private val søknadService: SøknadService,
                          private val taskRepository: TaskRepository) {
 
     fun opprettRevurderingManuelt(fagsakId: UUID): Behandling {
-        val sisteIverksatteBehandlingUUID = behandlingService.finnSisteIverksatteBehandling(fagsakId)
-                                            ?: error("Revurdering må ha eksisterende iverksatt behandling")
         val revurdering = behandlingService.opprettBehandling(BehandlingType.REVURDERING,
                                                               fagsakId,
                                                               BehandlingStatus.UTREDES,
                                                               StegType.BEREGNE_YTELSE)
+        val forrigeBehandlingId = revurdering.forrigeBehandlingId
+                                  ?: error("Revurdering må ha eksisterende iverksatt behandling")
         val saksbehandler = SikkerhetContext.hentSaksbehandler(true)
 
-        søknadService.kopierSøknad(sisteIverksatteBehandlingUUID, revurdering.id)
+        søknadService.kopierSøknad(forrigeBehandlingId, revurdering.id)
         grunnlagsdataService.opprettGrunnlagsdata(revurdering.id)
-        vurderingService.kopierVurderingerTilNyBehandling(sisteIverksatteBehandlingUUID, revurdering.id)
+        vurderingService.kopierVurderingerTilNyBehandling(forrigeBehandlingId, revurdering.id)
         val oppgaveId = oppgaveService.opprettOppgave(behandlingId = revurdering.id,
                                                       oppgavetype = Oppgavetype.BehandleSak,
                                                       tilordnetNavIdent = saksbehandler,

--- a/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseSteg.kt
@@ -82,7 +82,7 @@ class BeregnYtelseSteg(private val tilkjentYtelseService: TilkjentYtelseService,
 
     private fun andelerForRevurdering(behandling: Behandling,
                                       beløpsperioder: List<AndelTilkjentYtelse>): List<AndelTilkjentYtelse> {
-        val forrigeBehandlingId = behandlingService.finnSisteIverksatteBehandling(behandling.fagsakId)
+        val forrigeBehandlingId = behandling.forrigeBehandlingId
                                   ?: error("Finner ikke forrige behandling til behandling=${behandling.id}")
         val forrigeAndeler = tilkjentYtelseService.hentForBehandling(forrigeBehandlingId)
         return slåSammenAndelerSomSkalVidereføres(beløpsperioder, forrigeAndeler)

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -66,11 +66,10 @@ class SimuleringService(private val iverksettClient: IverksettClient,
                                                        eksternBehandlingId = behandling.eksternId.id,
                                                        stønadstype = fagsak.stønadstype,
                                                        eksternFagsakId = fagsak.eksternId.id)
-        val forrigeBehandlingId = behandlingService.finnSisteIverksatteBehandling(behandling.fagsakId)
 
         return iverksettClient.simuler(SimuleringDto(
                 nyTilkjentYtelseMedMetaData = tilkjentYtelseMedMedtadata,
-                forrigeBehandlingId = forrigeBehandlingId
+                forrigeBehandlingId = behandling.forrigeBehandlingId
         ))
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/task/BehandlingsstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/task/BehandlingsstatistikkTask.kt
@@ -48,9 +48,8 @@ class BehandlingsstatistikkTask(private val iverksettClient: IverksettClient,
     private val zoneIdOslo = ZoneId.of("Europe/Oslo")
 
     override fun doTask(task: Task) {
-        val (behandlingId, hendelse, hendelseTidspunkt, gjeldendeSaksbehandler, oppgaveId) = objectMapper.readValue<BehandlingsstatistikkTaskPayload>(
-                task.payload
-        )
+        val (behandlingId, hendelse, hendelseTidspunkt, gjeldendeSaksbehandler, oppgaveId) =
+                objectMapper.readValue<BehandlingsstatistikkTaskPayload>(task.payload)
 
         val behandling = behandlingService.hentBehandling(behandlingId)
         val fagsak = fagsakService.hentFagsak(behandling.fagsakId)
@@ -79,20 +78,10 @@ class BehandlingsstatistikkTask(private val iverksettClient: IverksettClient,
                 stønadstype = StønadType.valueOf(fagsak.stønadstype.name),
                 behandlingstype = BehandlingType.valueOf(behandling.type.name),
                 henvendelseTidspunkt = henvendelseTidspunkt.atZone(zoneIdOslo),
-                relatertBehandlingId = finnRelatertBehandlingId(behandling, hendelse)
+                relatertBehandlingId = behandling.forrigeBehandlingId
         )
 
         iverksettClient.sendBehandlingsstatistikk(behandlingsstatistikkDto)
-    }
-
-    private fun finnRelatertBehandlingId(behandling: Behandling, hendelse: Hendelse): UUID? {
-        if (hendelse == Hendelse.FERDIG) {
-            return null
-        }
-        return when (behandling.type) {
-            REVURDERING -> behandlingService.finnSisteIverksatteBehandling(fagsakId = behandling.fagsakId)
-            else -> null
-        }
     }
 
     private fun finnSisteOppgaveForBehandlingen(behandlingId: UUID, oppgaveId: Long?): Oppgave {

--- a/src/main/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtil.kt
@@ -31,6 +31,14 @@ object OpprettBehandlingUtil {
         }
     }
 
+    fun sistIverksatteBehandling(behandlinger: List<Behandling>): Behandling? {
+        return behandlinger
+                .filter { it.type != BehandlingType.BLANKETT }
+                .filter { it.resultat != BehandlingResultat.ANNULLERT }
+                .filter { it.status == BehandlingStatus.FERDIGSTILT }
+                .maxByOrNull { it.sporbar.opprettetTid }
+    }
+
     private fun validerTidligereBehandlingerErFerdigstilte(tidligereBehandlinger: List<Behandling>) {
         if (tidligereBehandlinger.any { it.status != BehandlingStatus.FERDIGSTILT }) {
             throw ApiFeil("Det finnes en behandling på fagsaken som ikke er ferdigstilt", HttpStatus.BAD_REQUEST)

--- a/src/main/resources/db/migration/V59__behandling_forrige_behandling_id.sql
+++ b/src/main/resources/db/migration/V59__behandling_forrige_behandling_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behandling ADD COLUMN forrige_behandling_id UUID REFERENCES behandling(id);

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
@@ -67,15 +67,16 @@ internal class SimuleringServiceTest {
 
     @Test
     internal fun `skal bruke lagret tilkjentYtelse for simulering`() {
-
-        val behandling = behandling(fagsak = fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING)
+        val forrigeBehandlingId = behandling(fagsak).id
+        val behandling = behandling(fagsak = fagsak,
+                                    type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                                    forrigeBehandlingId = forrigeBehandlingId)
 
         val tilkjentYtelse = tilkjentYtelse(behandlingId = behandling.id, personIdent = personIdent)
         val simuleringsresultat = Simuleringsresultat(behandlingId = behandling.id,
                                                       data = DetaljertSimuleringResultat(emptyList()))
         every { behandlingService.hentBehandling(any()) } returns behandling
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns behandling.id
         every { simuleringsresultatRepository.deleteById(any()) } just Runs
         every { simuleringsresultatRepository.insert(any()) } returns simuleringsresultat
 
@@ -92,7 +93,7 @@ internal class SimuleringServiceTest {
                 tilkjentYtelse.andelerTilkjentYtelse.first().stønadFom)
         assertThat(simulerSlot.captured.nyTilkjentYtelseMedMetaData.tilkjentYtelse.andelerTilkjentYtelse.first().tilOgMed).isEqualTo(
                 tilkjentYtelse.andelerTilkjentYtelse.first().stønadTom)
-        assertThat(simulerSlot.captured.forrigeBehandlingId).isEqualTo(behandling.id)
+        assertThat(simulerSlot.captured.forrigeBehandlingId).isEqualTo(forrigeBehandlingId)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -48,8 +48,10 @@ fun behandling(fagsak: Fagsak,
                id: UUID = UUID.randomUUID(),
                type: BehandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
                resultat: BehandlingResultat = BehandlingResultat.IKKE_SATT,
-               opprettetTid: LocalDateTime = SporbarUtils.now()): Behandling =
+               opprettetTid: LocalDateTime = SporbarUtils.now(),
+               forrigeBehandlingId: UUID? = null): Behandling =
         Behandling(fagsakId = fagsak.id,
+                   forrigeBehandlingId = forrigeBehandlingId,
                    id = id,
                    type = type,
                    status = status,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -87,13 +87,13 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         behandlingRepository.insert(behandling(fagsak = fagsak, status = BehandlingStatus.UTREDES))
 
         assertThat(catchThrowable { revurderingService.opprettRevurderingManuelt(fagsak.id) })
-                .hasMessageContaining("Revurdering må ha eksisterende iverksatt behandling")
+                .hasMessageContaining("Det finnes en behandling på fagsaken som ikke er ferdigstilt")
     }
 
     @Test
     internal fun `skal ikke være mulig å opprette fagsak hvis det ikke finnes en behandling fra før`() {
         assertThat(catchThrowable { revurderingService.opprettRevurderingManuelt(fagsak.id) })
-                .hasMessageContaining("Revurdering må ha eksisterende iverksatt behandling")
+                .hasMessageContaining("Det finnes ikke en tidligere behandling på fagsaken")
     }
 
     private fun lagreSøknad(behandling: Behandling,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseStegTest.kt
@@ -43,7 +43,6 @@ internal class BeregnYtelseStegTest {
     @BeforeEach
     internal fun setUp() {
         every { behandlingService.hentAktivIdent(any()) } returns "123"
-        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns UUID.randomUUID()
         every { simuleringService.hentOgLagreSimuleringsresultat(any()) } returns Simuleringsresultat(behandlingId = UUID.randomUUID(),
                                                                                                       data = DetaljertSimuleringResultat(
                                                                                                               emptyList()))
@@ -89,7 +88,6 @@ internal class BeregnYtelseStegTest {
         every { beregningService.beregnYtelse(any(), any()) } returns listOf(lagBeløpsperiode(LocalDate.now(), LocalDate.now()))
         utførSteg(BehandlingType.FØRSTEGANGSBEHANDLING)
 
-        verify(exactly = 0) { behandlingService.finnSisteIverksatteBehandling(any()) }
         verify(exactly = 0) { tilkjentYtelseService.hentForBehandling(any()) }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/steg/BeregnYtelseStegTest.kt
@@ -61,7 +61,7 @@ internal class BeregnYtelseStegTest {
                 lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(100, forrigeAndelFom, forrigeAndelTom)))
         every { beregningService.beregnYtelse(any(), any()) } returns listOf(lagBeløpsperiode(nyAndelFom, nyAndelTom))
 
-        utførSteg(BehandlingType.REVURDERING)
+        utførSteg(BehandlingType.REVURDERING, forrigeBehandlingId = UUID.randomUUID())
 
         val andeler = slot.captured.andelerTilkjentYtelse
         assertThat(andeler).hasSize(2)
@@ -179,8 +179,8 @@ internal class BeregnYtelseStegTest {
         assertThat(nyeAndeler[1].beløp).isEqualTo(100)
     }
 
-    private fun utførSteg(type: BehandlingType, vedtak: VedtakDto = Innvilget(periodeBegrunnelse = "", inntektBegrunnelse = "")) {
-        steg.utførSteg(behandling(fagsak(), type = type), vedtak = vedtak)
+    private fun utførSteg(type: BehandlingType, vedtak: VedtakDto = Innvilget(periodeBegrunnelse = "", inntektBegrunnelse = ""), forrigeBehandlingId: UUID? = null) {
+        steg.utførSteg(behandling(fagsak(), type = type, forrigeBehandlingId = forrigeBehandlingId), vedtak = vedtak)
     }
 
     private fun lagBeløpsperiode(fom: LocalDate, tom: LocalDate) =

--- a/src/test/kotlin/no/nav/familie/ef/sak/util/BehandlingOppsettUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/util/BehandlingOppsettUtil.kt
@@ -1,0 +1,64 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.util
+
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.domain.BehandlingResultat
+import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
+import no.nav.familie.ef.sak.repository.domain.BehandlingType
+import no.nav.familie.ef.sak.repository.domain.FagsakPerson
+import no.nav.familie.ef.sak.repository.domain.Sporbar
+import java.time.LocalDateTime
+
+object BehandlingOppsettUtil {
+
+    private val fagsak = fagsak(setOf(FagsakPerson("1")))
+
+    val annullertFørstegangsbehandling = behandling(fagsak)
+            .copy(type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                  status = BehandlingStatus.FERDIGSTILT,
+                  resultat = BehandlingResultat.ANNULLERT,
+                  sporbar = Sporbar(opprettetTid = LocalDateTime.now()
+                          .minusDays(4)))
+
+    val førstegangsbehandlingUnderBehandling = behandling(fagsak)
+            .copy(type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                  status = BehandlingStatus.UTREDES,
+                  resultat = BehandlingResultat.IKKE_SATT,
+                  sporbar = Sporbar(opprettetTid = LocalDateTime.now()
+                          .minusDays(4)))
+
+    val førstegangsbehandling = behandling(fagsak)
+            .copy(type = BehandlingType.FØRSTEGANGSBEHANDLING,
+                  status = BehandlingStatus.FERDIGSTILT,
+                  resultat = BehandlingResultat.INNVILGET,
+                  sporbar = Sporbar(opprettetTid = LocalDateTime.now().minusDays(3)))
+
+    val blankett = behandling(fagsak)
+            .copy(type = BehandlingType.BLANKETT,
+                  status = BehandlingStatus.FERDIGSTILT,
+                  resultat = BehandlingResultat.INNVILGET,
+                  sporbar = Sporbar(opprettetTid = LocalDateTime.now().minusDays(2)))
+
+    val annullertRevurdering = behandling(fagsak)
+            .copy(type = BehandlingType.REVURDERING,
+                  status = BehandlingStatus.FERDIGSTILT,
+                  resultat = BehandlingResultat.ANNULLERT,
+                  sporbar = Sporbar(opprettetTid = LocalDateTime.now().minusDays(1)))
+
+    val revurderingUnderArbeid = behandling(fagsak)
+            .copy(type = BehandlingType.REVURDERING,
+                  status = BehandlingStatus.IVERKSETTER_VEDTAK,
+                  resultat = BehandlingResultat.INNVILGET)
+
+    val iverksattRevurdering = behandling(fagsak)
+            .copy(type = BehandlingType.REVURDERING,
+                  status = BehandlingStatus.FERDIGSTILT,
+                  resultat = BehandlingResultat.INNVILGET)
+
+    fun lagBehandlingerForSisteIverksatte() = listOf(annullertFørstegangsbehandling,
+                                                     førstegangsbehandling,
+                                                     blankett,
+                                                     annullertRevurdering,
+                                                     revurderingUnderArbeid)
+
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtilTest.kt
@@ -107,7 +107,8 @@ internal class OpprettBehandlingUtilTest {
         val behandlingB = iverksatt(LocalDateTime.now())
         val behandlingC = iverksatt(LocalDateTime.now().plusDays(5))
 
-        assertThat(sistIverksatteBehandling(listOf(behandlingA, behandlingB, behandlingC))?.id).isEqualTo(behandlingB.id)
+        val behandlingerMedSistBehandlerIMidten = listOf(behandlingA, behandlingC, behandlingB)
+        assertThat(sistIverksatteBehandling(behandlingerMedSistBehandlerIMidten)?.id).isEqualTo(behandlingC.id)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/util/OpprettBehandlingUtilTest.kt
@@ -2,12 +2,19 @@ package no.nav.familie.ef.sak.util
 
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.util.BehandlingOppsettUtil
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.util.BehandlingOppsettUtil.iverksattRevurdering
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.util.BehandlingOppsettUtil.lagBehandlingerForSisteIverksatte
 import no.nav.familie.ef.sak.repository.domain.BehandlingStatus
 import no.nav.familie.ef.sak.repository.domain.BehandlingType
+import no.nav.familie.ef.sak.repository.domain.Sporbar
+import no.nav.familie.ef.sak.util.OpprettBehandlingUtil.sistIverksatteBehandling
 import no.nav.familie.ef.sak.util.OpprettBehandlingUtil.validerKanOppretteNyBehandling
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
 
 internal class OpprettBehandlingUtilTest {
 
@@ -75,4 +82,40 @@ internal class OpprettBehandlingUtilTest {
         }).hasMessage("Det er ikke mulig å lage en revurdering når siste behandlingen er teknisk opphør")
     }
 
+    @Test
+    internal fun `finnSisteIverksatteBehandling skal finne id til siste behandling som er ferdigstilt, ikke annulert eller blankett`() {
+        val behandlinger = lagBehandlingerForSisteIverksatte()
+        val førstegangsbehandling = BehandlingOppsettUtil.førstegangsbehandling
+        val sistIverksatteBehandlingId = sistIverksatteBehandling(behandlinger)?.id
+
+        assertThat(sistIverksatteBehandlingId).isNotNull
+        assertThat(sistIverksatteBehandlingId).isEqualTo(førstegangsbehandling.id)
+    }
+
+    @Test
+    internal fun `skal returnere tidligere behandling hvis den er iverksatt`() {
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.førstegangsbehandling))).isNotNull
+        assertThat(sistIverksatteBehandling(listOf(iverksattRevurdering))).isNotNull
+    }
+
+    @Test
+    internal fun `skal returnere sist iverksatte behandlingen`() {
+        fun iverksatt(tid: LocalDateTime) = iverksattRevurdering.copy(id = UUID.randomUUID(),
+                                                                      sporbar = Sporbar(opprettetTid = tid))
+
+        val behandlingA = iverksatt(LocalDateTime.now().minusDays(5))
+        val behandlingB = iverksatt(LocalDateTime.now())
+        val behandlingC = iverksatt(LocalDateTime.now().plusDays(5))
+
+        assertThat(sistIverksatteBehandling(listOf(behandlingA, behandlingB, behandlingC))?.id).isEqualTo(behandlingB.id)
+    }
+
+    @Test
+    internal fun `skal ikke returnere tidligere behandling for førstegangsbehandling som ikke er iverksatt`() {
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.førstegangsbehandlingUnderBehandling))).isNull()
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.annullertFørstegangsbehandling))).isNull()
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.blankett))).isNull()
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.annullertRevurdering))).isNull()
+        assertThat(sistIverksatteBehandling(listOf(BehandlingOppsettUtil.revurderingUnderArbeid))).isNull()
+    }
 }


### PR DESCRIPTION
Setter forrigeBehandlingId på en behandling for å ikke hente den fra databasen hele tiden. Kan også være fint for feilsøking hvis det er behov for det.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6285

noen typos blir fikset i https://github.com/navikt/familie-ef-sak/pull/827/files

Denne trenger en update i databasen etter merge. SQL kommer