### PR TITLE
Må rekjøre start-behandling for behandlinger som ikke er iverksatte. …

### DIFF
--- a/src/main/resources/db/migration/V74__rekjør_start_behandling_2.sql
+++ b/src/main/resources/db/migration/V74__rekjør_start_behandling_2.sql
@@ -1,0 +1,5 @@
+UPDATE task t
+SET status= 'KLAR_TIL_PLUKK'
+WHERE type = 'startBehandlingTask'
+  AND status = 'FERDIG'
+  AND NOT EXISTS(SELECT * FROM behandling WHERE id = t.payload::UUID AND status = 'FERDIGSTILT');


### PR DESCRIPTION
…Forrige query var feil då den tok å rekjørte alle som var iverksatte

Tasken har en sjekk på att det ikke finnes noen iverksatt på fagsaken, så forrige kjøring lage ingen start-behandling då alle de allerede var iverksatte