### PR TITLE
Skal slette mellomlagret brev ved lagring av nytt vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.brev.MellomlagringBrevService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.taMedAndelerFremTilDato
@@ -25,7 +26,8 @@ class BeregnYtelseSteg(private val tilkjentYtelseService: TilkjentYtelseService,
                        private val behandlingService: BehandlingService,
                        private val beregningService: BeregningService,
                        private val simuleringService: SimuleringService,
-                       private val vedtakService: VedtakService) : BehandlingSteg<VedtakDto> {
+                       private val vedtakService: VedtakService,
+                       private val mellomlagringBrevService: MellomlagringBrevService) : BehandlingSteg<VedtakDto> {
 
 
     override fun validerSteg(behandling: Behandling) {
@@ -51,6 +53,7 @@ class BeregnYtelseSteg(private val tilkjentYtelseService: TilkjentYtelseService,
         vedtakService.slettVedtakHvisFinnes(behandling.id)
         vedtakService.lagreVedtak(vedtakDto = vedtak, behandlingId = behandling.id)
         simuleringService.hentOgLagreSimuleringsresultat(behandling)
+        mellomlagringBrevService.slettMellomlagringHvisFinnes(behandling.id)
     }
 
     private fun opprettTilkjentYtelseForOpphørtBehandling(behandling: Behandling,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -35,10 +35,6 @@ class MellomlagringBrevService(private val mellomlagerBrevRepository: Mellomlage
         return null
     }
 
-    fun slettMellomlagringHvisFinnes(behandlingId: UUID){
-        if(mellomlagerBrevRepository.existsById(behandlingId)){
-            mellomlagerBrevRepository.deleteById(behandlingId)
-        }
-    }
+    fun slettMellomlagringHvisFinnes(behandlingId: UUID) = mellomlagerBrevRepository.deleteById(behandlingId)
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -35,4 +35,10 @@ class MellomlagringBrevService(private val mellomlagerBrevRepository: Mellomlage
         return null
     }
 
+    fun slettMellomlagringHvisFinnes(behandlingId: UUID){
+        if(mellomlagerBrevRepository.existsById(behandlingId)){
+            mellomlagerBrevRepository.deleteById(behandlingId)
+        }
+    }
+
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -342,6 +342,16 @@ internal class BeregnYtelseStegTest {
         assertThat(feil.frontendFeilmelding).contains("Kan kun opphøre ved revurdering")
     }
 
+    @Test
+    internal fun `skal slette mellomlagret brev ved utførBeregnYtelseSteg`() {
+        every { beregningService.beregnYtelse(any(), any()) } returns listOf(lagBeløpsperiode(LocalDate.now(), LocalDate.now()))
+        utførSteg(BehandlingType.FØRSTEGANGSBEHANDLING)
+
+        verify { mellomlagringBrevService.slettMellomlagringHvisFinnes(any()) }
+    }
+
+
+
 
     private fun utførSteg(type: BehandlingType, vedtak: VedtakDto = Innvilget(periodeBegrunnelse = "", inntektBegrunnelse = ""), forrigeBehandlingId: UUID? = null) {
         steg.utførSteg(behandling(fagsak(), type = type, forrigeBehandlingId = forrigeBehandlingId), vedtak = vedtak)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.brev.MellomlagringBrevService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.simulering.Simuleringsresultat
@@ -39,9 +40,10 @@ internal class BeregnYtelseStegTest {
     private val beregningService = mockk<BeregningService>()
     private val vedtakService = mockk<VedtakService>(relaxed = true)
     private val simuleringService = mockk<SimuleringService>()
+    private val mellomlagringBrevService = mockk<MellomlagringBrevService>(relaxed = true)
 
     private val steg =
-            BeregnYtelseSteg(tilkjentYtelseService, behandlingService, beregningService, simuleringService, vedtakService)
+            BeregnYtelseSteg(tilkjentYtelseService, behandlingService, beregningService, simuleringService, vedtakService, mellomlagringBrevService)
 
     @BeforeEach
     internal fun setUp() {


### PR DESCRIPTION
For at vi skal få de nyeste verdiene i brevet sletter vi mellomlagring ved nye beregninger.