### PR TITLE
Bruker TestoppsettService for å opprette fagsak. Den kommer senere op…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdat
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søknad
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
 import no.nav.familie.ef.sak.simulering.Simuleringsresultat
+import no.nav.familie.ef.sak.testutil.TestoppsettService
 import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekreving
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
@@ -77,6 +78,7 @@ abstract class OppslagSpringRunnerTest {
     @Autowired @Qualifier("kodeverkCache") private lateinit var cacheManagerKodeverk: CacheManager
     @Autowired private lateinit var rolleConfig: RolleConfig
     @Autowired private lateinit var mockOAuth2Server: MockOAuth2Server
+    @Autowired lateinit var testoppsettService: TestoppsettService
 
     @LocalServerPort
     private var port: Int? = 0

--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/AMeldingInntektControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/AMeldingInntektControllerTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.amelding
 import io.mockk.verify
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.amelding.ekstern.AMeldingInntektClient
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -21,7 +20,6 @@ import java.util.UUID
 
 internal class AMeldingInntektControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var aMeldingInntektClient: AMeldingInntektClient
 
     private val fagsak = fagsak(identer = fagsakpersoner(setOf("1")))
@@ -29,7 +27,7 @@ internal class AMeldingInntektControllerTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(lokalTestToken)
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingControllerTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.dto.BehandlingDto
 import no.nav.familie.ef.sak.behandling.dto.HenlagtDto
 import no.nav.familie.ef.sak.behandling.dto.HenlagtÅrsak
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -25,7 +24,6 @@ import java.util.UUID
 
 internal class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @BeforeEach
@@ -35,7 +33,7 @@ internal class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal returnere 200 OK med status IKKE_TILGANG dersom man ikke har tilgang til brukeren`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val respons = hentBehandling(behandling.id)
 
@@ -46,7 +44,7 @@ internal class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal henlegge behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("12345678901"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("12345678901"))))
         val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.BLANKETT))
         val respons = henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.BEHANDLES_I_GOSYS))
 
@@ -56,7 +54,7 @@ internal class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal ikke være mulig å henlegge blankett med annet enn BEHANDLES_I_GOSYS`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("12345678901"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("12345678901"))))
         val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.BLANKETT))
         val respons = henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT))
 
@@ -66,7 +64,7 @@ internal class BehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal henlegge FØRSTEGANGSBEHANDLING`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("12345678901"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("12345678901"))))
         val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.FØRSTEGANGSBEHANDLING))
         val respons = henlegg(behandling.id, HenlagtDto(årsak = HenlagtÅrsak.FEILREGISTRERT))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingshistorikkControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BehandlingshistorikkControllerTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.StegUtfall
 import no.nav.familie.ef.sak.behandlingshistorikk.dto.BehandlingshistorikkDto
 import no.nav.familie.ef.sak.behandlingshistorikk.dto.HendelseshistorikkDto
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.felles.domain.JsonWrapper
 import no.nav.familie.ef.sak.repository.behandling
@@ -31,7 +30,6 @@ import java.util.UUID
 
 internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var behandlingshistorikkRepository: BehandlingshistorikkRepository
 
@@ -42,7 +40,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal returnere 200 OK med status IKKE_TILGANG dersom man ikke har tilgang til brukeren`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val respons = hentHistorikk(behandling.id)
 
@@ -53,7 +51,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal kun returnere den første hendelsen av typen OPPRETTET - etterfølgende hendelser av denne typen skal lukes vekk`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
@@ -66,7 +64,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal returnere hendelser av alle typer i riktig rekkefølge for invilget behandling `() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
@@ -89,7 +87,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal returnere hendelser av alle typer i riktig rekkefølge for henlagt behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
@@ -109,7 +107,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal returnere alle hendelser dersom en behandling blir underkjent i totrinnskontroll, deretter sendt til beslutter på nytt og deretter godkjent`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         leggInnHistorikk(behandling, "1", LocalDateTime.now(), StegType.VILKÅR)
@@ -133,7 +131,7 @@ internal class BehandlingshistorikkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal returnere metadata som json`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val jsonMap = mapOf("key" to "value")

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BlankettControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/BlankettControllerTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.api.gui
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.repository.behandling
@@ -22,7 +21,6 @@ import java.util.UUID
 
 class BlankettControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var oppgaveRepository: OppgaveRepository
 
