### PR TITLE
Endepunkt som håndterer sjekk om det finnes behandling, av flere iden…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingControllerTest.kt
@@ -23,16 +23,19 @@ internal class EksternBehandlingControllerTest {
     private val behandlingRepository = mockk<BehandlingRepository>()
     private val eksternBehandlingController = EksternBehandlingController(pdlClient, behandlingRepository)
 
+    private val ident1 = "11111111111"
+    private val ident2 = "22222222222"
+
     @BeforeEach
     internal fun setUp() {
-        every { pdlClient.hentPersonidenter("1", true) } returns PdlIdenter(listOf(PdlIdent("1", true), PdlIdent("2", false)))
+        every { pdlClient.hentPersonidenter(ident1, true) } returns PdlIdenter(listOf(PdlIdent(ident1, true), PdlIdent(ident2, false)))
     }
 
     @Test
     internal fun `skal feile når den ikke finner identer til personen`() {
-        every { pdlClient.hentPersonidenter("1", true) } returns PdlIdenter(emptyList())
+        every { pdlClient.hentPersonidenter(ident1, true) } returns PdlIdenter(emptyList())
         val finnesBehandlingForPerson =
-                eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent("1"))
+                eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent(ident1))
         assertThat(finnesBehandlingForPerson.status)
                 .isEqualTo(Ressurs.Status.FEILET)
     }
@@ -40,48 +43,48 @@ internal class EksternBehandlingControllerTest {
     @Test
     internal fun `skal returnere false når det ikke finnes en behandling`() {
         every {
-            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf("1", "2"))
+            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf(ident1, ident2))
         } returns null
-        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent("1")).data)
+        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent(ident1)).data)
                 .isEqualTo(false)
     }
 
     @Test
     internal fun `skal returnere false når en behandling finnes som er teknisk opphør`() {
         every {
-            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf("1", "2"))
+            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf(ident1, ident2))
         } returns behandling(fagsak(), type = BehandlingType.TEKNISK_OPPHØR)
-        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent("1")).data)
+        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent(ident1)).data)
                 .isEqualTo(false)
     }
 
     @Test
     internal fun `skal returnere true når behandling finnes`() {
         every {
-            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf("1", "2"))
+            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(Stønadstype.OVERGANGSSTØNAD, setOf(ident1, ident2))
         } returns behandling(fagsak())
-        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent("1")).data)
+        assertThat(eksternBehandlingController.finnesBehandlingForPerson(Stønadstype.OVERGANGSSTØNAD, PersonIdent(ident1)).data)
                 .isEqualTo(true)
     }
 
     @Test
     internal fun `uten stønadstype - skal returnere false når det ikke finnes noen behandling`() {
-        every { behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(any(), setOf("1", "2")) } returns null
-        assertThat(eksternBehandlingController.finnesBehandlingForPerson(null, PersonIdent("1")).data)
+        every { behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(any(), setOf(ident1, ident2)) } returns null
+        assertThat(eksternBehandlingController.finnesBehandlingForPerson(null, PersonIdent(ident1)).data)
                 .isEqualTo(false)
     }
 
     @Test
     internal fun `uten stønadstype - skal returnere true når det minimum en behandling`() {
         var counter = 0
-        every { behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(any(), setOf("1", "2")) } answers {
+        every { behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(any(), setOf(ident1, ident2)) } answers {
             if (counter++ == 1) {
                 behandling(fagsak())
             } else {
                 null
             }
         }
-        assertThat(eksternBehandlingController.finnesBehandlingForPerson(null, PersonIdent("1")).data)
+        assertThat(eksternBehandlingController.finnesBehandlingForPerson(null, PersonIdent(ident1)).data)
                 .isEqualTo(true)
         verify(exactly = 2) { behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(any(), any()) }
     }


### PR DESCRIPTION
…ter for en person, for å unngå oppslag mot pdl når man kun sender en ident

Når vi håndterer personhendelser får vi en liste med identene til en person, så det blir unødvendig å kalle på pdl for å hente alle identer til en person for disse. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6550