### PR TITLE
Skal beholde kildeBehandlingId fra beregnYtelseSteg som håndter att m…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/tilkjentytelse/TilkjentYtelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilkjentytelse/TilkjentYtelseService.kt
@@ -25,9 +25,7 @@ class TilkjentYtelseService(private val behandlingService: BehandlingService,
     }
 
     fun opprettTilkjentYtelse(nyTilkjentYtelse: TilkjentYtelse): TilkjentYtelse {
-        val andelerMedGodtykkligKildeId =
-                nyTilkjentYtelse.andelerTilkjentYtelse.map { it.copy(kildeBehandlingId = nyTilkjentYtelse.behandlingId) }
-        return tilkjentYtelseRepository.insert(nyTilkjentYtelse.copy(andelerTilkjentYtelse = andelerMedGodtykkligKildeId))
+        return tilkjentYtelseRepository.insert(nyTilkjentYtelse)
     }
 
     fun harLøpendeUtbetaling(behandlingId: UUID): Boolean {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
@@ -1,0 +1,102 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.behandlingsflyt.steg
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.behandlingsflyt.steg.BeregnYtelseSteg
+import no.nav.familie.ef.sak.beregning.Inntekt
+import no.nav.familie.ef.sak.fagsak.FagsakRepository
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakpersoner
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
+import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
+import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+import java.time.YearMonth
+import java.util.UUID
+
+internal class BeregnYtelseStegIntegrationTest : OppslagSpringRunnerTest() {
+
+    @Autowired private lateinit var fagsakRepository: FagsakRepository
+    @Autowired private lateinit var behandlingRepository: BehandlingRepository
+    @Autowired private lateinit var beregnYtelseSteg: BeregnYtelseSteg
+    @Autowired private lateinit var tilkjentytelseRepository: TilkjentYtelseRepository
+
+    private val fagsak = fagsak(fagsakpersoner(setOf("1")))
+    private val behandling = behandling(fagsak)
+    private val behandling2 = behandling(fagsak, type = BehandlingType.REVURDERING, forrigeBehandlingId = behandling.id)
+
+    private val årMånedFra = YearMonth.of(2021, 1)
+    private val årMånedTil = YearMonth.of(2021, 3)
+
+    private val vedtaksperiode = opprettVedtaksperiode(årMånedFra, årMånedTil)
+    private val vedtaksperiode2 = opprettVedtaksperiode(årMånedTil, årMånedTil)
+
+    @Test
+    internal fun `kildeBehandlingId skal bli beholdr på andelen som ikke endrer seg`() {
+        opprettBehandlinger()
+        innvilg(behandling, listOf(vedtaksperiode))
+        settBehandlingTilIverksatt(behandling)
+        innvilg(behandling2, listOf(vedtaksperiode2), listOf(Inntekt(årMånedTil, BigDecimal.ZERO, BigDecimal(10_000))))
+        settBehandlingTilIverksatt(behandling2)
+
+        assertThat(hentAndeler(behandling.id)).hasSize(1)
+        val andeler = hentAndeler(behandling2.id)
+        assertThat(andeler).hasSize(2)
+        assertThat(andeler[0].kildeBehandlingId).isEqualTo(behandling.id)
+        assertThat(andeler[1].kildeBehandlingId).isEqualTo(behandling2.id)
+    }
+
+    @Test
+    internal fun `kildeBehandlingId skal bli endret når man skriver over hele perioden`() {
+        opprettBehandlinger()
+        innvilg(behandling, listOf(vedtaksperiode2))
+        settBehandlingTilIverksatt(behandling)
+        innvilg(behandling2, listOf(vedtaksperiode), listOf(Inntekt(årMånedFra, BigDecimal.ZERO, BigDecimal.ZERO),
+                                                            Inntekt(årMånedTil, BigDecimal.ZERO, BigDecimal(10_000))))
+        settBehandlingTilIverksatt(behandling2)
+
+        assertThat(hentAndeler(behandling.id)).hasSize(1)
+        val andeler = hentAndeler(behandling2.id)
+        assertThat(andeler).hasSize(2)
+        assertThat(andeler[0].kildeBehandlingId).isEqualTo(behandling2.id)
+        assertThat(andeler[1].kildeBehandlingId).isEqualTo(behandling2.id)
+    }
+
+    fun settBehandlingTilIverksatt(behandling: Behandling) {
+        behandlingRepository.update(behandling.copy(status = BehandlingStatus.FERDIGSTILT,
+                                                    resultat = BehandlingResultat.INNVILGET))
+    }
+
+    private fun hentAndeler(behandlingId: UUID): List<AndelTilkjentYtelse> =
+            tilkjentytelseRepository.findByBehandlingId(behandlingId)!!.andelerTilkjentYtelse.sortedBy { it.stønadFom }
+
+    private fun opprettVedtaksperiode(fra: YearMonth, til: YearMonth) =
+            VedtaksperiodeDto(fra, til, AktivitetType.BARNET_ER_SYKT, VedtaksperiodeType.PERIODE_FØR_FØDSEL)
+
+    private fun innvilg(behandling: Behandling,
+                        vedtaksperioder: List<VedtaksperiodeDto>,
+                        inntekter: List<Inntekt> = listOf(Inntekt(vedtaksperioder.first().årMånedFra, null, null))) {
+        val vedtak = Innvilget(perioder = vedtaksperioder,
+                               inntekter = inntekter,
+                               periodeBegrunnelse = null,
+                               inntektBegrunnelse = null)
+        beregnYtelseSteg.utførSteg(behandling, vedtak)
+    }
+
+    fun opprettBehandlinger() {
+        fagsakRepository.insert(fagsak)
+        behandlingRepository.insert(behandling)
+        behandlingRepository.insert(behandling2)
+    }
+}


### PR DESCRIPTION
…an beholder kildeBehandlingId hvis man endrer på perioden fra ett gitt dato.

Bakåtkompatibel? 
* Det finnes 2 revurderinger i prod idag
* Revurdering 1, er en revurdering på en avslått behandling
* Revurdering 2 er en revurdering som endrer på periodene fra start og setter kildeBehandlingId til siste behandlingen

Sånn att statet er riktig i prod, sånn som det allerede er. 