### PR TITLE
Migrering sjekk opphørt i infotrygd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/MigreringService.kt
@@ -176,7 +176,7 @@ class MigreringService(
         }
         val periode = gjeldendePerioder.single()
         if (periode.opphørsdato != null) { // Håndterer ikke denne nå
-            throw MigreringException("Har opphørsdatp (${periode.opphørsdato}) i perioden")
+            throw MigreringException("Har opphørsdato (${periode.opphørsdato}) i perioden")
         }
         return periode
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VentePåStatusFraIverksett.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VentePåStatusFraIverksett.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.behandlingsflyt.steg
 
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandlingsflyt.task.LagSaksbehandlingsblankettTask
-import no.nav.familie.ef.sak.behandlingsflyt.task.SjekkMigrertStatusIInfotrygdTask
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.kontrakter.ef.iverksett.IverksettStatus
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -15,17 +14,12 @@ class VentePåStatusFraIverksett(private val iverksettClient: IverksettClient,
 
     override fun utførSteg(behandling: Behandling, data: Void?) {
         iverksettClient.hentStatus(behandling.id).let {
-            val erMigrertOgOk = behandling.erMigrering() && it == IverksettStatus.OK_MOT_OPPDRAG
             when {
-                erMigrertOgOk -> opprettSjekkMigrertStatusIInfotrygdTask(behandling)
+                behandling.erMigrering() && it == IverksettStatus.OK_MOT_OPPDRAG -> opprettLagSaksbehandlingsblankettTask(behandling)
                 it == IverksettStatus.OK -> opprettLagSaksbehandlingsblankettTask(behandling)
                 else -> throw TaskExceptionUtenStackTrace("Mottok status $it fra iverksett for behandlingId=${behandling.id}")
             }
         }
-    }
-
-    fun opprettSjekkMigrertStatusIInfotrygdTask(behandling: Behandling) {
-        taskRepository.save(SjekkMigrertStatusIInfotrygdTask.opprettTask(behandling.id))
     }
 
     fun opprettLagSaksbehandlingsblankettTask(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VentePåStatusFraIverksett.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VentePåStatusFraIverksett.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.behandlingsflyt.steg
 
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandlingsflyt.task.LagSaksbehandlingsblankettTask
+import no.nav.familie.ef.sak.behandlingsflyt.task.SjekkMigrertStatusIInfotrygdTask
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.kontrakter.ef.iverksett.IverksettStatus
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -14,12 +15,17 @@ class VentePåStatusFraIverksett(private val iverksettClient: IverksettClient,
 
     override fun utførSteg(behandling: Behandling, data: Void?) {
         iverksettClient.hentStatus(behandling.id).let {
+            val erMigrertOgOk = behandling.erMigrering() && it == IverksettStatus.OK_MOT_OPPDRAG
             when {
-                behandling.erMigrering() && it == IverksettStatus.OK_MOT_OPPDRAG -> opprettLagSaksbehandlingsblankettTask(behandling)
+                erMigrertOgOk -> opprettSjekkMigrertStatusIInfotrygdTask(behandling)
                 it == IverksettStatus.OK -> opprettLagSaksbehandlingsblankettTask(behandling)
                 else -> throw TaskExceptionUtenStackTrace("Mottok status $it fra iverksett for behandlingId=${behandling.id}")
             }
         }
+    }
+
+    fun opprettSjekkMigrertStatusIInfotrygdTask(behandling: Behandling) {
+        taskRepository.save(SjekkMigrertStatusIInfotrygdTask.opprettTask(behandling.id))
     }
 
     fun opprettLagSaksbehandlingsblankettTask(behandling: Behandling) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/SjekkMigrertStatusIInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/SjekkMigrertStatusIInfotrygdTask.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ef.sak.behandlingsflyt.task
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.behandling.MigreringService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.domene.TaskRepository
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.YearMonth
+import java.util.Properties
+import java.util.UUID
+
+/**
+ * Brukes som ett mellomsteg før LagSaksbehandlingsblankettTask for å sjekke att personen har blitt opphørt i Infotrygd
+ * Kjører i 16 min før den settes til feilet
+ */
+@Service
+@TaskStepBeskrivelse(taskStepType = SjekkMigrertStatusIInfotrygdTask.TYPE,
+                     maxAntallFeil = 7,
+                     settTilManuellOppfølgning = true,
+                     triggerTidVedFeilISekunder = 120L,
+                     beskrivelse = "Sjekker status for migrert sak")
+
+class SjekkMigrertStatusIInfotrygdTask(private val taskRepository: TaskRepository,
+                                       private val migreringService: MigreringService) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        val (behandlingId, kjøremåned) = objectMapper.readValue<SjekkMigrertStatusIInfotrygdData>(task.payload)
+
+        if (migreringService.erOpphørtIInfotrygd(behandlingId, kjøremåned)) {
+            taskRepository.save(LagSaksbehandlingsblankettTask.opprettTask(behandlingId))
+        } else {
+            throw TaskExceptionUtenStackTrace("Er ikke opphørt i infotrygd")
+        }
+    }
+
+    companion object {
+
+        fun opprettTask(behandlingId: UUID): Task =
+                Task(type = TYPE,
+                     payload = objectMapper.writeValueAsString(SjekkMigrertStatusIInfotrygdData(behandlingId, YearMonth.now())),
+                     properties = Properties().apply {
+                         this["behandlingId"] = behandlingId.toString()
+                     }).copy(triggerTid = LocalDateTime.now().plusMinutes(2))
+
+
+        const val TYPE = "sjekkMigrertStatus"
+    }
+
+    data class SjekkMigrertStatusIInfotrygdData(val behandlingId: UUID, val kjøremåned: YearMonth)
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/SjekkMigrertStatusIInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/SjekkMigrertStatusIInfotrygdTask.kt
@@ -6,7 +6,6 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import no.nav.familie.prosessering.domene.TaskRepository
 import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
@@ -317,10 +317,10 @@ internal class MigreringServiceTest : OppslagSpringRunnerTest() {
 
     private fun kjørTasks(erMigrering: Boolean = true) {
         listOfNotNull(PollStatusFraIverksettTask.TYPE,
-                      if (erMigrering) SjekkMigrertStatusIInfotrygdTask.TYPE else null,
                       LagSaksbehandlingsblankettTask.TYPE,
                       FerdigstillBehandlingTask.TYPE,
-                      PubliserVedtakshendelseTask.TYPE).forEach { type ->
+                      PubliserVedtakshendelseTask.TYPE,
+                      if (erMigrering) SjekkMigrertStatusIInfotrygdTask.TYPE else null).forEach { type ->
             try {
                 val task = taskRepository.findAll()
                         .filter { it.status == Status.KLAR_TIL_PLUKK || it.status == Status.UBEHANDLET }


### PR DESCRIPTION
Oppretter en task som kjøres uavhengig av selve "behandlings-flytet", men som verifiserer att behandlinger er markert som opphørt i Infotrygd.