### PR TITLE
Trenger ikke å logge packagename for className ved feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
@@ -78,7 +78,8 @@ class ApiExceptionHandler {
             !it.className.contains("InsertUpdateRepositoryImpl")
         }
         if (firstElement != null) {
-            return "${firstElement.className}::${firstElement.methodName}(${firstElement.lineNumber})"
+            val className = firstElement.className.split(".").lastOrNull()
+            return "$className::${firstElement.methodName}(${firstElement.lineNumber})"
         }
         return e.cause?.let { finnMetodeSomFeiler(it) } ?: "(Ukjent metode som feiler)"
     }


### PR DESCRIPTION
Alternativt kan man logge packagename med første bokstaven i hver del, men tenker vi likevel har stacktrace i securelogs så det trengs ikke