### PR TITLE
Flytter cache for personopplysninger.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlAnnenForelde
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonKort
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
 
@@ -21,7 +20,6 @@ class GrunnlagsdataRegisterService(private val pdlClient: PdlClient,
                                    private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
                                    private val infotrygdService: InfotrygdService) {
 
-    @Cacheable("registergrunnlag", cacheManager = "shortCache")
     fun hentGrunnlagsdataFraRegister(personIdent: String,
                                      barneforeldreFraSøknad: List<String>): GrunnlagsdataDomene {
         val pdlSøker = pdlClient.hentSøker(personIdent)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -41,6 +41,7 @@ class PersonopplysningerService(private val personService: PersonService,
         )
     }
 
+    @Cacheable("personopplysninger", cacheManager = "shortCache")
     fun hentPersonopplysninger(personIdent: String): PersonopplysningerDto {
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdataFraRegister(personIdent, emptyList())
         val egenAnsatt = egenAnsatt(personIdent)


### PR DESCRIPTION
Når vi oppdaterer vilkår med registergrunnlag må vi hente de på nytt, uten å bruke cacheade verdier.
Når vi henter personopplysinger til fagsak-siden så brukes cache sånn att vi ikke henter de unødvendig mange ganger

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7604