### PR TITLE
Refaktorering pakkestruktur

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/arbeidsfordeling/ArbeidsfordelingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/arbeidsfordeling/ArbeidsfordelingService.kt
@@ -1,13 +1,13 @@
 package no.nav.familie.ef.sak.arbeidsfordeling
 
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import org.springframework.stereotype.Component
 
 @Component
 class ArbeidsfordelingService(private val personService: PersonService,
-                              private val familieIntegrasjonerClient: FamilieIntegrasjonerClient) {
+                              private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient) {
 
     private val MASKINELL_JOURNALFOERENDE_ENHET = "9999"
 
@@ -22,7 +22,7 @@ class ArbeidsfordelingService(private val personService: PersonService,
                                                                           it.value.adressebeskyttelse.gjeldende()?.gradering)
                                            }
         val identMedStrengeste = finnPersonMedStrengesteAdressebeskyttelse(identerMedAdressebeskyttelse)
-        return familieIntegrasjonerClient.hentNavEnhet(identMedStrengeste ?: ident).firstOrNull()
+        return personopplysningerIntegrasjonerClient.hentNavEnhet(identMedStrengeste ?: ident).firstOrNull()
     }
 
     fun hentNavEnhetIdEllerBrukMaskinellEnhetHvisNull(personIdent: String): String {

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaStønadsperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaStønadsperioderService.kt
@@ -8,10 +8,10 @@ import no.nav.familie.ef.sak.ekstern.arena.ArenaPeriodeUtil.mapOgFiltrer
 import no.nav.familie.ef.sak.ekstern.arena.ArenaPeriodeUtil.slåSammenPerioder
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infrastruktur.exception.PdlNotFoundException
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaRequest
@@ -32,7 +32,7 @@ class ArenaStønadsperioderService(private val infotrygdReplikaClient: Infotrygd
                                   private val fagsakService: FagsakService,
                                   private val behandlingService: BehandlingService,
                                   private val tilkjentYtelseService: TilkjentYtelseService,
-                                  private val familieIntegrasjonerClient: FamilieIntegrasjonerClient,
+                                  private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
                                   private val pdlClient: PdlClient) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -43,9 +43,9 @@ class ArenaStønadsperioderService(private val infotrygdReplikaClient: Infotrygd
      */
     fun hentPerioder(request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
         return runBlocking {
-            val asyncResponse = async { familieIntegrasjonerClient.hentInfotrygdPerioder(request) }
+            val asyncResponse = async { personopplysningerIntegrasjonerClient.hentInfotrygdPerioder(request) }
 
-            //val responseFraReplika = hentReplikaPerioder(request) // TODO ta i bruk når replikaen virker i prod
+            //val responseFraReplika = hentReplikaPerioder(request) // TODO ta i bruk når replikaen virker i prod. Husk å rydde i PersonopplysningerInt
             val perioderFraInfotrygd = asyncResponse.await()
             val perioderFraEf = hentPerioderFraEf(request)
             PerioderOvergangsstønadResponse(perioderFraInfotrygd.perioder + perioderFraEf)

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/integration/FamilieIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/integration/FamilieIntegrasjonerClient.kt
@@ -12,7 +12,6 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.getDataOrThrow
-import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import org.slf4j.LoggerFactory
@@ -39,14 +38,6 @@ class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperati
 
     fun hentMedlemskapsinfo(ident: String): Medlemskapsinfo {
         return postForEntity<Ressurs<Medlemskapsinfo>>(integrasjonerConfig.medlemskapUri, PersonIdent(ident)).data!!
-    }
-
-    fun hentKodeverkLandkoder(): KodeverkDto {
-        return getForEntity<Ressurs<KodeverkDto>>(integrasjonerConfig.kodeverkLandkoderUri).data!!
-    }
-
-    fun hentKodeverkPoststed(): KodeverkDto {
-        return getForEntity<Ressurs<KodeverkDto>>(integrasjonerConfig.kodeverkPoststedUri).data!!
     }
 
     fun hentNavEnhet(ident: String): List<Arbeidsfordelingsenhet> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/CachedKodeverkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/CachedKodeverkService.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.felles.integration
+package no.nav.familie.ef.sak.felles.kodeverk
 
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
 import org.slf4j.LoggerFactory
@@ -13,16 +13,16 @@ import org.springframework.stereotype.Service
 
 @Service
 @CacheConfig(cacheManager = "kodeverkCache")
-class CachedKodeverkService(private val familieIntegrasjonerClient: FamilieIntegrasjonerClient) {
+class CachedKodeverkService(private val kodeverkClient: KodeverkClient) {
 
     @Cacheable("kodeverk_landkoder")
     fun hentLandkoder(): KodeverkDto {
-        return familieIntegrasjonerClient.hentKodeverkLandkoder()
+        return kodeverkClient.hentKodeverkLandkoder()
     }
 
     @Cacheable("kodeverk_poststed")
     fun hentPoststed(): KodeverkDto {
-        return familieIntegrasjonerClient.hentKodeverkPoststed()
+        return kodeverkClient.hentKodeverkPoststed()
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkClient.kt
@@ -1,0 +1,29 @@
+package no.nav.familie.ef.sak.felles.kodeverk
+
+import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
+import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+@Component
+class KodeverkClient(@Qualifier("azure") restOperations: RestOperations,
+                                 private val integrasjonerConfig: IntegrasjonerConfig)
+    : AbstractPingableRestClient(restOperations, "kodeverk") {
+
+    override val pingUri: URI = integrasjonerConfig.pingUri
+    val logger = LoggerFactory.getLogger(this::class.java)
+
+
+    fun hentKodeverkLandkoder(): KodeverkDto {
+        return getForEntity<Ressurs<KodeverkDto>>(integrasjonerConfig.kodeverkLandkoderUri).data!!
+    }
+
+    fun hentKodeverkPoststed(): KodeverkDto {
+        return getForEntity<Ressurs<KodeverkDto>>(integrasjonerConfig.kodeverkPoststedUri).data!!
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkService.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.felles.integration
+package no.nav.familie.ef.sak.felles.kodeverk
 
 import no.nav.familie.kontrakter.felles.kodeverk.hentGjeldende
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/health/FamilieIntegrasjonHealth.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/health/FamilieIntegrasjonHealth.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ef.sak.infrastruktur.health
 
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.http.health.AbstractHealthIndicator
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Component
 @Profile("!local")
-class FamilieIntegrasjonHealth(familieIntegrasjonerClient: FamilieIntegrasjonerClient)
-    : AbstractHealthIndicator(familieIntegrasjonerClient, "familie.integrasjoner")
+class FamilieIntegrasjonHealth(personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient)
+    : AbstractHealthIndicator(personopplysningerIntegrasjonerClient, "familie.integrasjoner")

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
@@ -1,17 +1,17 @@
 package no.nav.familie.ef.sak.infrastruktur.sikkerhet
 
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.ManglerTilgang
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
-import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class TilgangService(private val integrasjonerClient: FamilieIntegrasjonerClient,
+class TilgangService(private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
                      private val behandlingService: BehandlingService,
                      private val fagsakService: FagsakService,
                      private val rolleConfig: RolleConfig,
@@ -27,7 +27,7 @@ class TilgangService(private val integrasjonerClient: FamilieIntegrasjonerClient
 
     private fun harTilgangTilPersonMedRelasjoner(personIdent: String): Boolean {
         return harSaksbehandlerTilgang("validerTilgangTilPersonMedBarn", personIdent) {
-            integrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(personIdent).harTilgang
+            personopplysningerIntegrasjonerClient.sjekkTilgangTilPersonMedRelasjoner(personIdent).harTilgang
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
@@ -1,19 +1,18 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapAnnenForelder
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapBarn
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Familierelasjonsrolle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlAnnenForelder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonKort
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapAnnenForelder
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapBarn
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapSøker
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
-import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -23,7 +22,7 @@ import java.util.UUID
 class GrunnlagsdataService(private val pdlClient: PdlClient,
                            private val grunnlagsdataRepository: GrunnlagsdataRepository,
                            private val søknadService: SøknadService,
-                           private val familieIntegrasjonerClient: FamilieIntegrasjonerClient) {
+                           private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient) {
 
     val logger = LoggerFactory.getLogger(this.javaClass)
     val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -57,7 +56,7 @@ class GrunnlagsdataService(private val pdlClient: PdlClient,
         val dataTilAndreIdenter = hentDataTilAndreIdenter(pdlSøker)
 
         /*TODO VAD SKA VI BRUKE FRA MEDL ?? */
-        val medlUnntak = familieIntegrasjonerClient.hentMedlemskapsinfo(ident = personIdent)
+        val medlUnntak = personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(ident = personIdent)
 
         return GrunnlagsdataDomene(
                 søker = mapSøker(pdlSøker, dataTilAndreIdenter),

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerIntegrasjonerClient.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.felles.integration
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.felles.integration.dto.EgenAnsattRequest
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.annotasjoner.Improvement
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.getDataOrThrow
@@ -23,7 +24,7 @@ import org.springframework.web.client.RestOperations
 import java.net.URI
 
 @Component
-class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperations,
+class PersonopplysningerIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperations,
                                  private val integrasjonerConfig: IntegrasjonerConfig)
     : AbstractPingableRestClient(restOperations, "familie.integrasjoner") {
 
@@ -55,13 +56,15 @@ class FamilieIntegrasjonerClient(@Qualifier("azure") restOperations: RestOperati
                                                           EgenAnsattRequest(ident)).data!!.erEgenAnsatt
     }
 
-    fun hentInfotrygdPerioder(request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
-        return postForEntity<Ressurs<PerioderOvergangsstønadResponse>>(integrasjonerConfig.infotrygdVedtaksperioder, request)
-                .getDataOrThrow()
-    }
 
     fun hentNavKontor(ident: String): NavKontorEnhet {
         return postForEntity<Ressurs<NavKontorEnhet>>(integrasjonerConfig.navKontorUri, PersonIdent(ident)).getDataOrThrow()
+    }
+
+    @Improvement("Fjern denne når infotrygdReplika fungerer i prod")
+    fun hentInfotrygdPerioder(request: PerioderOvergangsstønadRequest): PerioderOvergangsstønadResponse {
+        return postForEntity<Ressurs<PerioderOvergangsstønadResponse>>(integrasjonerConfig.infotrygdVedtaksperioder, request)
+                .getDataOrThrow()
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.PersonopplysningerMapper
@@ -16,7 +15,7 @@ import java.util.UUID
 @Service
 class PersonopplysningerService(private val personService: PersonService,
                                 private val søknadService: SøknadService,
-                                private val familieIntegrasjonerClient: FamilieIntegrasjonerClient,
+                                private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
                                 private val grunnlagsdataService: GrunnlagsdataService,
                                 private val personopplysningerMapper: PersonopplysningerMapper) {
 
@@ -26,7 +25,7 @@ class PersonopplysningerService(private val personService: PersonService,
         val søknad = søknadService.hentOvergangsstønad(behandlingId)
         val personIdent = søknad.fødselsnummer
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdata(behandlingId)
-        val egenAnsatt = familieIntegrasjonerClient.egenAnsatt(personIdent)
+        val egenAnsatt = personopplysningerIntegrasjonerClient.egenAnsatt(personIdent)
 
 
         return personopplysningerMapper.tilPersonopplysninger(
@@ -38,7 +37,7 @@ class PersonopplysningerService(private val personService: PersonService,
 
     fun hentPersonopplysninger(personIdent: String): PersonopplysningerDto {
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdataFraRegister(personIdent, emptyList())
-        val egenAnsatt = familieIntegrasjonerClient.egenAnsatt(personIdent)
+        val egenAnsatt = personopplysningerIntegrasjonerClient.egenAnsatt(personIdent)
 
 
         return personopplysningerMapper.tilPersonopplysninger(
@@ -56,6 +55,6 @@ class PersonopplysningerService(private val personService: PersonService,
 
     @Cacheable("navKontor")
     fun hentNavKontor(ident: String): NavKontorEnhet {
-        return familieIntegrasjonerClient.hentNavKontor(ident)
+        return personopplysningerIntegrasjonerClient.hentNavKontor(ident)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseMapper.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Postboksadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtenlandskAdresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtenlandskAdresseIFrittFormat
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Vegadresse
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import no.nav.familie.ef.sak.felles.util.datoEllerIdag
 import org.springframework.stereotype.Component
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper
 
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.AnnenForelderMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/StatsborgerskapMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/StatsborgerskapMapper.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper
 
 import no.nav.familie.ef.sak.vilkår.dto.StatsborgerskapDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import no.nav.familie.ef.sak.felles.util.datoEllerIdag
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.InnflyttingTilN
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Medlemskap
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import no.nav.familie.ef.sak.vilkår.dto.MedlemskapDto
 import no.nav.familie.ef.sak.vilkår.dto.MedlemskapRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.MedlemskapSøknadsgrunnlagDto

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -22,8 +22,7 @@ fun main(args: Array<String>) {
                       "mock-infotrygd-replika",
                       "mock-kodeverk",
                       "mock-blankett",
-                      "mock-iverksett",
-                      "mock-brev")
+                      "mock-iverksett")
             .properties(properties)
             .run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/KodeverkServiceMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/KodeverkServiceMock.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.sak.config
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/StatsborgerskapMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/StatsborgerskapMapperTest.kt
@@ -4,7 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.StatsborgerskapMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/ArbeidsfordelingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/ArbeidsfordelingServiceTest.kt
@@ -4,29 +4,29 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.SøkerMedBarn
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Adressebeskyttelse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.AdressebeskyttelseGradering
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
 import no.nav.familie.ef.sak.testutil.pdlBarn
 import no.nav.familie.ef.sak.testutil.pdlSøker
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class ArbeidsfordelingServiceTest {
 
     private lateinit var personService: PersonService
-    private lateinit var familieIntegrasjonerClient: FamilieIntegrasjonerClient
+    private lateinit var personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient
     private lateinit var arbeidsfordelingService: ArbeidsfordelingService
 
     @BeforeEach
     internal fun setUp() {
         personService = mockk()
-        familieIntegrasjonerClient = mockk()
-        every { familieIntegrasjonerClient.hentNavEnhet(any()) } returns listOf()
-        arbeidsfordelingService = ArbeidsfordelingService(personService, familieIntegrasjonerClient)
+        personopplysningerIntegrasjonerClient = mockk()
+        every { personopplysningerIntegrasjonerClient.hentNavEnhet(any()) } returns listOf()
+        arbeidsfordelingService = ArbeidsfordelingService(personService, personopplysningerIntegrasjonerClient)
     }
 
     @Test
@@ -36,7 +36,7 @@ internal class ArbeidsfordelingServiceTest {
                              graderingBarn = AdressebeskyttelseGradering.FORTROLIG)
 
         arbeidsfordelingService.hentNavEnhet(IDENT_FORELDER)
-        verify(exactly = 1) { familieIntegrasjonerClient.hentNavEnhet(IDENT_FORELDER) }
+        verify(exactly = 1) { personopplysningerIntegrasjonerClient.hentNavEnhet(IDENT_FORELDER) }
     }
 
     @Test
@@ -46,7 +46,7 @@ internal class ArbeidsfordelingServiceTest {
                              graderingBarn = AdressebeskyttelseGradering.STRENGT_FORTROLIG)
 
         arbeidsfordelingService.hentNavEnhet(IDENT_FORELDER)
-        verify(exactly = 1) { familieIntegrasjonerClient.hentNavEnhet(IDENT_BARN) }
+        verify(exactly = 1) { personopplysningerIntegrasjonerClient.hentNavEnhet(IDENT_BARN) }
     }
 
     private fun søkerMedBarn(graderingForelder: AdressebeskyttelseGradering,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/ArenaStønadsperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/ArenaStønadsperioderServiceTest.kt
@@ -7,10 +7,10 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.ekstern.arena.ArenaStønadsperioderService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infrastruktur.exception.PdlNotFoundException
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
 import no.nav.familie.ef.sak.repository.behandling
@@ -36,7 +36,7 @@ internal class ArenaStønadsperioderServiceTest {
     private val pdlClient = mockk<PdlClient>()
     private val infotrygdReplikaClient = mockk<InfotrygdReplikaClient>(relaxed = true)
     private val behandlingService = mockk<BehandlingService>(relaxed = true)
-    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val personopplysningerIntergasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
     private val fagsakService = mockk<FagsakService>()
 
@@ -45,7 +45,7 @@ internal class ArenaStønadsperioderServiceTest {
                                         behandlingService = behandlingService,
                                         pdlClient = pdlClient,
                                         tilkjentYtelseService = tilkjentYtelseService,
-                                        familieIntegrasjonerClient = familieIntegrasjonerClient,
+                                        personopplysningerIntegrasjonerClient = personopplysningerIntergasjonerClient,
                                         fagsakService = fagsakService)
 
     private val ident = "01234567890"
@@ -101,7 +101,7 @@ internal class ArenaStønadsperioderServiceTest {
         every { behandlingService.finnSisteIverksatteBehandling(fagsakOvergangsstønad.id) } returns behandlingOvergangsstønad
         every { behandlingService.finnSisteIverksatteBehandling(fagsakBarnetilsyn.id) } returns behandlingBarnetilsyn
 
-        every { familieIntegrasjonerClient.hentInfotrygdPerioder(any()) } returns PerioderOvergangsstønadResponse(listOf(
+        every { personopplysningerIntergasjonerClient.hentInfotrygdPerioder(any()) } returns PerioderOvergangsstønadResponse(listOf(
                 PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-01-31"), Datakilde.INFOTRYGD)))
         every { tilkjentYtelseService.hentForBehandling(behandlingOvergangsstønad.id) } returns
                 lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(1, parse("2021-01-01"), parse("2021-01-31"), ident)))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/CachedKodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/CachedKodeverkServiceTest.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.service
 
-import no.nav.familie.ef.sak.felles.integration.CachedKodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.CachedKodeverkService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.cache.annotation.Cacheable

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -4,19 +4,19 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.config.PdlClientConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstandstype
+import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
-import no.nav.familie.ef.sak.config.PdlClientConfig
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
-import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
-import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import org.assertj.core.api.Assertions.assertThat
@@ -34,7 +34,7 @@ internal class GrunnlagsdataServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val pdlClient = PdlClientConfig().pdlClient()
     private val søknadService = mockk<SøknadService>()
-    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
 
     private val søknad = SøknadsskjemaMapper.tilDomene(TestsøknadBuilder.Builder().setBarn(listOf(
             TestsøknadBuilder.Builder().defaultBarn("Navn1 navnesen", fødselTermindato = LocalDate.now().plusMonths(4)),
@@ -44,12 +44,12 @@ internal class GrunnlagsdataServiceTest {
     private val service = GrunnlagsdataService(pdlClient = pdlClient,
                                                grunnlagsdataRepository = grunnlagsdataRepository,
                                                søknadService = søknadService,
-                                               familieIntegrasjonerClient = familieIntegrasjonerClient)
+                                               personopplysningerIntegrasjonerClient = personopplysningerIntegrasjonerClient)
 
     @BeforeEach
     internal fun setUp() {
         every { søknadService.hentOvergangsstønad(any()) } returns søknad
-        every { familieIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns
+        every { personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns
                 Medlemskapsinfo("", emptyList(), emptyList(), emptyList())
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/KodeverkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/KodeverkServiceTest.kt
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
-import no.nav.familie.ef.sak.felles.integration.KodeverkService
+import no.nav.familie.ef.sak.felles.kodeverk.KodeverkService
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -6,9 +6,9 @@ import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.config.PdlClientConfig
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.PersonopplysningerMapper
@@ -25,7 +25,7 @@ internal class PersonopplysningerServiceTest {
     private val kodeverkService = KodeverkServiceMock().kodeverkService()
 
     private lateinit var personopplysningerService: PersonopplysningerService
-    private lateinit var familieIntegrasjonerClient: FamilieIntegrasjonerClient
+    private lateinit var personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient
     private lateinit var adresseMapper: AdresseMapper
     private lateinit var arbeidsfordelingService: ArbeidsfordelingService
     private lateinit var grunnlagsdataService: GrunnlagsdataService
@@ -33,13 +33,13 @@ internal class PersonopplysningerServiceTest {
 
     @BeforeEach
     internal fun setUp() {
-        familieIntegrasjonerClient = mockk()
+        personopplysningerIntegrasjonerClient = mockk()
         adresseMapper = AdresseMapper(kodeverkService)
         arbeidsfordelingService = mockk()
         søknadService = mockk()
 
         val pdlClient = PdlClientConfig().pdlClient()
-        grunnlagsdataService = GrunnlagsdataService(pdlClient, mockk(), søknadService, familieIntegrasjonerClient)
+        grunnlagsdataService = GrunnlagsdataService(pdlClient, mockk(), søknadService, personopplysningerIntegrasjonerClient)
         val personopplysningerMapper =
                 PersonopplysningerMapper(adresseMapper,
                                          StatsborgerskapMapper(kodeverkService),
@@ -48,18 +48,18 @@ internal class PersonopplysningerServiceTest {
         val personService = PersonService(pdlClient)
         personopplysningerService = PersonopplysningerService(personService,
                                                               søknadService,
-                                                              familieIntegrasjonerClient,
+                                                              personopplysningerIntegrasjonerClient,
                                                               grunnlagsdataService,
                                                               personopplysningerMapper)
     }
 
     @Test
     internal fun `mapper grunnlagsdata til PersonopplysningerDto`() {
-        every { familieIntegrasjonerClient.egenAnsatt(any()) } returns true
-        every { familieIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns Medlemskapsinfo("01010172272",
-                                                                                                emptyList(),
-                                                                                                emptyList(),
-                                                                                                emptyList())
+        every { personopplysningerIntegrasjonerClient.egenAnsatt(any()) } returns true
+        every { personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns Medlemskapsinfo("01010172272",
+                                                                                                           emptyList(),
+                                                                                                           emptyList(),
+                                                                                                           emptyList())
         every { arbeidsfordelingService.hentNavEnhet(any()) } returns Arbeidsfordelingsenhet("1", "Enhet")
         val søker = personopplysningerService.hentPersonopplysninger("01010172272")
         assertThat(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(søker))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
@@ -2,17 +2,17 @@ package no.nav.familie.ef.sak.service
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
-import no.nav.familie.ef.sak.vilkår.MedlemskapMapper
-import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
 import no.nav.familie.ef.sak.config.PdlClientConfig
-import no.nav.familie.ef.sak.repository.behandling
-import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.vilkår.MedlemskapMapper
 import no.nav.familie.ef.sak.vilkår.VilkårGrunnlagService
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
@@ -26,7 +26,7 @@ internal class VilkårGrunnlagServiceTest {
 
     private val grunnlagsdataRepository = mockk<GrunnlagsdataRepository>()
     private val pdlClient = PdlClientConfig().pdlClient()
-    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val søknadService = mockk<SøknadService>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val medlemskapMapper = MedlemskapMapper(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
@@ -34,7 +34,7 @@ internal class VilkårGrunnlagServiceTest {
     private val grunnlagsdataService = GrunnlagsdataService(pdlClient,
                                                             grunnlagsdataRepository,
                                                             søknadService,
-                                                            familieIntegrasjonerClient)
+                                                            personopplysningerIntegrasjonerClient)
 
     private val service = VilkårGrunnlagService(medlemskapMapper, grunnlagsdataService)
     private val behandling = behandling(fagsak())
@@ -49,7 +49,7 @@ internal class VilkårGrunnlagServiceTest {
     @BeforeEach
     internal fun setUp() {
         every { søknadService.hentOvergangsstønad(behandlingId) } returns søknad
-        every { familieIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns medlemskapsinfo
+        every { personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(any()) } returns medlemskapsinfo
         every { featureToggleService.isEnabled(any(), any()) } returns false
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceTest.kt
@@ -8,25 +8,25 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.blankett.BlankettRepository
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
-import no.nav.familie.ef.sak.repository.behandling
-import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
-import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
-import no.nav.familie.ef.sak.vilkår.dto.SivilstandInngangsvilkårDto
-import no.nav.familie.ef.sak.vilkår.dto.SivilstandRegistergrunnlagDto
-import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.VilkårGrunnlagService
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.vilkår.VurderingService
+import no.nav.familie.ef.sak.vilkår.dto.SivilstandInngangsvilkårDto
+import no.nav.familie.ef.sak.vilkår.dto.SivilstandRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.SivilstandRegel
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
@@ -42,7 +42,7 @@ internal class VurderingServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val søknadService = mockk<SøknadService>()
     private val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
-    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val blankettRepository = mockk<BlankettRepository>()
     private val vilkårGrunnlagService = mockk<VilkårGrunnlagService>()
     private val stegService = mockk<StegService>()
@@ -62,7 +62,7 @@ internal class VurderingServiceTest {
         every { behandlingService.hentBehandling(BEHANDLING_ID) } returns behandling
         every { søknadService.hentOvergangsstønad(any()) }.returns(søknad)
         every { blankettRepository.deleteById(any()) } just runs
-        every { familieIntegrasjonerClient.hentMedlemskapsinfo(any()) }
+        every { personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(any()) }
                 .returns(Medlemskapsinfo(personIdent = søknad.fødselsnummer,
                                          gyldigePerioder = emptyList(),
                                          uavklartePerioder = emptyList(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingStegServiceTest.kt
@@ -9,32 +9,32 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.blankett.BlankettRepository
-import no.nav.familie.ef.sak.infrastruktur.exception.Feil
-import no.nav.familie.ef.sak.felles.integration.FamilieIntegrasjonerClient
-import no.nav.familie.ef.sak.repository.behandling
-import no.nav.familie.ef.sak.repository.fagsak
-import no.nav.familie.ef.sak.repository.vilkårsvurdering
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
+import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
-import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
-import no.nav.familie.ef.sak.vilkår.dto.DelvilkårsvurderingDto
-import no.nav.familie.ef.sak.vilkår.dto.OppdaterVilkårsvurderingDto
-import no.nav.familie.ef.sak.vilkår.dto.SivilstandInngangsvilkårDto
-import no.nav.familie.ef.sak.vilkår.dto.SivilstandRegistergrunnlagDto
-import no.nav.familie.ef.sak.vilkår.dto.SvarPåVurderingerDto
-import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.VilkårGrunnlagService
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.vilkår.Vurdering
-import no.nav.familie.ef.sak.vilkår.dto.VurderingDto
 import no.nav.familie.ef.sak.vilkår.VurderingStegService
+import no.nav.familie.ef.sak.vilkår.dto.DelvilkårsvurderingDto
+import no.nav.familie.ef.sak.vilkår.dto.OppdaterVilkårsvurderingDto
+import no.nav.familie.ef.sak.vilkår.dto.SivilstandInngangsvilkårDto
+import no.nav.familie.ef.sak.vilkår.dto.SivilstandRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.SvarPåVurderingerDto
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.VurderingDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
@@ -56,7 +56,7 @@ internal class VurderingStegServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val søknadService = mockk<SøknadService>()
     private val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
-    private val familieIntegrasjonerClient = mockk<FamilieIntegrasjonerClient>()
+    private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val blankettRepository = mockk<BlankettRepository>()
     private val vilkårGrunnlagService = mockk<VilkårGrunnlagService>()
     private val stegService = mockk<StegService>()
@@ -83,7 +83,7 @@ internal class VurderingStegServiceTest {
         every { søknadService.hentOvergangsstønad(any()) }.returns(søknad)
         every { blankettRepository.deleteById(any()) } just runs
         every { taskRepository.save(any())} answers { firstArg() }
-        every { familieIntegrasjonerClient.hentMedlemskapsinfo(any()) }
+        every { personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(any()) }
                 .returns(Medlemskapsinfo(personIdent = søknad.fødselsnummer,
                                          gyldigePerioder = emptyList(),
                                          uavklartePerioder = emptyList(),


### PR DESCRIPTION
- Flytter koderverkkall fra FamilieIntegrasjonerClient til ny KodeverkClient i felles-pakken
- Flytter perosnopplysningskall fra FamilieIntegrasjonerClient til ny PersonopplysningerIntegrasjonerClient