### PR TITLE
erIverksatt skal kun returnere true hvis resultatet er innvilget elle…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/OpprettBehandlingUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/OpprettBehandlingUtil.kt
@@ -40,9 +40,14 @@ object OpprettBehandlingUtil {
                 .maxByOrNull { it.sporbar.opprettetTid }
     }
 
+    /**
+     * Vi ønsker å peke den nye behandlingen til en behandling som er iverksatt og som påvirker andeler
+     *  [BehandlingResultat.INNVILGET] ELLER [BehandlingResultat.OPPHØRT]
+     *  [BehandlingResultat.AVSLÅTT] og [BehandlingResultat.ANNULLERT] er ikke intressante for det formålet
+     */
     private fun erIverksatt(behandling: Behandling) =
             behandling.type != BehandlingType.BLANKETT &&
-            behandling.resultat != BehandlingResultat.ANNULLERT &&
+            setOf(BehandlingResultat.INNVILGET, BehandlingResultat.OPPHØRT).contains(behandling.resultat) &&
             behandling.status == BehandlingStatus.FERDIGSTILT
 
     private fun validerTekniskOpphør(sisteBehandling: Behandling?, tidligereBehandlinger: List<Behandling>) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -4,19 +4,20 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.RevurderingService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.FagsakRepository
-import no.nav.familie.ef.sak.repository.behandling
-import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.repository.fagsakpersoner
-import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.repository.vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
@@ -56,7 +57,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal opprette revurdering`() {
-        val behandling = behandlingRepository.insert(behandling(fagsak = fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling = behandlingRepository.insert(behandling(fagsak = fagsak,
+                                                                status = BehandlingStatus.FERDIGSTILT,
+                                                                resultat = BehandlingResultat.INNVILGET))
         val søknad = lagreSøknad(behandling, fagsak)
         opprettVilkår(behandling, søknad)
 
@@ -68,7 +71,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `revurdering - skal kopiere vilkår`() {
-        val behandling = behandlingRepository.insert(behandling(fagsak = fagsak, status = BehandlingStatus.FERDIGSTILT))
+        val behandling = behandlingRepository.insert(behandling(fagsak = fagsak,
+                                                                status = BehandlingStatus.FERDIGSTILT,
+                                                                resultat = BehandlingResultat.INNVILGET))
         val søknad = lagreSøknad(behandling, fagsak)
         opprettVilkår(behandling, søknad)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/TekniskOpphørTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/TekniskOpphørTest.kt
@@ -2,17 +2,18 @@ package no.nav.familie.ef.sak.service
 
 import io.mockk.every
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.TekniskOpphørService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandlingsflyt.task.PollStatusTekniskOpphør
+import no.nav.familie.ef.sak.fagsak.FagsakRepository
+import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
+import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
+import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
-import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
-import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
-import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
-import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
-import no.nav.familie.ef.sak.behandling.TekniskOpphørService
-import no.nav.familie.ef.sak.behandlingsflyt.task.PollStatusTekniskOpphør
 import no.nav.familie.kontrakter.ef.iverksett.IverksettStatus
 import no.nav.familie.prosessering.domene.TaskRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -26,7 +27,7 @@ internal class TekniskOpphørTest : OppslagSpringRunnerTest() {
     @Autowired lateinit var tekniskOpphørService: TekniskOpphørService
     @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var behandlingRepository: BehandlingRepository
-    @Autowired lateinit var taskRepository : TaskRepository
+    @Autowired lateinit var taskRepository: TaskRepository
     @Autowired lateinit var pollStatusTekniskOpphør: PollStatusTekniskOpphør
     @Autowired lateinit var iverksettClient: IverksettClient
 
@@ -45,7 +46,9 @@ internal class TekniskOpphørTest : OppslagSpringRunnerTest() {
     internal fun `skal iverksette teknisk opphør og vente på status uten å kasta exceptions`() {
         val ident = "1234"
         val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(ident = ident))))
-        behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
+        behandlingRepository.insert(behandling(fagsak,
+                                               status = BehandlingStatus.FERDIGSTILT,
+                                               resultat = BehandlingResultat.INNVILGET))
 
         tekniskOpphørService.håndterTeknisktOpphør(fagsak.id)
 


### PR DESCRIPTION
…r opphørt. Det skal ikke returnere true for de som ikke har resultat satt, avslått eller annulert.

Dette fordi vi ønsker å koble forrigeBehandlingId til en behandling som påvirket andeler/perioder for utbetaling