### PR TITLE
Lagt til ekstern id for oversending til dhv.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>1.20211202083100_64f46dd</felles.version>
         <prosessering.version>1.20211125150647_a7c6f64</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20220105105400_27e0fb4</kontrakter.version>
+        <kontrakter.version>2.0_20220105124543_5666f57</kontrakter.version>
 
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
@@ -62,12 +62,15 @@ class BehandlingsstatistikkTask(private val iverksettClient: IverksettClient,
         val resultatBegrunnelse = finnResultatBegrunnelse(hendelse, vedtak)
         val søker = grunnlagsdataService.hentGrunnlagsdata(behandlingId).grunnlagsdata.søker
         val henvendelseTidspunkt = finnHenvendelsestidspunkt(behandling)
+        val relatertEksternBehandlingId =
+                behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it).eksternId.id }
 
         val behandlingsstatistikkDto = BehandlingsstatistikkDto(
                 behandlingId = behandlingId,
+                eksternBehandlingId = behandling.eksternId.id,
                 personIdent = personIdent,
                 gjeldendeSaksbehandlerId = finnSaksbehandler(hendelse, vedtak, gjeldendeSaksbehandler),
-                eksternFagsakId = fagsak.eksternId.id.toString(),
+                eksternFagsakId = fagsak.eksternId.id,
                 hendelseTidspunkt = hendelseTidspunkt.atZone(zoneIdOslo),
                 behandlingOpprettetTidspunkt = behandling.sporbar.opprettetTid.atZone(zoneIdOslo),
                 hendelse = hendelse,
@@ -79,7 +82,8 @@ class BehandlingsstatistikkTask(private val iverksettClient: IverksettClient,
                 stønadstype = StønadType.valueOf(fagsak.stønadstype.name),
                 behandlingstype = BehandlingType.valueOf(behandling.type.name),
                 henvendelseTidspunkt = henvendelseTidspunkt.atZone(zoneIdOslo),
-                relatertBehandlingId = behandling.forrigeBehandlingId
+                relatertEksternBehandlingId = relatertEksternBehandlingId,
+                relatertBehandlingId = null
         )
 
         iverksettClient.sendBehandlingsstatistikk(behandlingsstatistikkDto)


### PR DESCRIPTION
Sender ekstern Id til iverksett for å kunne sende denne til dvh. Vi er ikke konsistente i Id-bruk mot dvh, og må sørge for at alle id-er er de eksterne.