@@ -45,7 +43,7 @@ class BlankettControllerTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `Oppgave finnes allerede i db returner eksisterende bahandlingsid`() {
 
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val oppgave = oppgaveRepository.insert(oppgave(behandling, false))
         val respons: ResponseEntity<Ressurs<UUID>> = opprettBlankettBehandling(oppgave.gsakOppgaveId)

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/FagsakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/FagsakControllerTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.api.gui
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.FagsakRequest
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
@@ -24,7 +23,6 @@ import java.util.UUID
 
 internal class FagsakControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @BeforeEach
@@ -51,7 +49,7 @@ internal class FagsakControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Gitt fagsak med behandlinger finnes når get fagsak endpoint kalles skal det returneres 200 OK med fagsakDto`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("01010199999"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("01010199999"))))
         behandlingRepository.insert(behandling(fagsak))
         behandlingRepository.insert(behandling(fagsak))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/SøkControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/SøkControllerTest.kt
@@ -42,7 +42,7 @@ internal class SøkControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Gitt person med fagsak når søk på personensident kallas skal det returneres 200 OK med Søkeresultat`() {
-        fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("01010199999"))))
+        testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("01010199999"))))
 
         val response = søkPerson("01010199999")
         assertThat(response.statusCode).isEqualTo(

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.brev.VedtaksbrevService
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
@@ -47,7 +46,6 @@ import java.util.UUID
 
 internal class VedtakControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var rolleConfig: RolleConfig
     @Autowired private lateinit var vedtaksbrevService: VedtaksbrevService
@@ -69,7 +67,7 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     internal fun setUp() {
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/soknad/SøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/soknad/SøknadControllerTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
@@ -29,7 +28,6 @@ import java.util.UUID
 
 internal class SøknadControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired lateinit var behandlingService: BehandlingService
     @Autowired lateinit var fagsakService: FagsakService
@@ -42,7 +40,7 @@ internal class SøknadControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal returnere 200 OK med status IKKE_TILGANG dersom man ikke har tilgang til brukeren`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson("ikkeTilgang"))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val respons = hentSøknadData(behandling.id)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/arbeidsforhold/ArbeidsforholdControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/arbeidsforhold/ArbeidsforholdControllerTest.kt
@@ -3,10 +3,8 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.arbeidsforhold
 
 import io.mockk.verify
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
-import no.nav.familie.ef.sak.amelding.AMeldingInntektDto
 import no.nav.familie.ef.sak.arbeidsforhold.ArbeidsforholdDto
 import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdClient
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -14,9 +12,7 @@ import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mock
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.boot.test.web.client.exchange
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
@@ -26,7 +22,6 @@ import java.util.UUID
 
 internal class ArbeidsforholdControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var arbeidsforholdClient: ArbeidsforholdClient
 
     private val fagsak = fagsak(identer = fagsakpersoner(setOf("1")))
@@ -34,7 +29,7 @@ internal class ArbeidsforholdControllerTest : OppslagSpringRunnerTest() {
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(lokalTestToken)
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandlingsflyt.steg.BeregnYtelseSteg
 import no.nav.familie.ef.sak.beregning.Inntekt
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
@@ -28,7 +27,6 @@ import java.util.UUID
 
 internal class BeregnYtelseStegIntegrationTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var beregnYtelseSteg: BeregnYtelseSteg
     @Autowired private lateinit var tilkjentytelseRepository: TilkjentYtelseRepository
@@ -97,7 +95,7 @@ internal class BeregnYtelseStegIntegrationTest : OppslagSpringRunnerTest() {
     }
 
     fun opprettBehandlinger() {
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
         behandlingRepository.insert(behandling)
         behandlingRepository.insert(behandling2)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
@@ -31,7 +31,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal håndtere en ny søknad`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.UTREDES))
 
         stegService.håndterVilkår(behandling)
