### PR TITLE
Legger til felt for å indikere om avsnitt skal skjules i brevbygger.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevDto.kt
@@ -9,6 +9,6 @@ data class FrittståendeBrevDto(val overskrift: String,
                                val stønadType: StønadType,
                                val brevType: FrittståendeBrevKategori)
 
-data class FrittståendeBrevAvsnitt(val deloverskrift: String, val innhold: String)
+data class FrittståendeBrevAvsnitt(val deloverskrift: String, val innhold: String, val skalSkjulesIBrevbygger: Boolean? = false)
 
 


### PR DESCRIPTION
Forhåndsutfylte avsnitt, f.eks. avslutningstekst i fritekstbrevet burde ikke vises i brevbyggeren.

Knyttet til https://github.com/navikt/familie-ef-sak-frontend/pull/621