### PR TITLE
Henter ut utflyttingsdato fra pdl som vi skal vise i personopplysning…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -83,9 +83,9 @@ class PersonopplysningerMapper(private val adresseMapper: AdresseMapper,
                 },
                 utflyttingFraNorge = søker.utflyttingFraNorge.map {
                     UtflyttingDto(it.tilflyttingsland?.let { land -> kodeverkService.hentLand(land, LocalDate.now()) },
-                                  null,
+                                  it.utflyttingsdato,
                                   it.tilflyttingsstedIUtlandet)
-                },
+                }.sortedByDescending { it.dato ?: LocalDate.MIN },
                 oppholdstillatelse = OppholdstillatelseMapper.map(søker.opphold),
                 vergemål = mapVergemål(søker)
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -285,6 +285,7 @@ data class InnflyttingTilNorge(val fraflyttingsland: String?,
 
 data class UtflyttingFraNorge(val tilflyttingsland: String?,
                               val tilflyttingsstedIUtlandet: String?,
+                              val utflyttingsdato: LocalDate?,
                               val folkeregistermetadata: Folkeregistermetadata)
 
 data class UtenlandskAdresse(val adressenavnNummer: String?,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
@@ -72,7 +72,7 @@ class MedlemskapMapper(private val statsborgerskapMapper: StatsborgerskapMapper,
                 UtflyttingDto(tilflyttingsland = utflytting.tilflyttingsland?.let {
                     kodeverkService.hentLand(it, LocalDate.now()) ?: it
                 },
-                              dato = null)
+                              dato = utflytting.utflyttingsdato)
             }
 
 }

--- a/src/main/resources/pdl/andreForeldre.graphql
+++ b/src/main/resources/pdl/andreForeldre.graphql
@@ -128,6 +128,7 @@ query($identer: [ID!]!){
             utflyttingFraNorge {
                 tilflyttingsland
                 tilflyttingsstedIUtlandet
+                utflyttingsdato
                 folkeregistermetadata {
                     gyldighetstidspunkt
                     opphoerstidspunkt

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -237,6 +237,7 @@ query($ident: ID!){
         utflyttingFraNorge {
             tilflyttingsland
             tilflyttingsstedIUtlandet
+            utflyttingsdato
             folkeregistermetadata {
                 gyldighetstidspunkt
                 opphoerstidspunkt

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -125,7 +125,10 @@ class PdlClientConfig {
                          telefonnummer = listOf(Telefonnummer(landskode = "+47", nummer = "98999923", prioritet = 1)),
                          tilrettelagtKommunikasjon = listOf(),
                          innflyttingTilNorge = listOf(InnflyttingTilNorge("SWE", "Stockholm", folkeregistermetadata)),
-                         utflyttingFraNorge = listOf(UtflyttingFraNorge("SWE", "Stockholm", folkeregistermetadata)),
+                         utflyttingFraNorge = listOf(UtflyttingFraNorge(tilflyttingsland = "SWE",
+                                                                        tilflyttingsstedIUtlandet = "Stockholm",
+                                                                        utflyttingsdato = LocalDate.of(2021, 1, 1),
+                                                                        folkeregistermetadata = folkeregistermetadata)),
                          vergemaalEllerFremtidsfullmakt = vergemaalEllerFremtidsfullmakt()
                 )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -58,7 +58,7 @@ object PdlTestdata {
 
     private val innflyttingTilNorge = listOf(InnflyttingTilNorge("", "", folkeregistermetadata))
 
-    private val utflyttingFraNorge = listOf(UtflyttingFraNorge("", "", folkeregistermetadata))
+    private val utflyttingFraNorge = listOf(UtflyttingFraNorge("", "", LocalDate.now(), folkeregistermetadata))
 
     val pdlSøkerData =
             PdlSøkerData(PdlSøker(adressebeskyttelse,

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -986,6 +986,11 @@
             "type" : "String",
             "nullable" : true
           },
+          "utflyttingsdato" : {
+            "name" : "utflyttingsdato",
+            "type" : "LocalDate",
+            "nullable" : true
+          },
           "folkeregistermetadata" : {
             "name" : "folkeregistermetadata",
             "type" : "Object",
@@ -1646,6 +1651,11 @@
           "tilflyttingsstedIUtlandet" : {
             "name" : "tilflyttingsstedIUtlandet",
             "type" : "String",
+            "nullable" : true
+          },
+          "utflyttingsdato" : {
+            "name" : "utflyttingsdato",
+            "type" : "LocalDate",
             "nullable" : true
           },
           "folkeregistermetadata" : {

--- a/src/test/resources/json/personopplysningerDto.json
+++ b/src/test/resources/json/personopplysningerDto.json
@@ -95,7 +95,7 @@
   } ],
   "utflyttingFraNorge" : [ {
     "tilflyttingsland" : "Sverige",
-    "dato" : null,
+    "dato" : "2021-01-01",
     "tilflyttingssted" : "Stockholm"
   } ],
   "oppholdstillatelse" : [ {


### PR DESCRIPTION
…er i frontend

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7176

Det er lagt til å hente datoet for annenForelder nå, blir sansynligvis en ny pr der vi fjerner utflytting og innflytting på annen forelder då disse ikke brukes