### PR TITLE
Må få med inntektsgrunnlag i SummertInfotrygdPeriode for å kunne bruk…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPerioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPerioderDto.kt
@@ -4,30 +4,32 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
 import java.time.LocalDate
 
 data class InfotrygdPerioderDto(
-        val overgangsstønad: InfotrygdPerioder,
-        val barnetilsyn: InfotrygdPerioder,
-        val skolepenger: InfotrygdPerioder
+        val overgangsstønad: InfotrygdStønadPerioderDto,
+        val barnetilsyn: InfotrygdStønadPerioderDto,
+        val skolepenger: InfotrygdStønadPerioderDto
 )
 
-data class InfotrygdPerioder(
+data class InfotrygdStønadPerioderDto(
         val perioder: List<InfotrygdPeriode>,
-        val summert: List<SummertInfotrygdPeriode>
+        val summert: List<SummertInfotrygdPeriodeDto>
 )
 
-data class SummertInfotrygdPeriode(
+data class SummertInfotrygdPeriodeDto(
         val stønadFom: LocalDate,
         val stønadTom: LocalDate,
         val opphørsdato: LocalDate?,
+        val inntektsgrunnlag: Int,
         val inntektsreduksjon: Int,
         val samordningsfradrag: Int,
         val beløp: Int
 )
 
-fun InternPeriode.tilSummertInfotrygdperiodeDto(): SummertInfotrygdPeriode =
-        SummertInfotrygdPeriode(
+fun InfotrygdPeriode.tilSummertInfotrygdperiodeDto(): SummertInfotrygdPeriodeDto =
+        SummertInfotrygdPeriodeDto(
                 stønadFom = this.stønadFom,
                 stønadTom = this.stønadTom,
                 opphørsdato = this.opphørsdato,
+                inntektsgrunnlag = this.inntektsgrunnlag,
                 inntektsreduksjon = this.inntektsreduksjon,
                 samordningsfradrag = this.samordningsfradrag,
                 beløp = this.beløp

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -47,15 +47,15 @@ class InfotrygdService(private val infotrygdReplikaClient: InfotrygdReplikaClien
     /**
      * Filtrerer og slår sammen perioder fra infotrygd for å få en bedre totalbilde om hva som er gjeldende
      */
-    fun hentSummertePerioder(personIdenter: Set<String>): InternePerioder {
+    fun hentSammenslåttePerioderSomInternPerioder(personIdenter: Set<String>): InternePerioder {
         val perioder = hentPerioderFraReplika(personIdenter)
-        return InternePerioder(overgangsstønad = filtrerOgSlåSammenPerioder(perioder.overgangsstønad),
-                               barnetilsyn = filtrerOgSlåSammenPerioder(perioder.barnetilsyn),
-                               skolepenger = filtrerOgSlåSammenPerioder(perioder.skolepenger))
+        return InternePerioder(overgangsstønad = filtrerOgSlåSammenPerioder(perioder.overgangsstønad).map { it.tilInternPeriode() },
+                               barnetilsyn = filtrerOgSlåSammenPerioder(perioder.barnetilsyn).map { it.tilInternPeriode() },
+                               skolepenger = filtrerOgSlåSammenPerioder(perioder.skolepenger).map { it.tilInternPeriode() })
     }
 
     private fun mapPerioder(perioder: List<InfotrygdPeriode>) =
-            InfotrygdPerioder(perioder, filtrerOgSlåSammenPerioder(perioder).map { it.tilSummertInfotrygdperiodeDto() })
+            InfotrygdStønadPerioderDto(perioder, filtrerOgSlåSammenPerioder(perioder).map { it.tilSummertInfotrygdperiodeDto() })
 
     private fun hentPerioderFraReplika(identer: Set<String>,
                                        stønadstyper: Set<StønadType> = StønadType.values().toSet()): InfotrygdPeriodeResponse {
@@ -64,7 +64,7 @@ class InfotrygdService(private val infotrygdReplikaClient: InfotrygdReplikaClien
         return infotrygdReplikaClient.hentPerioder(request)
     }
 
-    private fun filtrerOgSlåSammenPerioder(perioder: List<InfotrygdPeriode>): List<InternPeriode> {
+    private fun filtrerOgSlåSammenPerioder(perioder: List<InfotrygdPeriode>): List<InfotrygdPeriode> {
         val filtrertPerioder = InfotrygdPeriodeUtil.filtrerOgSorterPerioderFraInfotrygd(perioder)
                 .filter { it.kode != InfotrygdEndringKode.ANNULERT && it.kode != InfotrygdEndringKode.UAKTUELL }
         return InfotrygdPeriodeUtil.slåSammenInfotrygdperioder(filtrertPerioder)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriode.kt
@@ -1,7 +1,5 @@
 package no.nav.familie.ef.sak.infotrygd
 
-import no.nav.familie.ef.sak.felles.util.isEqualOrAfter
-import no.nav.familie.ef.sak.felles.util.isEqualOrBefore
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import java.time.LocalDate
 
@@ -24,18 +22,6 @@ data class InternPeriode(
         val opphørsdato: LocalDate?,
         val datakilde: PeriodeOvergangsstønad.Datakilde
 ) {
-
-    private fun erDatoInnenforPeriode(dato: LocalDate): Boolean {
-        return dato.isEqualOrBefore(stønadTom) && dato.isEqualOrAfter(stønadFom)
-    }
-
-    fun erPeriodeOverlappende(periode: InternPeriode): Boolean {
-        return (erDatoInnenforPeriode(periode.stønadFom) || erDatoInnenforPeriode(periode.stønadTom))
-               || omslutter(periode)
-    }
-
-    private fun omslutter(periode: InternPeriode) =
-            periode.stønadFom.isBefore(stønadFom) && periode.stønadTom.isAfter(stønadTom)
 
     fun erFullOvergangsstønad(): Boolean = this.inntektsreduksjon == 0 && this.samordningsfradrag == 0
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
@@ -23,7 +23,7 @@ class PeriodeService(
 
     fun hentPerioderForOvergangsstønadFraEfOgInfotrygd(personIdent: String): List<InternPeriode> {
         val personIdenter = pdlClient.hentPersonidenter(personIdent, true).identer()
-        val perioderFraReplika = infotrygdService.hentSummertePerioder(personIdenter).overgangsstønad
+        val perioderFraReplika = infotrygdService.hentSammenslåttePerioderSomInternPerioder(personIdenter).overgangsstønad
         val perioderFraEf = hentPerioderForOvergangsstønadFraEf(personIdenter)
 
         return InternPeriodeUtil.slåSammenPerioder(perioderFraEf, perioderFraReplika)

--- a/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPeriodeTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPeriodeTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.infotrygd
 
+import no.nav.familie.ef.sak.infotrygd.InfotrygdPeriodeUtil.erPeriodeOverlappende
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -20,58 +21,58 @@ internal class InfotrygdPeriodeTest {
 
     }
 
-    private val startperiode = lagInternPeriode(FOM, TOM)
+    private val startperiode = lagPeriode(FOM, TOM)
 
     @Test
     internal fun `erInfotrygdPeriodeOverlappende - ikke overlappende`() {
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FØR_STARTDATO_FOM, FØR_STARTDATO_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FØR_STARTDATO_FOM, FØR_STARTDATO_TOM)))
                 .withFailMessage("Perioden starter og slutter før startperioden")
                 .isFalse
 
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(ETTER_SLUTDATO_FOM, ETTER_SLUTTDATO_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(ETTER_SLUTDATO_FOM, ETTER_SLUTTDATO_TOM)))
                 .withFailMessage("Perioden starter og slutter etter startperioden")
                 .isFalse
     }
 
     @Test
     internal fun `erInfotrygdPeriodeOverlappende - overlappende startdato starter før`() {
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FØR_STARTDATO_FOM, MIDT_I_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FØR_STARTDATO_FOM, MIDT_I_TOM)))
                 .withFailMessage("Perioden starter før og slutter midt i")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FØR_STARTDATO_FOM, TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FØR_STARTDATO_FOM, TOM)))
                 .withFailMessage("Perioden starter før og slutter samtidig")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FØR_STARTDATO_FOM, ETTER_SLUTTDATO_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FØR_STARTDATO_FOM, ETTER_SLUTTDATO_TOM)))
                 .withFailMessage("Perioden starter før og slutter etter")
                 .isTrue
     }
 
     @Test
     internal fun `erInfotrygdPeriodeOverlappende - overlappende startdato starter samtidig`() {
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FOM, MIDT_I_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FOM, MIDT_I_TOM)))
                 .withFailMessage("Perioden starter samtidig og slutter midt i")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FOM, TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FOM, TOM)))
                 .withFailMessage("Perioden starter og slutter samtidig")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(FOM, ETTER_SLUTTDATO_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(FOM, ETTER_SLUTTDATO_TOM)))
                 .withFailMessage("Perioden starter og slutter etter")
                 .isTrue
     }
 
     @Test
     internal fun `erInfotrygdPeriodeOverlappende - overlappende startdato starter midt i`() {
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(MIDT_I_FOM, MIDT_I_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(MIDT_I_FOM, MIDT_I_TOM)))
                 .withFailMessage("Perioden starter midt i og slutter midt i")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(MIDT_I_FOM, TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(MIDT_I_FOM, TOM)))
                 .withFailMessage("Perioden starter midt i og slutter samtidig")
                 .isTrue
