### PR TITLE
finnSisteBehandlingSomIkkeErBlankett returnerer en behandling for fag…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTask.kt
@@ -36,10 +36,7 @@ class StartBehandlingTask(private val iverksettClient: IverksettClient,
     }
 
     private fun finnesEnIverksattBehandlingFor(fagsak: Fagsak) =
-            behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(
-                    fagsak.stønadstype,
-                    fagsak.søkerIdenter.map { it.ident }.toSet()
-            ) != null
+            behandlingRepository.finnSisteIverksatteBehandling(fagsak.id) != null
 
     companion object {
 

--- a/src/main/resources/db/migration/V73__rekjør_start_behandling.sql
+++ b/src/main/resources/db/migration/V73__rekjør_start_behandling.sql
@@ -2,4 +2,4 @@ UPDATE task t
 SET status= 'KLAR_TIL_PLUKK'
 WHERE type = 'startBehandlingTask'
   AND status = 'FERDIG'
-  AND EXISTS(SELECT * FROM behandling WHERE id = t.payload AND status = 'FERDIGSTILT');
+  AND EXISTS(SELECT * FROM behandling WHERE id = t.payload::UUID AND status = 'FERDIGSTILT');

--- a/src/main/resources/db/migration/V73__rekjør_start_behandling.sql
+++ b/src/main/resources/db/migration/V73__rekjør_start_behandling.sql
@@ -1,0 +1,5 @@
+UPDATE task t
+SET status= 'KLAR_TIL_PLUKK'
+WHERE type = 'startBehandlingTask'
+  AND status = 'FERDIG'
+  AND EXISTS(SELECT * FROM behandling WHERE id = t.payload AND status = 'FERDIGSTILT');


### PR DESCRIPTION
…saken, som alltid returnerer true, og av den grunnen blir klienten aldri kallet på.

Vi sjekker nå hvis det finnes en tidligere iverksatt behandling for fagsaken

Vi har ca 200 behandlinger i prod idag
Det er idag bare sendt 1 start-behandling til infotrygd. samtidig som vi sendt ca 100 fattet vedtak. Så det mangler ca 100st som ikke er låste.
Vi trenger ikke å låse de som allerede er fattet vedtak for - då de allerede burde være låste