### PR TITLE
Mellomlagring fritekstbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -1,7 +1,8 @@
 package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.brev.dto.MellomlagreBrevRequestDto
-import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponseDto
+import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponse
+import no.nav.familie.ef.sak.brev.dto.VedtaksbrevFritekstDto
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -33,10 +34,18 @@ class BrevMellomlagerController(private val tilgangService: TilgangService,
                                                                         mellomlagretBrev.versjon))
     }
 
+    @PostMapping("/fritekst")
+    fun mellomlagreFritekstbrev(@RequestBody mellomlagretBrev: VedtaksbrevFritekstDto): Ressurs<UUID> {
+        tilgangService.validerTilgangTilBehandling(mellomlagretBrev.behandlingId)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return Ressurs.success(mellomlagringBrevService.mellomlagreFritekstbrev(mellomlagretBrev))
+    }
+
 
     @GetMapping("/{behandlingId}")
     fun hentMellomlagretBrevverdier(@PathVariable behandlingId: UUID,
-                                    @RequestParam sanityVersjon: String): Ressurs<MellomlagretBrevResponseDto?> {
+                                    @RequestParam sanityVersjon: String): Ressurs<MellomlagretBrevResponse?> {
         tilgangService.validerTilgangTilBehandling(behandlingId)
 
         return Ressurs.success(mellomlagringBrevService.hentOgValiderMellomlagretBrev(behandlingId,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepository.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ef.sak.brev
+
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
+import no.nav.familie.ef.sak.repository.InsertUpdateRepository
+import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface MellomlagerFritekstbrevRepository : RepositoryInterface<MellomlagretFritekstbrev, UUID>, InsertUpdateRepository<MellomlagretFritekstbrev>

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -1,17 +1,23 @@
 package no.nav.familie.ef.sak.brev
 
+import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
-import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponseDto
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
+import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevFritekst
+import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponse
+import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevSanity
+import no.nav.familie.ef.sak.brev.dto.VedtaksbrevFritekstDto
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
 
 @Service
-class MellomlagringBrevService(private val mellomlagerBrevRepository: MellomlagerBrevRepository) {
+class MellomlagringBrevService(private val mellomlagerBrevRepository: MellomlagerBrevRepository,
+                               private val mellomlagerFritekstbrevRepository: MellomlagerFritekstbrevRepository) {
 
     fun mellomLagreBrev(behandlingId: UUID, brevverdier: String, brevmal: String, sanityVersjon: String): UUID {
-
+        mellomlagerFritekstbrevRepository.deleteById(behandlingId)
         return when (val mellomlagretBrev = mellomlagerBrevRepository.findByIdOrNull(behandlingId)) {
             null -> mellomlagerBrevRepository.insert(MellomlagretBrev(behandlingId,
                                                                       brevverdier,
@@ -26,10 +32,25 @@ class MellomlagringBrevService(private val mellomlagerBrevRepository: Mellomlage
 
     }
 
-    fun hentOgValiderMellomlagretBrev(behhandlingId: UUID, sanityVersjon: String): MellomlagretBrevResponseDto? {
-        val mellomlagretBrev = mellomlagerBrevRepository.findByIdOrNull(behhandlingId)
-        if (sanityVersjon == mellomlagretBrev?.sanityVersjon) {
-            return MellomlagretBrevResponseDto(brevverdier = mellomlagretBrev.brevverdier, brevmal = mellomlagretBrev.brevmal)
+    fun mellomlagreFritekstbrev(mellomlagretBrev: VedtaksbrevFritekstDto): UUID {
+        mellomlagerBrevRepository.deleteById(mellomlagretBrev.behandlingId)
+        val mellomlagretFritekstbrev = MellomlagretFritekstbrev(mellomlagretBrev.behandlingId,
+                                                                Fritekstbrev(overskrift = mellomlagretBrev.overskrift,
+                                                                             avsnitt = mellomlagretBrev.avsnitt))
+
+        return mellomlagerFritekstbrevRepository.insert(mellomlagretFritekstbrev).behandlingId
+    }
+
+    fun hentOgValiderMellomlagretBrev(behhandlingId: UUID, sanityVersjon: String): MellomlagretBrevResponse? {
+        mellomlagerBrevRepository.findByIdOrNull(behhandlingId)?.let {
+            if (sanityVersjon == it.sanityVersjon) {
+                return MellomlagretBrevSanity(brevverdier = it.brevverdier,
+                                              brevmal = it.brevmal)
+            }
+            return null
+        }
+        mellomlagerFritekstbrevRepository.findByIdOrNull(behhandlingId)?.let {
+            return MellomlagretBrevFritekst(brev = it.brev)
         }
         return null
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFritekstbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFritekstbrev.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.ef.sak.brev.domain
+
+import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevAvsnitt
+import org.springframework.data.annotation.Id
+import java.util.UUID
+
+
+data class MellomlagretFritekstbrev(@Id val behandlingId: UUID, val brev: Fritekstbrev)
+
+data class Fritekstbrev(val overskrift: String, val avsnitt: List<FrittståendeBrevAvsnitt>)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponse.kt
@@ -1,0 +1,16 @@
+package no.nav.familie.ef.sak.brev.dto
+
+import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
+
+sealed class MellomlagretBrevResponse
+
+data class MellomlagretBrevSanity(val brevtype: Brevtype = Brevtype.SANITYBREV, val brevmal: String, val brevverdier: String?) :
+        MellomlagretBrevResponse()
+
+data class MellomlagretBrevFritekst(val brevtype: Brevtype = Brevtype.FRITEKSTBREV, val brev: Fritekstbrev, val brevmal: String = "Fritekstbrev") :
+        MellomlagretBrevResponse()
+
+enum class Brevtype {
+    FRITEKSTBREV,
+    SANITYBREV
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponseDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponseDto.kt
@@ -1,4 +1,0 @@
-package no.nav.familie.ef.sak.brev.dto
-
-data class MellomlagretBrevResponseDto(val brevverdier: String?,
-                                       val brevmal: String)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/DatabaseConfiguration.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.infrastruktur.config
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
 import no.nav.familie.ef.sak.felles.domain.Endret
 import no.nav.familie.ef.sak.felles.domain.Fil
 import no.nav.familie.ef.sak.felles.domain.JsonWrapper
@@ -109,7 +110,9 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                                             PGobjectTilDetaljertSimuleringResultat(),
                                             DetaljertSimuleringResultatTilPGobjectConverter(),
                                             PGobjectTilBeriketSimuleringsresultat(),
-                                            BeriketSimuleringsresultatTilPGobjectConverter()
+                                            BeriketSimuleringsresultatTilPGobjectConverter(),
+                                            PGObjectTilFritekstbrevConverter(),
+                                            FritekstbrevTilPGObjectConverter()
         ))
     }
 
@@ -338,6 +341,24 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
     class BeriketSimuleringsresultatTilPGobjectConverter : Converter<BeriketSimuleringsresultat, PGobject> {
 
         override fun convert(simuleringsresultat: BeriketSimuleringsresultat): PGobject =
+                PGobject().apply {
+                    type = "json"
+                    value = objectMapper.writeValueAsString(simuleringsresultat)
+                }
+    }
+
+    @ReadingConverter
+    class PGObjectTilFritekstbrevConverter : Converter<PGobject, Fritekstbrev?> {
+
+        override fun convert(pGobject: PGobject): Fritekstbrev? {
+            return pGobject.value?.let { objectMapper.readValue(it) }
+        }
+    }
+
+    @WritingConverter
+    class FritekstbrevTilPGObjectConverter : Converter<Fritekstbrev, PGobject> {
+
+        override fun convert(simuleringsresultat: Fritekstbrev): PGobject =
                 PGobject().apply {
                     type = "json"
                     value = objectMapper.writeValueAsString(simuleringsresultat)

--- a/src/main/resources/db/migration/V69__mellomlagring_fritekstbrev.sql
+++ b/src/main/resources/db/migration/V69__mellomlagring_fritekstbrev.sql
@@ -1,0 +1,4 @@
+CREATE TABLE mellomlagret_fritekstbrev (
+    behandling_id UUID PRIMARY KEY REFERENCES behandling (id),
+    brev          JSON
+)

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk
 import no.nav.familie.ef.sak.blankett.Blankett
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
 import no.nav.familie.ef.sak.brev.domain.Vedtaksbrev
 import no.nav.familie.ef.sak.database.DbContainerInitializer
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
@@ -106,6 +107,7 @@ abstract class OppslagSpringRunnerTest {
                 Blankett::class,
                 Vedtak::class,
                 MellomlagretBrev::class,
+                MellomlagretFritekstbrev::class,
                 Behandlingsjournalpost::class,
                 Grunnlagsdata::class,
                 Tilbakekreving::class,

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepositoryTest.kt
@@ -1,0 +1,38 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.brev
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.brev.MellomlagerBrevRepository
+import no.nav.familie.ef.sak.brev.MellomlagerFritekstbrevRepository
+import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
+import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
+import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevAvsnitt
+import no.nav.familie.ef.sak.fagsak.FagsakRepository
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+internal class MellomlagerFritekstbrevRepositoryTest : OppslagSpringRunnerTest() {
+
+    @Autowired private lateinit var fagsakRepository: FagsakRepository
+    @Autowired private lateinit var behandlingRepository: BehandlingRepository
+    @Autowired private lateinit var mellomlagerFritekstbrevRepository: MellomlagerFritekstbrevRepository
+
+    @Test
+    internal fun `skal lagre mellomlagret brev`() {
+        val fagsak = fagsakRepository.insert(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val mellomlagretBrev = MellomlagretFritekstbrev(behandlingId = behandling.id,
+                                                        brev = Fritekstbrev(overskrift = "Et testbrev", avsnitt = listOf(
+                                                                FrittståendeBrevAvsnitt(deloverskrift = "En deloverskift",
+                                                                                        innhold = "Noe innhold"))))
+
+        mellomlagerFritekstbrevRepository.insert(mellomlagretBrev)
+
+        Assertions.assertThat(mellomlagerFritekstbrevRepository.findById(behandling.id))
+                .get().usingRecursiveComparison().isEqualTo(mellomlagretBrev)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/MellomlagringBrevServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.brev.MellomlagerBrevRepository
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
+import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevSanity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,7 +16,7 @@ import java.util.UUID
 internal class MellomlagringBrevServiceTest {
 
     private val mellomlagerBrevRepository = mockk<MellomlagerBrevRepository>()
-    private val mellomlagringBrevService = no.nav.familie.ef.sak.brev.MellomlagringBrevService(mellomlagerBrevRepository)
+    private val mellomlagringBrevService = no.nav.familie.ef.sak.brev.MellomlagringBrevService(mellomlagerBrevRepository, mockk())
 
 
     @Test
@@ -24,9 +25,9 @@ internal class MellomlagringBrevServiceTest {
         every { mellomlagerBrevRepository.findByIdOrNull(behandlingId) } returns mellomlagretBrev
 
         assertThat(mellomlagringBrevService.hentOgValiderMellomlagretBrev(behandlingId,
-                                                                          sanityVersjon)).usingRecursiveComparison()
-                .isEqualTo(mellomlagretBrev)
-
+                                                                          sanityVersjon))
+                .isEqualTo(MellomlagretBrevSanity(brevmal = mellomlagretBrev.brevmal,
+                                                  brevverdier = mellomlagretBrev.brevverdier))
     }
 
     @Test


### PR DESCRIPTION
Er nå to forskjellige endepunkt for mellomlagring av brev. Et for fritekstbrev og et for sanitybrev.

Men bruker fremdeles samme endepunkt for henting av mellomlagret brev. Det returnerer bl.a. en enum som er forskjellig for de to brevtypene.

