### PR TITLE
Skal ikke returnere registrerte arbeidssøkere. Saksbehandlere trenger…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepository.kt
@@ -12,7 +12,7 @@ import java.util.UUID
 interface UttrekkArbeidssøkerRepository : RepositoryInterface<UttrekkArbeidssøkere, UUID>,
                                           InsertUpdateRepository<UttrekkArbeidssøkere> {
 
-    fun findAllByÅrMåned(årMåned: YearMonth): List<UttrekkArbeidssøkere>
+    fun findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned: YearMonth): List<UttrekkArbeidssøkere>
 
     // language=PostgreSQL
     @Query("""

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -45,6 +45,7 @@ class UttrekkArbeidssøkerService(
     }
 
     fun settKontrollert(id: UUID, kontrollert: Boolean): UttrekkArbeidssøkerDto {
+        tilgangService.validerHarSaksbehandlerrolle()
         val uttrekkArbeidssøkere = uttrekkArbeidssøkerRepository.findByIdOrThrow(id)
         tilgangService.validerTilgangTilFagsak(uttrekkArbeidssøkere.fagsakId)
 
@@ -58,7 +59,8 @@ class UttrekkArbeidssøkerService(
 
     fun hentUttrekkArbeidssøkere(årMåned: YearMonth = forrigeMåned().invoke(),
                                  visKontrollerte: Boolean = false): UttrekkArbeidssøkereDto {
-        val arbeidssøkere = uttrekkArbeidssøkerRepository.findAllByÅrMåned(årMåned)
+        tilgangService.validerHarSaksbehandlerrolle()
+        val arbeidssøkere = uttrekkArbeidssøkerRepository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned)
         val filtrerteArbeidsssøkere = mapTilDtoOgFiltrer(arbeidssøkere)
 
         val totaltAntallUkontrollerte = arbeidssøkere.count { !it.kontrollert }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepositoryTest.kt
@@ -19,7 +19,6 @@ internal class UttrekkArbeidssøkerRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired private lateinit var repository: UttrekkArbeidssøkerRepository
 
     private val årMåned = YearMonth.of(2021, 1)
-    private val sort = Sort.by("id")
 
     @BeforeEach
     internal fun setUp() {
@@ -28,22 +27,30 @@ internal class UttrekkArbeidssøkerRepositoryTest : OppslagSpringRunnerTest() {
         for (i in 1..10) {
             repository.insert(UttrekkArbeidssøkere(fagsakId = fagsak.id,
                                                    vedtakId = behandling.id,
-                                                   årMåned = årMåned))
+                                                   årMåned = årMåned,
+                                                   registrertArbeidssøker = false))
         }
 
         for (i in 1..5) {
             repository.insert(UttrekkArbeidssøkere(fagsakId = fagsak.id,
                                                    vedtakId = behandling.id,
                                                    årMåned = årMåned.plusMonths(1),
-                                                   kontrollert = true))
+                                                   kontrollert = true,
+                                                   registrertArbeidssøker = false))
+        }
+        for (i in 1..2) {
+            repository.insert(UttrekkArbeidssøkere(fagsakId = fagsak.id,
+                                                   vedtakId = behandling.id,
+                                                   årMåned = årMåned.plusMonths(1),
+                                                   registrertArbeidssøker = true))
         }
     }
 
     @Test
     internal fun `skal hente uttrekk for gitt måned`() {
-        assertThat(repository.findAllByÅrMåned(årMåned.minusMonths(1))).isEmpty()
-        assertThat(repository.findAllByÅrMåned(årMåned)).hasSize(10)
-        assertThat(repository.findAllByÅrMåned(årMåned.plusMonths(1))).hasSize(5)
-        assertThat(repository.findAllByÅrMåned(årMåned.plusMonths(2))).isEmpty()
+        assertThat(repository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned.minusMonths(1))).isEmpty()
+        assertThat(repository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned)).hasSize(10)
+        assertThat(repository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned.plusMonths(1))).hasSize(5)
+        assertThat(repository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned.plusMonths(2))).isEmpty()
     }
 }


### PR DESCRIPTION
… kun å kontrollere de som ikke er registrerte. Lagt til sjekk att man må ha minimum saksbehandlertilgang for å hente uttrekk og sette til kontrollert.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7628

Denne kan merges etter att uttrekket for desember/januar er kontrollert. 