@@ -39,7 +39,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal legge inn historikkinnslag for beregn ytelse selv om behandlingen står på send til beslutter`() {
-        val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("0101017227"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("0101017227"))))
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 status = BehandlingStatus.UTREDES,
                                                                 steg = StegType.SEND_TIL_BESLUTTER))
@@ -64,7 +64,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal feile håndtering av ny søknad hvis en behandling er ferdigstilt`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, steg = StegType.BEHANDLING_FERDIGSTILT))
 
         assertThrows<IllegalStateException> {
@@ -74,7 +74,7 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal feile håndtering av ny søknad hvis en behandling er sendt til beslutter`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, steg = StegType.BESLUTTE_VEDTAK))
 
         assertThrows<IllegalStateException> {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTaskTest.kt
@@ -6,7 +6,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.BehandlingOppsettUtil
 import no.nav.familie.ef.sak.iverksett.IverksettClient
@@ -28,7 +27,6 @@ import java.util.Properties
 class StartBehandlingTaskTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var fagsakService: FagsakService
 
     private val iverksettClient = mockk<IverksettClient>()
@@ -42,7 +40,7 @@ class StartBehandlingTaskTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     fun setup() {
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
 
         every { pdlClient.hentPersonidenter(personIdent, true) } returns PdlIdenter(listOf(PdlIdent(personIdent, false)))
         justRun { iverksettClient.startBehandling(capture(opprettStartBehandlingHendelseDtoSlot)) }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
@@ -55,7 +55,7 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal klare å inserte ett vedtak med resultatet avslå`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VEDTA_BLANKETT,
                                                                 type = BehandlingType.BLANKETT,
@@ -70,7 +70,7 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `Skal klare å inserte ett vedtak med resultatet innvilge`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VEDTA_BLANKETT,
                                                                 type = BehandlingType.BLANKETT,
@@ -108,7 +108,7 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
     }
 
     private fun lagFagsakOgBehandling(): Behandling {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(""))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(""))))
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VEDTA_BLANKETT,
                                                                 type = BehandlingType.FØRSTEGANGSBEHANDLING,

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
@@ -31,7 +31,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
     fun `lagre og hent vedtak, lagre igjen - da skal første slettes`() {
 
         /** Pre */
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VILKÅR,
                                                                 status = BehandlingStatus.UTREDES,
@@ -70,7 +70,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `skal hente lagret vedtak hvis finnes`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VILKÅR,
                                                                 status = BehandlingStatus.UTREDES,
@@ -88,7 +88,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal oppdatere saksbehandler på vedtaket`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VILKÅR,
                                                                 status = BehandlingStatus.UTREDES,
@@ -107,7 +107,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal oppdatere beslutter på vedtaket`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 steg = StegType.VILKÅR,
                                                                 status = BehandlingStatus.UTREDES,
@@ -133,7 +133,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `hentVedtakForBehandlinger - skal returnere vedtak`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak)).id
         val behandling2 = behandlingRepository.insert(behandling(fagsak)).id
         val vedtakDto = Innvilget(resultatType = ResultatType.INNVILGE,

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereRepositoryTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ef.sak.brev.domain.Brevmottakere
 import no.nav.familie.ef.sak.brev.domain.MottakerRolle
 import no.nav.familie.ef.sak.brev.domain.OrganisasjonerWrapper
 import no.nav.familie.ef.sak.brev.domain.PersonerWrapper
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import org.assertj.core.api.Assertions
@@ -18,13 +17,12 @@ import org.springframework.beans.factory.annotation.Autowired
 
 internal class BrevmottakereRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var brevmottakereRepository: BrevmottakereRepository
 
     @Test
     internal fun `skal lagre brevmottaker`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val brevmottakere = Brevmottakere(behandlingId = behandling.id,
                                           personer = PersonerWrapper(listOf(BrevmottakerPerson(personIdent = "12345678910",

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepositoryTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
 import no.nav.familie.ef.sak.brev.dto.FritekstBrevKategori
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevAvsnitt
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import org.assertj.core.api.Assertions
@@ -16,13 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired
 
 internal class MellomlagerFritekstbrevRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var mellomlagerFritekstbrevRepository: MellomlagerFritekstbrevRepository
 
     @Test
     internal fun `skal lagre mellomlagret brev`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val mellomlagretBrev = MellomlagretFritekstbrev(behandlingId = behandling.id,
                                                         brev = Fritekstbrev(overskrift = "Et testbrev", avsnitt = listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeRepositoryTest.kt
@@ -21,7 +21,7 @@ internal class MellomlagerFrittståendeRepositoryTest : OppslagSpringRunnerTest(
 
     @Test
     internal fun `skal lagre mellomlagret brev`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val mellomlagretBrev = MellomlagretFrittståendeBrev(fagsakId = fagsak.id,
                                                             brev = Fritekstbrev(overskrift = "Et testbrev",
                                                                                 avsnitt = listOf(FrittståendeBrevAvsnitt(
@@ -42,7 +42,7 @@ internal class MellomlagerFrittståendeRepositoryTest : OppslagSpringRunnerTest(
     @Test
     internal fun `skal finne igjen mellomlagret brev fra fagsakId og saksbehandlers ident`() {
         val saksbehandlerIdent = "12345678910"
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val mellomlagretBrev = MellomlagretFrittståendeBrev(fagsakId = fagsak.id,
                                                             brev = Fritekstbrev(overskrift = "Et testbrev",
                                                                                 avsnitt = listOf(FrittståendeBrevAvsnitt(

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringControllerTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.iverksett
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.dto.BehandlingDto
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -29,7 +28,6 @@ import java.util.UUID
 
 internal class SimuleringControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
     @Autowired private lateinit var simuleringsresultatRepository: SimuleringsresultatRepository
@@ -42,7 +40,7 @@ internal class SimuleringControllerTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `Skal returnere 200 OK for simulering av behandling`() {
         val personIdent = "12345678901"
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(personIdent))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(personIdent))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         tilkjentYtelseRepository
                 .insert(TilkjentYtelse(behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepositoryTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.GjeldendeBarnRepository
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -24,14 +23,13 @@ import java.time.LocalDateTime
 class GjeldendeBarnRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var gjeldendeBarnRepository: GjeldendeBarnRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
     @Autowired private lateinit var søknadService: SøknadService
 
     @Test
     internal fun `finnBarnAvGjeldendeIverksatteBehandlinger med fremtidig andel, forvent barn fra behandling med fremtidig andel `() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandlingMedTidligereAndel = behandlingRepository.insert(behandling(fagsak,
                                                                                  status = BehandlingStatus.FERDIGSTILT,
                                                                                  resultat = BehandlingResultat.INNVILGET,
@@ -76,8 +74,8 @@ class GjeldendeBarnRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnBarnAvGjeldendeIverksatteBehandlinger med fremtidig andel fra to forskjellige fagsaker, forvent barn fra behandling med fremtidig andel`() {
-        val fagsakForTidligereAndel = fagsakRepository.insert(fagsak())
-        val fagsakForFremtidigAndel = fagsakRepository.insert(fagsak())
+        val fagsakForTidligereAndel = testoppsettService.lagreFagsak(fagsak())
+        val fagsakForFremtidigAndel = testoppsettService.lagreFagsak(fagsak())
 
         val behandlingMedTidligereAndel = behandlingRepository.insert(behandling(fagsakForTidligereAndel,
                                                                                  status = BehandlingStatus.FERDIGSTILT,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -42,14 +42,14 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal ikke være mulig å legge inn en behandling med referanse til en behandling som ikke eksisterer`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         assertThatThrownBy { behandlingRepository.insert(behandling(fagsak, forrigeBehandlingId = UUID.randomUUID())) }
                 .isInstanceOf(DbActionExecutionException::class.java)
     }
 
     @Test
     internal fun findByFagsakId() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         assertThat(behandlingRepository.findByFagsakId(UUID.randomUUID())).isEmpty()
@@ -58,7 +58,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun findByFagsakAndStatus() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.OPPRETTET))
 
         assertThat(behandlingRepository.findByFagsakIdAndStatus(UUID.randomUUID(), BehandlingStatus.OPPRETTET)).isEmpty()
@@ -68,7 +68,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun finnMedEksternId() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val findByBehandlingId = behandlingRepository.findById(behandling.id)
         val findByEksternId = behandlingRepository.finnMedEksternId(behandling.eksternId.id)
@@ -80,7 +80,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnFnrForBehandlingId(sql) skal finne gjeldende fnr for behandlingsid`() {
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson(ident = "1"),
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson(ident = "1"),
                                                           FagsakPerson(ident = "2",
                                                                        sporbar = Sporbar(endret = Endret(endretTid = LocalDateTime.now()
                                                                                .plusDays(2)))),
@@ -99,7 +99,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `finnSisteBehandlingSomIkkeErBlankett`() {
         val personidenter = setOf("1", "2")
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson("1"))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         assertThat(behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(OVERGANGSSTØNAD, personidenter))
@@ -111,7 +111,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `finnSisteBehandlingSomIkkeErBlankett - skal returnere teknisk opphør`() {
         val personidenter = setOf("1", "2")
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson("1"))))
         val behandling = behandlingRepository.insert(behandling(fagsak, type = BehandlingType.TEKNISK_OPPHØR))
 
         assertThat(behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(OVERGANGSSTØNAD, personidenter))
@@ -121,7 +121,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `skal ikke returnere behandling hvis det er blankett`() {
         val personidenter = setOf("1", "2")
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson("1"))))
         behandlingRepository.insert(behandling(fagsak, type = BehandlingType.BLANKETT))
 
         assertThat(behandlingRepository.finnSisteBehandlingSomIkkeErBlankett(OVERGANGSSTØNAD, personidenter)).isNull()
@@ -129,7 +129,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandling - skal returnere teknisk opphør hvis siste behandling er teknisk opphør`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(ident))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(ident))))
         behandlingRepository.insert(behandling(fagsak,
                                                status = FERDIGSTILT,
                                                opprettetTid = LocalDateTime.now().minusDays(2)))
@@ -143,7 +143,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandling - skal ikke returnere noe hvis behandlingen ikke er ferdigstilt`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(ident))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(ident))))
         behandlingRepository.insert(behandling(fagsak,
                                                status = UTREDES,
                                                opprettetTid = LocalDateTime.now().minusDays(2)))
@@ -152,7 +152,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandling - skal ikke returnere noe hvis behandlingen er type blankett`() {
-        val fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(ident))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(ident))))
         behandlingRepository.insert(behandling(fagsak,
                                                status = FERDIGSTILT,
                                                type = BehandlingType.BLANKETT,
@@ -163,7 +163,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `finnSisteIverksatteBehandling skal finne id til siste ferdigstilte behandling, ikke henlagt eller blankett`() {
         val førstegangsbehandling = BehandlingOppsettUtil.iverksattFørstegangsbehandling
-        val fagsak = fagsakRepository.insert(fagsak(setOf(FagsakPerson("1"))).copy(id = førstegangsbehandling.fagsakId))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(setOf(FagsakPerson("1"))).copy(id = førstegangsbehandling.fagsakId))
 
         val behandlinger = BehandlingOppsettUtil.lagBehandlingerForSisteIverksatte()
         behandlingRepository.insertAll(behandlinger)
@@ -174,7 +174,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnEksterneIder - skal hente eksterne ider`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val eksterneIder = behandlingRepository.finnEksterneIder(setOf(behandling.id))
@@ -191,7 +191,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal finne behandlingsider til behandlinger som er iverksatte`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         behandlingRepository.insert(behandling(fagsak,
                                                status = FERDIGSTILT,
                                                resultat = BehandlingResultat.INNVILGET,
@@ -205,7 +205,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandlinger - skal ikke finne behandling hvis siste er avslått eller henlagt`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         behandlingRepository.insert(behandling(fagsak, status = FERDIGSTILT, resultat = BehandlingResultat.AVSLÅTT))
         behandlingRepository.insert(behandling(fagsak, status = FERDIGSTILT, resultat = BehandlingResultat.HENLAGT))
         assertThat(behandlingRepository.finnSisteIverksatteBehandlinger(OVERGANGSSTØNAD)).isEmpty()
@@ -213,7 +213,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandlinger - skal filtrere vekk blankett før den henter siste behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 status = FERDIGSTILT,
                                                                 resultat = BehandlingResultat.INNVILGET,
@@ -228,7 +228,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnSisteIverksatteBehandlinger - skal filtrere vekk henlagte-, avslåtte- eller blankettbehandlinger før den henter siste behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 status = FERDIGSTILT,
                                                                 resultat = BehandlingResultat.INNVILGET,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingsjournalpostRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingsjournalpostRepositoryTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingsjournalpostRepository
 import no.nav.familie.ef.sak.behandling.domain.Behandlingsjournalpost
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
@@ -14,13 +13,12 @@ import org.springframework.beans.factory.annotation.Autowired
 
 internal class BehandlingsjournalpostRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var behandlingsjournalpostRepository: BehandlingsjournalpostRepository
 
     @Test
     internal fun `skal kunne lagre flere journalposter på samme behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling1 = behandlingRepository.insert(behandling(fagsak))
         val behandling2 = behandlingRepository.insert(behandling(fagsak))
         behandlingsjournalpostRepository.insert(Behandlingsjournalpost(behandling1.id, "1", Journalposttype.U))
@@ -33,7 +31,7 @@ internal class BehandlingsjournalpostRepositoryTest : OppslagSpringRunnerTest() 
 
     @Test
     internal fun `skal ikke være mulig å legge inn 2 journalposter med samme journalpostId`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling1 = behandlingRepository.insert(behandling(fagsak))
         behandlingsjournalpostRepository.insert(Behandlingsjournalpost(behandling1.id, "1", Journalposttype.U))
         val throwable = catchThrowable {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
@@ -21,7 +21,7 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun findByFagsakId() {
-        val fagsakPersistert = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("12345678901", "98765432109"))))
+        val fagsakPersistert = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("12345678901", "98765432109"))))
         val fagsak = fagsakRepository.findByIdOrNull(fagsakPersistert.id) ?: error("Finner ikke fagsak med id")
 
         assertThat(fagsak).isNotNull
@@ -32,7 +32,7 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun findBySøkerIdent() {
-        fagsakRepository.insert(fagsak(fagsakpersoner(setOf("12345678901", "98765432109"))))
+        testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("12345678901", "98765432109"))))
         val fagsakHentetFinnesIkke = fagsakRepository.findBySøkerIdent(setOf("0"), Stønadstype.OVERGANGSSTØNAD)
 
         assertThat(fagsakHentetFinnesIkke).isNull()
@@ -49,8 +49,8 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
         val fagsakPerson = fagsakpersoner(setOf("12345678901"))
         var fagsak1 = fagsak(identer = fagsakPerson, stønadstype = Stønadstype.OVERGANGSSTØNAD)
         var fagsak2 = fagsak(identer = fagsakPerson, stønadstype = Stønadstype.SKOLEPENGER)
-        fagsak1 = fagsakRepository.insert(fagsak1)
-        fagsak2 = fagsakRepository.insert(fagsak2)
+        fagsak1 = testoppsettService.lagreFagsak(fagsak1)
+        fagsak2 = testoppsettService.lagreFagsak(fagsak2)
         val fagsaker = fagsakRepository.findBySøkerIdent(setOf("12345678901"))
 
         assertThat(fagsaker.forEach { fagsak ->
@@ -65,7 +65,7 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun finnMedEksternId() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val findByEksternId = fagsakRepository.finnMedEksternId(fagsak.eksternId.id)
                               ?: throw error("Fagsak med ekstern id ${fagsak.eksternId} finnes ikke")
 
@@ -81,14 +81,14 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `finnAktivIdent - skal finne aktiv ident`() {
         val fagsak = opprettFagsakMedFlereIdenter()
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
         assertThat(fagsakRepository.finnAktivIdent(fagsak.id)).isEqualTo("2")
     }
 
     @Test
     internal fun `skal hente fagsak på behandlingId`() {
         var fagsak = opprettFagsakMedFlereIdenter()
-        fagsak = fagsakRepository.insert(fagsak)
+        fagsak = testoppsettService.lagreFagsak(fagsak)
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val finnFagsakTilBehandling = fagsakRepository.finnFagsakTilBehandling(behandling.id)!!
@@ -100,14 +100,14 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal sette eksternId til 200_000_000 som default`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         assertThat(fagsak.eksternId.id).isGreaterThanOrEqualTo(200_000_000)
     }
 
     @Test
     internal fun `skal hente siste identen for hver fagsak`() {
-        val fagsak = fagsakRepository.insert(opprettFagsakMedFlereIdenter())
-        val fagsak2 = fagsakRepository.insert(opprettFagsakMedFlereIdenter("4", "5", "6"))
+        val fagsak = testoppsettService.lagreFagsak(opprettFagsakMedFlereIdenter())
+        val fagsak2 = testoppsettService.lagreFagsak(opprettFagsakMedFlereIdenter("4", "5", "6"))
         val aktiveIdenterPerFagsak = fagsakRepository.finnAktivIdenter(setOf(fagsak.id, fagsak2.id))
         assertThat(aktiveIdenterPerFagsak).hasSize(2)
         assertThat(aktiveIdenterPerFagsak.single { it.first == fagsak.id }.second).isEqualTo("2")
@@ -116,7 +116,7 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal kunne søke opp fagsak basert på forskjellige personidenter - kun ett treff per fagsak`() {
-        val fagsakMedFlereIdenter = fagsakRepository.insert(opprettFagsakMedFlereIdenter("4", "5", "6"))
+        val fagsakMedFlereIdenter = testoppsettService.lagreFagsak(opprettFagsakMedFlereIdenter("4", "5", "6"))
 
         assertThat(fagsakMedFlereIdenter.søkerIdenter).hasSize(3)
         assertThat(fagsakRepository.findBySøkerIdent(fagsakMedFlereIdenter.søkerIdenter.map { it.ident }.toSet(), Stønadstype.OVERGANGSSTØNAD)).isNotNull

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/GrunnlagsdataRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/GrunnlagsdataRepositoryTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.felles.util.opprettGrunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
@@ -14,13 +13,12 @@ import org.springframework.beans.factory.annotation.Autowired
 
 internal class GrunnlagsdataRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var grunnlagsdataRepository: GrunnlagsdataRepository
 
     @Test
     internal fun `hente data går OK`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val grunnlagsdata = opprettGrunnlagsdata()
@@ -31,7 +29,7 @@ internal class GrunnlagsdataRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnBehandlingerSomManglerGrunnlagsdata skal finne behandlinger som har status OPPRETTET`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak,
                                                                 status = BehandlingStatus.OPPRETTET,
                                                                 type = BehandlingType.BLANKETT))
@@ -50,7 +48,7 @@ internal class GrunnlagsdataRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `bakåtkompatibilitet - tidligereVedtaksPerioder er null då den ikke finnes med i tidligere objekter`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val grunnlagsdata = opprettGrunnlagsdata().copy(tidligereVedtaksperioder = null)

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/MellomlagringBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/MellomlagringBrevRepositoryTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.brev.MellomlagerBrevRepository
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,13 +11,12 @@ import java.time.LocalDate
 
 internal class MellomlagringBrevRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var mellomlagerBrevRepository: MellomlagerBrevRepository
 
     @Test
     internal fun `skal lagre mellomlagret brev`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val mellomlagretBrev = MellomlagretBrev(behandling.id, "{}", "mal", "1", LocalDate.now())
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/OppgaveRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/OppgaveRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.felles.domain.Sporbar
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
@@ -17,12 +16,11 @@ import java.util.UUID
 internal class OppgaveRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var oppgaveRepository: OppgaveRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @Test
     internal fun findByBehandlingIdAndTypeAndErFerdigstiltIsFalse() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val oppgave = oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true))
 
@@ -40,7 +38,7 @@ internal class OppgaveRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal finne nyeste oppgave for behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val sporbar = Sporbar(opprettetTid = LocalDateTime.now().plusDays(1))
         oppgaveRepository.insert(oppgave(behandling, erFerdigstilt = true, gsakOppgaveId = 1))
@@ -56,7 +54,7 @@ internal class OppgaveRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal finne nyeste oppgave for riktig behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val behandling2 = behandlingRepository.insert(behandling(fagsak))
 
@@ -71,7 +69,7 @@ internal class OppgaveRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal feile hvis det ikke finnes en oppgave for behandlingen`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         assertThrows<EmptyResultDataAccessException> {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/SøknadRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.felles.domain.Sporbar
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadRepository
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søker
@@ -18,12 +17,11 @@ import kotlin.random.Random.Default.nextInt
 internal class SøknadRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var søknadRepository: SøknadRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @Test
     fun `finner søknad på behandlingId`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         opprettSøknad("1", "11111122222", behandling.id)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtakRepositoryTest.kt
@@ -3,12 +3,11 @@ package no.nav.familie.ef.sak.repository
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.beregning.Inntektsperiode
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
+import no.nav.familie.ef.sak.vedtak.VedtakRepository
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
-import no.nav.familie.ef.sak.vedtak.VedtakRepository
 import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType
@@ -21,12 +20,11 @@ import java.time.LocalDate
 internal class VedtakRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var vedtakRepository: VedtakRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @Test
     internal fun `skal lagre vedtak med riktige felter`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val vedtak = Vedtak(behandlingId = behandling.id,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.brev.VedtaksbrevRepository
 import no.nav.familie.ef.sak.brev.domain.Vedtaksbrev
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,12 +11,11 @@ import org.springframework.beans.factory.annotation.Autowired
 internal class VedtaksbrevRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var vedtaksbrevRepository: VedtaksbrevRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @Test
     internal fun findByBehandlingId() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val vedtaksbrev = Vedtaksbrev(behandlingId = behandling.id,
                                       saksbehandlerBrevrequest = "testhallo",

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.vilkår.VilkårType
@@ -19,12 +18,11 @@ import java.util.UUID
 internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Autowired private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
 
     @Test
     internal fun findByBehandlingId() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val vilkårsvurdering = vilkårsvurderingRepository.insert(vilkårsvurdering(behandling.id,
@@ -37,7 +35,7 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun oppdaterEndretTid() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val vilkårsvurdering = vilkårsvurderingRepository.insert(vilkårsvurdering(behandling.id,
@@ -54,7 +52,7 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `setter maskinellt opprettet på vilkår`() {
         val saksbehandler = "C000"
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         val vilkårsvurdering: Vilkårsvurdering = testWithBrukerContext(preferredUsername = saksbehandler) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceIntegrationTest.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -19,13 +18,12 @@ import java.util.UUID
 internal class BehandlingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var behandlingRepository: BehandlingRepository
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var behandlingService: BehandlingService
     private val behandlingÅrsak = BehandlingÅrsak.SØKNAD
 
     @Test
     internal fun `opprettBehandling skal ikke være mulig å opprette en revurdering om forrige behandling ikke er ferdigstilt`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         behandlingRepository.insert(behandling(fagsak = fagsak,
                                                status = BehandlingStatus.UTREDES))
         assertThatThrownBy {
@@ -37,7 +35,7 @@ internal class BehandlingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `opprettBehandling - skal ikke være mulig å opprette en revurdering om det ikke finnes en behandling fra før`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         assertThatThrownBy {
             behandlingService.opprettBehandling(BehandlingType.REVURDERING,
                                                 fagsak.id,
@@ -47,7 +45,7 @@ internal class BehandlingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `opprettBehandling - skal ikke være mulig å opprette en revurdering hvis forrige behandling er blankett`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         behandlingRepository.insert(behandling(fagsak = fagsak,
                                                status = BehandlingStatus.FERDIGSTILT,
                                                type = BehandlingType.BLANKETT))
@@ -60,7 +58,7 @@ internal class BehandlingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `opprettBehandling - skal ikke være mulig å opprette en revurdering om forrige behandling er teknisk opphør`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         behandlingRepository.insert(behandling(fagsak = fagsak,
                                                status = BehandlingStatus.FERDIGSTILT,
                                                type = BehandlingType.TEKNISK_OPPHØR))
@@ -81,7 +79,7 @@ internal class BehandlingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `hentBehandlinger - skal returnere behandlinger`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val behandling2 = behandlingRepository.insert(behandling(fagsak))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingshistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingshistorikkServiceTest.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.tilHendelseshistorikkDto
 import no.nav.familie.ef.sak.behandlingshistorikk.dto.HendelseshistorikkDto
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -24,13 +23,12 @@ internal class BehandlingshistorikkServiceTest : OppslagSpringRunnerTest() {
     @Autowired private lateinit var behandlingshistorikkService: BehandlingshistorikkService
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var behandlingshistorikkRepository: BehandlingshistorikkRepository
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
 
     @Test
     fun `lagre behandling og hent historikk`() {
 
         /** Lagre */
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val behandlingHistorikk =
                 behandlingshistorikkRepository.insert(Behandlingshistorikk(behandlingId = behandling.id,
@@ -50,7 +48,7 @@ internal class BehandlingshistorikkServiceTest : OppslagSpringRunnerTest() {
     fun `Finn hendelseshistorikk på behandling uten historikk`() {
 
         /** Lagre */
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         /** Hent */
@@ -62,7 +60,7 @@ internal class BehandlingshistorikkServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finn seneste behandlinghistorikk`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         insert(behandling, "A", LocalDateTime.now().minusDays(1))
@@ -75,7 +73,7 @@ internal class BehandlingshistorikkServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finn seneste behandlinghistorikk med type`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
         insert(behandling, "A", LocalDateTime.now().minusDays(1))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
@@ -7,7 +7,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.EksternFagsakId
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
@@ -29,7 +28,6 @@ import java.util.UUID
 internal class FagsakServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var fagsakService: FagsakService
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var behandlingRepository: BehandlingRepository
 
     @AfterEach
@@ -52,7 +50,7 @@ internal class FagsakServiceTest : OppslagSpringRunnerTest() {
 
         val fagsakRequest = Fagsak(stønadstype = Stønadstype.BARNETILSYN,
                                    søkerIdenter = setOf(FagsakPerson(ident = personIdent)))
-        val fagsakDB = fagsakRepository.insert(fagsakRequest)
+        val fagsakDB = testoppsettService.lagreFagsak(fagsakRequest)
 
         val behandling1 = Behandling(fagsakId = fagsakDB.id,
                                      type = BehandlingType.FØRSTEGANGSBEHANDLING,
@@ -101,7 +99,7 @@ internal class FagsakServiceTest : OppslagSpringRunnerTest() {
 
         val gjeldendeIdent = "12345678901"
         val feilRegistrertIdent = "99988877712"
-        val fagsakMedFeilregistrertIdent = fagsakRepository.insert(Fagsak(eksternId = EksternFagsakId(id = 1234),
+        val fagsakMedFeilregistrertIdent = testoppsettService.lagreFagsak(Fagsak(eksternId = EksternFagsakId(id = 1234),
                                                                          stønadstype = Stønadstype.OVERGANGSSTØNAD,
                                                                          søkerIdenter = setOf(FagsakPerson(ident = gjeldendeIdent,
                                                                                                            sporbar = iGår),
@@ -126,7 +124,7 @@ internal class FagsakServiceTest : OppslagSpringRunnerTest() {
 
         val gjeldendeIdent = "12345678901"
         val historiskIdent = "98765432109"
-        val fagsakMedHistoriskIdent = fagsakRepository.insert(Fagsak(eksternId = EksternFagsakId(id = 1234),
+        val fagsakMedHistoriskIdent = testoppsettService.lagreFagsak(Fagsak(eksternId = EksternFagsakId(id = 1234),
                                                                      stønadstype = Stønadstype.OVERGANGSSTØNAD,
                                                                      søkerIdenter = setOf(FagsakPerson(ident = historiskIdent,
                                                                                                            sporbar = iGår))))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
@@ -39,7 +38,6 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var revurderingService: RevurderingService
     @Autowired lateinit var behandlingRepository: BehandlingRepository
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
     @Autowired lateinit var søknadService: SøknadService
     @Autowired lateinit var søknadRepository: SøknadRepository
@@ -55,7 +53,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
     fun setUp() {
         BrukerContextUtil.mockBrukerContext("Heider")
         val identer = fagsakpersoner(setOf(personIdent))
-        fagsak = fagsakRepository.insert(fagsak(identer = identer))
+        fagsak = testoppsettService.lagreFagsak(fagsak(identer = identer))
         revurderingDto = RevurderingDto(fagsak.id, behandlingsårsak, kravMottatt)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøknadServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.service
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.Behandling
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadRepository
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -18,13 +17,12 @@ import org.springframework.beans.factory.annotation.Autowired
 internal class SøknadServiceTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var behandlingRepository: BehandlingRepository
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var søknadRepository: SøknadRepository
     @Autowired lateinit var søknadService: SøknadService
 
     @Test
     internal fun `skal kopiere søknadskjema til ny behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val revurdering = behandlingRepository.insert(behandling(fagsak))
 
@@ -36,7 +34,7 @@ internal class SøknadServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal opprette ny søknad til grunnlag som bruker den samme søknadsskjemaet`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val revurdering = behandlingRepository.insert(behandling(fagsak))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/TekniskOpphørTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/TekniskOpphørTest.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillBehandlingTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.PollStatusTekniskOpphør
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
@@ -31,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired
 internal class TekniskOpphørTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var tekniskOpphørService: TekniskOpphørService
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var behandlingRepository: BehandlingRepository
     @Autowired lateinit var taskRepository: TaskRepository
     @Autowired lateinit var pollStatusTekniskOpphør: PollStatusTekniskOpphør
@@ -48,7 +46,7 @@ internal class TekniskOpphørTest : OppslagSpringRunnerTest() {
         mockBrukerContext("saksbehandler")
         every { iverksettClient.hentStatus(any()) } returns IverksettStatus.OK_MOT_OPPDRAG
 
-        fagsak = fagsakRepository.insert(fagsak(identer = setOf(FagsakPerson(ident = ident))))
+        fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(FagsakPerson(ident = ident))))
         behandling = behandlingRepository.insert(behandling(fagsak,
                                                             status = BehandlingStatus.FERDIGSTILT,
                                                             resultat = BehandlingResultat.INNVILGET))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceIntegratsjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VurderingServiceIntegratsjonsTest.kt
@@ -4,7 +4,6 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -31,13 +30,12 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
 
     @Autowired lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
     @Autowired lateinit var behandlingRepository: BehandlingRepository
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var vurderingService: VurderingService
     @Autowired lateinit var søknadService: SøknadService
 
     @Test
     internal fun `kopierVurderingerTilNyBehandling - skal kopiere vurderinger til ny behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val revurdering = behandlingRepository.insert(behandling(fagsak))
         val søknadskjema = lagreSøknad(behandling, fagsak)
@@ -58,7 +56,7 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `oppdaterGrunnlagsdataOgHentEllerOpprettVurderinger - skal kaste feil dersom behandlingen er låst for videre behandling`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, status = BehandlingStatus.FERDIGSTILT))
         assertThat(catchThrowable { vurderingService.oppdaterGrunnlagsdataOgHentEllerOpprettVurderinger(behandling.id) })
                 .hasMessage("Kan ikke laste inn nye grunnlagsdata for behandling med status ${behandling.status}")
@@ -67,7 +65,7 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `kopierVurderingerTilNyBehandling - skal kaste feil hvis det ikke finnes noen vurderinger`() {
         val tidligereBehandlingId = UUID.randomUUID()
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val revurdering = behandlingRepository.insert(behandling(fagsak))
 
         assertThat(catchThrowable { vurderingService.kopierVurderingerTilNyBehandling(tidligereBehandlingId, revurdering.id) })

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/PeriodeControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/PeriodeControllerTest.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.vedtak
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
@@ -19,7 +18,6 @@ import org.springframework.http.ResponseEntity
 
 internal class PeriodeControllerTest : OppslagSpringRunnerTest() {
 
-    @Autowired lateinit var fagsakRepository: FagsakRepository
     @Autowired lateinit var behandlingRepository: BehandlingRepository
 
     @BeforeEach
@@ -29,7 +27,7 @@ internal class PeriodeControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `kan kalle på andelshistorikk uten query param`() {
-        val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("1"))))
         behandlingRepository.insert(behandling(fagsak))
 
         val response: ResponseEntity<Ressurs<List<AndelHistorikkDto>>> =
@@ -42,7 +40,7 @@ internal class PeriodeControllerTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `kan kalle på endepunkt med query param`() {
-        val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("1"))))
         behandlingRepository.insert(behandling(fagsak))
 
         val response: ResponseEntity<Ressurs<List<AndelHistorikkDto>>> =

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerRepositoryTest.kt
@@ -2,19 +2,16 @@ package no.nav.familie.ef.sak.vedtak.uttrekk
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Sort
 import java.time.YearMonth
 
 internal class UttrekkArbeidssøkerRepositoryTest : OppslagSpringRunnerTest() {
 
-    @Autowired private lateinit var fagsakRepository: FagsakRepository
     @Autowired private lateinit var behandlingRepository: BehandlingRepository
     @Autowired private lateinit var repository: UttrekkArbeidssøkerRepository
 
@@ -22,7 +19,7 @@ internal class UttrekkArbeidssøkerRepositoryTest : OppslagSpringRunnerTest() {
 
     @BeforeEach
     internal fun setUp() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         for (i in 1..10) {
             repository.insert(UttrekkArbeidssøkere(fagsakId = fagsak.id,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
@@ -259,7 +259,7 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
                 identer.associate { it.first to lagPersonKort(it.second) }
             }
             identer.forEach {
-                val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf(it.first))))
+                val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf(it.first))))
                 val behandling = behandlingRepository.insert(behandling(fagsak))
                 val arbeidssøkere = UttrekkArbeidssøkere(fagsakId = fagsak.id,
                                                          vedtakId = behandling.id,
@@ -371,7 +371,7 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `settKontrollert - har ikke tilgang til fagsak`() {
-        val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("ikkeTilgang"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("ikkeTilgang"))))
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val uttrekkArbeidssøkere = UttrekkArbeidssøkere(fagsakId = fagsak.id, vedtakId = behandling.id, årMåned = mars2021)
         val uttrekk = uttrekkArbeidssøkerRepository.insert(uttrekkArbeidssøkere)
@@ -394,7 +394,7 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
     }
 
     private fun opprettEkstraFagsak() {
-        val fagsak = fagsakRepository.insert(fagsak(fagsakpersoner(setOf("1"))))
+        val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("1"))))
         val behandling = behandlingRepository.insert(
                 behandling(fagsak = fagsak,
                            type = BehandlingType.REVURDERING,
@@ -428,7 +428,7 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
     }
 
     fun opprettBehandlinger() {
-        fagsakRepository.insert(fagsak)
+        testoppsettService.lagreFagsak(fagsak)
         behandlingRepository.insert(behandling)
         behandlingRepository.insert(behandling2)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/økonomi/TilkjentYtelseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/økonomi/TilkjentYtelseRepositoryTest.kt
@@ -39,7 +39,7 @@ internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     fun `Opprett og hent andeler tilkjent ytelse`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak = fagsak))
         val tilkjentYtelse = DataGenerator.tilfeldigTilkjentYtelse(opprettBehandling(), 2)
 
@@ -74,7 +74,7 @@ internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `finnTilkjentYtelserTilKonsistensAvstemming`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak).innvilgetOgFerdigstilt())
 
         val tilkjentYtelse = DataGenerator.tilfeldigTilkjentYtelse(behandling)
@@ -95,7 +95,7 @@ internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
 
     @Test
     internal fun `skal kun finne siste behandlingen sin tilkjenteytelse`() {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val opprettetTid = LocalDate.of(2021, 1, 1).atStartOfDay()
         val behandling = behandlingRepository.insert(behandling(fagsak, opprettetTid = opprettetTid).innvilgetOgFerdigstilt())
         val behandling2 = behandlingRepository.insert(behandling(fagsak).innvilgetOgFerdigstilt())
@@ -111,7 +111,7 @@ internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
     @Test
     internal fun `finnTilkjentYtelserTilKonsistensavstemming skal ikke få med tilkjent ytelser som kun har 0-beløp`() {
         val beløp = 0
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak, opprettetTid = LocalDate.of(2021, 1, 1).atStartOfDay())
                                                              .innvilgetOgFerdigstilt())
         val andelerTilkjentYtelse = listOf(lagAndelTilkjentYtelse(beløp = beløp,
@@ -125,7 +125,7 @@ internal class TilkjentYtelseRepositoryTest : OppslagSpringRunnerTest() {
     }
 
     private fun opprettBehandling(): Behandling {
-        val fagsak = fagsakRepository.insert(fagsak())
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
 
         return behandlingRepository.insert(behandling(fagsak))
     }

--- a/src/test/kotlin/testutil/TestoppsettService.kt
+++ b/src/test/kotlin/testutil/TestoppsettService.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ef.sak.testutil
+
+import no.nav.familie.ef.sak.fagsak.FagsakRepository
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("integrasjonstest")
+@Service
+class TestoppsettService(
+        private val fagsakRepository: FagsakRepository,
+) {
+
+    fun lagreFagsak(fagsak: Fagsak): Fagsak {
+        return fagsakRepository.insert(fagsak)
+    }
+    
+}


### PR DESCRIPTION
…prette overbygg-person når personen ikke finnes sånn att vi ikke trenger å opprette person i tillegg.

For å få en ryddigere PR for å legge til Person i overbygg

Tanken er att den skal se ut slik:
```kotlin
class TestoppsettService(
        private val fagsakRepository: FagsakRepository,
        private val personRepository: PersonRepository
) {

    fun lagreFagsak(fagsak: Fagsak): Fagsak {
        personRepository.findByIdOrNull(fagsak.personId)
        ?: personRepository.insert(Person(fagsak.personId, identer = fagsak.søkerIdenter.map { PersonIdent(it.ident) }.toSet()))
        return fagsakRepository.insert(FagsakDao(id = fagsak.id,
                                                 stønadstype = fagsak.stønadstype,
                                                 eksternId = fagsak.eksternId,
                                                 personId = fagsak.personId,
                                                 søkerIdenter = fagsak.søkerIdenter)).tilFagsak()
    }

```