-        assertThat(startperiode.erPeriodeOverlappende(lagInternPeriode(MIDT_I_FOM, ETTER_SLUTTDATO_TOM)))
+        assertThat(startperiode.erPeriodeOverlappende(lagPeriode(MIDT_I_FOM, ETTER_SLUTTDATO_TOM)))
                 .withFailMessage("Perioden starter midt i og slutter etter")
                 .isTrue
     }
 
-    private fun lagInternPeriode(fom: LocalDate, tom: LocalDate) =
-            InternPeriodeTestUtil.lagInternPeriode(stønadFom = fom, stønadTom = tom)
+    private fun lagPeriode(fom: LocalDate, tom: LocalDate) =
+            InfotrygdPeriodeTestUtil.lagInfotrygdPeriode(stønadFom = fom, stønadTom = tom)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPeriodeUtilCsvTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdPeriodeUtilCsvTest.kt
@@ -97,7 +97,7 @@ internal class InfotrygdPeriodeUtilCsvTest {
     fun lagPerioder(perioder: List<InfotrygdPeriode>): List<InternPeriode> {
         val filtrertPerioder = InfotrygdPeriodeUtil.filtrerOgSorterPerioderFraInfotrygd(perioder)
 
-        return InfotrygdPeriodeUtil.slåSammenInfotrygdperioder(filtrertPerioder)
+        return InfotrygdPeriodeUtil.slåSammenInfotrygdperioder(filtrertPerioder).map { it.tilInternPeriode() }
     }
 
     private fun parseFil(fil: String) = InfotrygdPeriodeParser.parse(this::class.java.classLoader.getResource(fil)!!)


### PR DESCRIPTION
…e til beregning av nye perioder og avstemming mot infotrygd.

Endrer om sånn att InfotrygdPeriodeUtil forholder seg til InfotrygdPeriode og ikke InternPeriode, men att den mappingen gjøres i servicen i stedet. Får då enklere returnert inntektsgrunnlag til frontend.

Koblet til migrering https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7649