### PR TITLE
Slår sammen perioder fra infotrygd og ny løsning.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtil.kt
@@ -1,78 +1,66 @@
 package no.nav.familie.ef.sak.ekstern.arena
 
-import no.nav.familie.ef.sak.ekstern.tilEksternPeriodeOvergangsstønad
-import no.nav.familie.ef.sak.felles.util.isEqualOrAfter
-import no.nav.familie.ef.sak.felles.util.isEqualOrBefore
-import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdArenaPeriode
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaResponse
+import no.nav.familie.ef.sak.infotrygd.InternePerioder
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
-import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad.Datakilde
+import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import java.time.LocalDate
 import java.time.YearMonth
-import java.util.Stack
 
+/**
+ * Denne erstatter tjenesten som Arena kaller idag i Infotrygd.
+ * https://confluence.adeo.no/pages/viewpage.action?pageId=395741283#
+ * Denne tjenesten henter perioder fra de ulike stønadene og slår sammen de,
+ * tvers stønadstyper og returnerer perioder som overlapper datoer i input
+ *
+ * Den tjenesten filtrerte tidligere ut perioder som har stønadsbeløp > 0,
+ * dette har vi blitt enige om å ikke gjøre i denne, nye tjenesten
+ */
 object ArenaPeriodeUtil {
 
-    /**
-     * Skal filtrere bort de som har beløp = 0
-     * Skal filtere bort de som har tomdato < fomDato || opphørdato < tomDato
-     */
-    fun mapOgFiltrer(infotrygdPerioder: InfotrygdPerioderArenaResponse) =
-            infotrygdPerioder.perioder.filter { it.beløp > 0 }.map {
-                PeriodeOvergangsstønad(personIdent = it.personIdent,
-                                       fomDato = it.fomDato,
-                                       tomDato = it.opphørsdatoEllerTomDato(),
-                                       datakilde = Datakilde.INFOTRYGD)
-            }.filterNot { it.tomDato.isBefore(it.fomDato) }
-
-    fun mapOgFiltrer(andeler: List<AndelTilkjentYtelse>) =
-            andeler.filter { it.beløp > 0 }
-                    .map(AndelTilkjentYtelse::tilEksternPeriodeOvergangsstønad)
-
-    private fun InfotrygdArenaPeriode.opphørsdatoEllerTomDato(): LocalDate {
-        val opphørsdato = this.opphørsdato
-        return if (opphørsdato != null && opphørsdato.isBefore(tomDato)) {
-            opphørsdato
-        } else {
-            tomDato
-        }
+    fun slåSammenPerioderFraEfOgInfotrygd(request: PerioderOvergangsstønadRequest,
+                                          perioder: InternePerioder): List<PeriodeOvergangsstønad> {
+        val måneder = finnUnikeÅrMånedForPerioder(perioder)
+        val sammenslåddeÅrMåneder = slåSammenÅrMåneder(måneder)
+        return sammenslåddeÅrMåneder.map {
+            PeriodeOvergangsstønad(personIdent = request.personIdent,
+                                   fomDato = it.first.atDay(1),
+                                   tomDato = it.second.atEndOfMonth(),
+                                   datakilde = PeriodeOvergangsstønad.Datakilde.EF)
+        }.filter { overlapper(request, it) }
     }
 
-    /**
-     * Slår sammen perioder som er sammenhengende og overlappende.
-     * Dette er noe som idag gjøres i infotrygd men er ikke sikkert burde gjøres når vi henter perioder fra vår egen database
-     */
-    fun slåSammenPerioder(perioder: List<PeriodeOvergangsstønad>): List<PeriodeOvergangsstønad> {
-        val mergedePerioder = Stack<PeriodeOvergangsstønad>()
-        perioder.sortedBy { it.fomDato }.forEach { period ->
-            if (mergedePerioder.isEmpty()) {
-                mergedePerioder.push(period)
-            }
-            val last = mergedePerioder.peek()
-            if (erSammenhengendeEllerOverlappende(last, period)) {
-                mergedePerioder.push(mergedePerioder.pop().copy(fomDato = minOf(last.fomDato, period.fomDato),
-                                                                tomDato = maxOf(last.tomDato, period.tomDato)))
+    private fun overlapper(request: PerioderOvergangsstønadRequest, periode: PeriodeOvergangsstønad): Boolean {
+        val requestFom = request.fomDato ?: LocalDate.now() // Arena sender alltid fom/tom-datoer, burde endre kontraktet
+        val requestTom = request.tomDato ?: LocalDate.now()
+        val range = periode.fomDato..periode.tomDato
+        return requestFom in range
+               || requestTom in range
+               || (requestFom < periode.fomDato && requestTom > periode.tomDato) // omslutter
+    }
+
+    private fun slåSammenÅrMåneder(måneder: MutableSet<YearMonth>): MutableList<Pair<YearMonth, YearMonth>> {
+        return måneder.toList().sorted().fold(mutableListOf()) { acc, yearMonth ->
+            val last = acc.lastOrNull()
+            if (last == null || last.second.plusMonths(1) != yearMonth) {
+                acc.add(Pair(yearMonth, yearMonth))
             } else {
-                mergedePerioder.push(period)
+                acc.removeLast()
+                acc.add(last.copy(second = yearMonth))
+            }
+            acc
+        }
+    }
+
+    private fun finnUnikeÅrMånedForPerioder(perioder: InternePerioder): MutableSet<YearMonth> {
+        val måneder = mutableSetOf<YearMonth>()
+        (perioder.overgangsstønad + perioder.barnetilsyn + perioder.skolepenger).forEach {
+            var start: LocalDate = it.stønadFom
+            while (start <= it.stønadTom) {
+                måneder.add(YearMonth.from(start))
+                start = start.plusMonths(1)
             }
         }
-        return mergedePerioder
+        return måneder
     }
 
-    private fun erSammenhengendeEllerOverlappende(last: PeriodeOvergangsstønad,
-                                                  period: PeriodeOvergangsstønad) =
-            sammenhengendePeriode(last, period) || erOverlappende(last, period)
-
-    /**
-     * En periode er sammenhengende hvis perioden er i den samme måneden, eller om måned + 1 er lik
-     */
-    private fun sammenhengendePeriode(first: PeriodeOvergangsstønad, second: PeriodeOvergangsstønad): Boolean {
-        val firstTomDato = YearMonth.from(first.tomDato)
-        val secondFom = YearMonth.from(second.fomDato)
-        return firstTomDato == secondFom || firstTomDato.plusMonths(1) == secondFom
-    }
-
-    private fun erOverlappende(mergedPeriode: PeriodeOvergangsstønad, period: PeriodeOvergangsstønad) =
-            mergedPeriode.fomDato.isEqualOrBefore(period.tomDato) && mergedPeriode.tomDato.isEqualOrAfter(period.fomDato)
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtil.kt
@@ -20,8 +20,8 @@ object ArenaPeriodeUtil {
     fun slåSammenPerioderFraEfOgInfotrygd(request: PerioderOvergangsstønadRequest,
                                           perioder: InternePerioder): List<PeriodeOvergangsstønad> {
         val måneder = finnUnikeÅrMånedForPerioder(perioder)
-        val sammenslåddeÅrMåneder = slåSammenÅrMåneder(måneder)
-        return sammenslåddeÅrMåneder.map {
+        val sammenslåtteÅrMåneder = slåSammenÅrMåneder(måneder)
+        return sammenslåtteÅrMåneder.map {
             PeriodeOvergangsstønad(personIdent = request.personIdent,
                                    fomDato = it.first.atDay(1),
                                    tomDato = it.second.atEndOfMonth(),

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
@@ -4,8 +4,6 @@ import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaRequest
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
 import org.springframework.beans.factory.annotation.Qualifier
@@ -22,21 +20,14 @@ class InfotrygdReplikaClient(@Value("\${INFOTRYGD_REPLIKA_API_URL}")
                              restOperations: RestOperations)
     : AbstractPingableRestClient(restOperations, "infotrygd.replika") {
 
-    private val perioderArenaUri: URI =
-            UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/perioder/arena").build().toUri()
-
     private val perioderUri: URI =
-        UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/perioder").build().toUri()
+            UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/perioder").build().toUri()
 
     private val finnSakerUri: URI =
-        UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/saker/finn").build().toUri()
+            UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/saker/finn").build().toUri()
 
     private val eksistererUri: URI =
             UriComponentsBuilder.fromUri(infotrygdReplikaUri).pathSegment("api/stonad/eksisterer").build().toUri()
-
-    fun hentPerioderArena(request: InfotrygdPerioderArenaRequest): InfotrygdPerioderArenaResponse {
-        return postForEntity(perioderArenaUri, request)
-    }
 
     fun hentPerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse {
         return postForEntity(perioderUri, request)

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/arena/ArenaPeriodeUtilTest.kt
@@ -1,192 +1,149 @@
 package no.nav.familie.ef.sak.ekstern.arena
 
-import no.nav.familie.ef.sak.ekstern.arena.ArenaPeriodeUtil.mapOgFiltrer
-import no.nav.familie.ef.sak.ekstern.arena.ArenaPeriodeUtil.slåSammenPerioder
-import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdArenaPeriode
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaResponse
+import no.nav.familie.ef.sak.ekstern.arena.ArenaPeriodeUtil.slåSammenPerioderFraEfOgInfotrygd
+import no.nav.familie.ef.sak.infotrygd.InternPeriode
+import no.nav.familie.ef.sak.infotrygd.InternePerioder
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
+import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
+import java.time.YearMonth
+import java.time.YearMonth.of
 
 internal class ArenaPeriodeUtilTest {
 
-    private val ident = "01234567890"
-
     @Test
-    internal fun `skal slå sammen perioder til arena`() {
-        val infotrygPerioder = listOf(periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2018-04-30"), 1f,
-                                              LocalDate.parse("2018-07-31")),
-                                      periode(LocalDate.parse("2018-05-01"), LocalDate.parse("2020-07-31"), 1f,
-                                              LocalDate.parse("2018-07-31")),
-                                      periode(LocalDate.parse("2018-09-01"), LocalDate.parse("2018-12-31"), 1f),
-                                      periode(LocalDate.parse("2019-01-01"), LocalDate.parse("2019-04-30"), 1f),
-                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-30"), 1f),
-                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-08-31"), 1f))
+    internal fun `sammenhengende periode fra ef og infotrygd slås sammen tvers stønadstyper`() {
+        val request = request(of(2022, 1), of(2022, 1))
+        val perioder = internePerioder(listOf(periode(of(2021, 1), of(2022, 1))),
+                                       listOf(periode(of(2022, 2), of(2023, 1))))
 
-
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2017-08-01") to LocalDate.parse("2018-07-31"),
-                                  LocalDate.parse("2018-09-01") to LocalDate.parse("2020-08-31")))
+        val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+        assertThat(resultat).containsExactly(lagResultatPeriode(of(2021, 1), of(2023, 1)))
     }
 
     @Test
-    internal fun `skal slå sammen perioder til arena 2`() {
-        val infotrygPerioder = listOf(periode(LocalDate.parse("2018-12-01"), LocalDate.parse("2019-04-30"), 1f),
-                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2019-12-31"), 1f),
-                                      periode(LocalDate.parse("2019-12-01"), LocalDate.parse("2020-02-29"), 1f),
-                                      periode(LocalDate.parse("2020-02-01"), LocalDate.parse("2020-04-30"), 1f),
-                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-10-31"), 1f),
-                                      periode(LocalDate.parse("2020-09-01"), LocalDate.parse("2020-12-31"), 1f),
-                                      periode(LocalDate.parse("2021-01-01"), LocalDate.parse("2022-01-31"), 1f))
+    internal fun `ikke sammenhengende periode tvers stønadstyper fra ef og infotrygd returneres oppdelte`() {
+        val request = request(of(2022, 1), of(2022, 4))
+        val perioder = internePerioder(listOf(periode(of(2021, 1), of(2022, 1))),
+                                       listOf(periode(of(2022, 3), of(2023, 1))))
 
-
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2018-12-01") to LocalDate.parse("2022-01-31")))
+        val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+        assertThat(resultat).containsExactly(lagResultatPeriode(of(2021, 1), of(2022, 1)),
+                                             lagResultatPeriode(of(2022, 3), of(2023, 1)))
     }
 
     @Test
-    internal fun `skal slå sammen perioder til arena 3`() {
-        val infotrygPerioder = listOf(periode(LocalDate.parse("2017-06-01"),
-                                              LocalDate.parse("2017-10-31"), 1f,
-                                              LocalDate.parse("2018-07-31")),
-                                      periode(LocalDate.parse("2017-08-01"),
-                                              LocalDate.parse("2018-04-30"), 1f,
-                                              LocalDate.parse("2018-07-31")),
-                                      periode(LocalDate.parse("2018-05-01"),
-                                              LocalDate.parse("2020-07-31"), 1f,
-                                              LocalDate.parse("2018-07-31")),
-                                      periode(LocalDate.parse("2018-09-01"), LocalDate.parse("2018-12-31"), 1f),
-                                      periode(LocalDate.parse("2019-01-01"), LocalDate.parse("2019-04-30"), 1f),
-                                      periode(LocalDate.parse("2019-05-01"), LocalDate.parse("2020-04-30"), 1f),
-                                      periode(LocalDate.parse("2020-05-01"), LocalDate.parse("2020-08-31"), 1f))
+    internal fun `ikke sammenhengende periode av en type stønad fra ef og infotrygd returneres oppdelte`() {
+        val request = request(of(2022, 1), of(2022, 4))
+        val perioder = internePerioder(listOf(periode(of(2021, 1), of(2022, 1)),
+                                              periode(of(2022, 3), of(2023, 1))))
 
-
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(
-                        LocalDate.parse("2017-06-01") to LocalDate.parse("2018-07-31"),
-                        LocalDate.parse("2018-09-01") to LocalDate.parse("2020-08-31")))
+        val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+        assertThat(resultat).containsExactly(lagResultatPeriode(of(2021, 1), of(2022, 1)),
+                                             lagResultatPeriode(of(2022, 3), of(2023, 1)))
     }
 
     @Test
-    internal fun `skal slå sammen perioder til arena 4`() {
-        val infotrygPerioder =
-                listOf(periode(LocalDate.parse("2018-05-01"), LocalDate.parse("2018-05-31"), 1555f),
-                       periode(LocalDate.parse("2018-04-01"), LocalDate.parse("2018-05-31"), 2887f),
-                       periode(LocalDate.parse("2018-03-01"), LocalDate.parse("2018-05-31"), 0f),
-                       periode(LocalDate.parse("2018-02-01"), LocalDate.parse("2018-05-31"), 2024f),
-                       periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2018-05-31"), 3269f),
-                       periode(LocalDate.parse("2016-09-01"), LocalDate.parse("2018-05-31"), 869f),
-                       periode(LocalDate.parse("2016-04-01"), LocalDate.parse("2018-05-31"), 0f),
-                       periode(LocalDate.parse("2016-03-01"), LocalDate.parse("2018-05-31"), 0f),
-                       periode(LocalDate.parse("2018-01-01"), LocalDate.parse("2018-01-31"), 3299f),
-                       periode(LocalDate.parse("2017-12-01"), LocalDate.parse("2017-12-31"), 0f),
-                       periode(LocalDate.parse("2017-11-01"), LocalDate.parse("2017-12-31"), 1199f),
-                       periode(LocalDate.parse("2017-10-01"), LocalDate.parse("2017-12-31"), 1612f),
-                       periode(LocalDate.parse("2017-09-01"), LocalDate.parse("2017-12-31"), 0f),
-                       periode(LocalDate.parse("2017-08-01"), LocalDate.parse("2017-12-31"), 1424f),
-                       periode(LocalDate.parse("2017-02-01"), LocalDate.parse("2017-12-31"), 306f),
-                       periode(LocalDate.parse("2017-05-01"), LocalDate.parse("2017-11-30"), 3269f),
-                       periode(LocalDate.parse("2017-04-01"), LocalDate.parse("2017-04-30"), 2406f),
-                       periode(LocalDate.parse("2017-03-01"), LocalDate.parse("2017-04-30"), 0f),
-                       periode(LocalDate.parse("2017-02-01"), LocalDate.parse("2017-04-30"), 3006f),
-                       periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2017-02-28"), 2969f),
-                       periode(LocalDate.parse("2016-12-01"), LocalDate.parse("2017-02-28"), 0f),
-                       periode(LocalDate.parse("2016-11-01"), LocalDate.parse("2017-02-28"), 2256f),
-                       periode(LocalDate.parse("2016-10-01"), LocalDate.parse("2017-02-28"), 2069f),
-                       periode(LocalDate.parse("2016-09-01"), LocalDate.parse("2017-02-28"), 269f),
-                       periode(LocalDate.parse("2016-08-01"), LocalDate.parse("2016-08-31"), 2481f),
-                       periode(LocalDate.parse("2016-07-01"), LocalDate.parse("2016-07-31"), 3194f),
-                       periode(LocalDate.parse("2016-06-01"), LocalDate.parse("2016-06-30"), 0f),
-                       periode(LocalDate.parse("2016-05-01"), LocalDate.parse("2016-05-31"), 269f))
+    internal fun `request overlapper kun en av periodene`() {
+        val request = request(of(2022, 1), of(2022, 1))
+        val perioder = internePerioder(listOf(periode(of(2021, 1), of(2022, 1)),
+                                              periode(of(2022, 3), of(2023, 1))))
 
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(
-                        LocalDate.parse("2016-05-01") to LocalDate.parse("2016-05-31"),
-                        LocalDate.parse("2016-07-01") to LocalDate.parse("2018-05-31"))
-                )
+        val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+        assertThat(resultat).containsExactly(lagResultatPeriode(of(2021, 1), of(2022, 1)))
     }
 
     @Test
-    internal fun `skal slå sammen perioder til arena 5 - perioder som har samme startdato og sluttdato`() {
-        val infotrygPerioder =
-                listOf(periode(LocalDate.parse("2017-01-01"),
-                               LocalDate.parse("2017-06-30"), 17358f,
-                               LocalDate.parse("2017-01-01")),
-                       periode(LocalDate.parse("2017-01-01"),
-                               LocalDate.parse("2017-01-31"), 17358f,
-                               LocalDate.parse("2017-01-01")),
-                       periode(LocalDate.parse("2017-01-01"),
-                               LocalDate.parse("2017-05-31"), 17358f,
-                               LocalDate.parse("2017-03-31")))
+    internal fun `overlappende periode fra ef og infotrygd slås sammen tvers stønadstyper`() {
+        val request = request(of(2022, 1), of(2022, 1))
+        val perioder = internePerioder(listOf(periode(of(2021, 11), of(2022, 1))),
+                                       listOf(periode(of(2021, 1), of(2023, 1))))
 
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2017-01-01") to LocalDate.parse("2017-03-31")))
+        val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+        assertThat(resultat).containsExactly(lagResultatPeriode(of(2021, 1), of(2023, 1)))
     }
 
-    @Test
-    internal fun `skal slå sammen perioder til arena - sammenhengende måneder`() {
-        val infotrygPerioder =
-                listOf(periode(LocalDate.parse("2011-08-01"), LocalDate.parse("2011-08-01"), 1f),
-                       periode(LocalDate.parse("2011-09-01"), LocalDate.parse("2017-02-28"), 1f))
+    @Nested
+    inner class `Overlappende datoer` {
 
+        private val fom = of(2021, 3)
+        private val tom = of(2021, 5)
+        private val perioder = internePerioder(listOf(periode(fom, tom)))
+        private val expected = lagResultatPeriode(fom, tom)
 
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
+        @Test
+        internal fun `overlapper startdato`() {
+            val request = request(fom.minusMonths(1), tom.minusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).containsExactly(expected)
+        }
 
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2011-08-01") to LocalDate.parse("2017-02-28")))
+        @Test
+        internal fun `overlapper sluttdato`() {
+            val request = request(fom.plusMonths(1), tom.plusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).containsExactly(expected)
+        }
+
+        @Test
+        internal fun `delmengde av periode`() {
+            val request = request(fom.plusMonths(1), tom.minusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).containsExactly(expected)
+        }
+
+        @Test
+        internal fun `sammensluter periode`() {
+            val request = request(fom.minusMonths(1), tom.plusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).containsExactly(expected)
+        }
+
+        @Test
+        internal fun `før periode`() {
+            val request = request(fom.minusMonths(1), fom.minusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).isEmpty()
+        }
+
+        @Test
+        internal fun `etter periode`() {
+            val request = request(tom.plusMonths(1), tom.plusMonths(1))
+            val resultat = slåSammenPerioderFraEfOgInfotrygd(request, perioder)
+            assertThat(resultat).isEmpty()
+        }
     }
-
-    @Test
-    internal fun `skal slå sammen perioder til arena - opphør før FOM`() {
-        val infotrygPerioder =
-                listOf(periode(LocalDate.parse("2013-04-01"), LocalDate.parse("2013-06-30"), 2013f),
-                       periode(LocalDate.parse("2009-02-01"),
-                               LocalDate.parse("2011-04-30"), 11534f,
-                               LocalDate.parse("2009-01-31")),
-                       periode(LocalDate.parse("2009-02-01"),
-                               LocalDate.parse("2011-04-30"), 11534f,
-                               LocalDate.parse("2009-02-28")),
-                       periode(LocalDate.parse("2008-12-01"),
-                               LocalDate.parse("2009-01-31"), 11534f,
-                               LocalDate.parse("2009-01-31")))
-
-
-        val perioder = slåSammenPerioder(mapOgFiltrer(InfotrygdPerioderArenaResponse(infotrygPerioder)))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2008-12-01") to LocalDate.parse("2009-02-28"),
-                                  LocalDate.parse("2013-04-01") to LocalDate.parse("2013-06-30")))
-    }
-
-    @Test
-    internal fun `skal slå sammen perioder fra ulike stønadstyper fra ef`() {
-        val perioder = slåSammenPerioder(mapOgFiltrer(listOf(
-                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-01-01"), LocalDate.parse("2021-01-31")),
-                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-03-01"), LocalDate.parse("2021-05-31")),
-                lagAndelTilkjentYtelse(1, LocalDate.parse("2021-04-01"), LocalDate.parse("2021-07-31")),
-        )))
-
-        assertThat(perioder.tilFomTomDato())
-                .isEqualTo(listOf(LocalDate.parse("2021-01-01") to LocalDate.parse("2021-01-31"),
-                                  LocalDate.parse("2021-03-01") to LocalDate.parse("2021-07-31")))
-    }
-
-    private fun List<PeriodeOvergangsstønad>.tilFomTomDato(): List<Pair<LocalDate, LocalDate>> =
-            this.map { it.fomDato to it.tomDato }
-
-    private fun periode(fomDato: LocalDate, tomDato: LocalDate, beløp: Float, opphørsdato: LocalDate? = null) =
-            InfotrygdArenaPeriode(ident, fomDato, tomDato, beløp, opphørsdato)
 
 }
+
+private val ident = "01234567890"
+
+private fun request(fom: YearMonth, tom: YearMonth) =
+        PerioderOvergangsstønadRequest(ident, fom.atDay(1), tom.atEndOfMonth())
+
+private fun periode(fom: YearMonth, tom: YearMonth) =
+        InternPeriode(
+                personIdent = ident,
+                inntektsreduksjon = 0,
+                samordningsfradrag = 0,
+                beløp = 0,
+                stønadFom = fom.atDay(1),
+                stønadTom = tom.atEndOfMonth(),
+                opphørsdato = null,
+                datakilde = PeriodeOvergangsstønad.Datakilde.EF)
+
+private fun internePerioder(
+        overgangsstønad: List<InternPeriode> = emptyList(),
+        barnetilsyn: List<InternPeriode> = emptyList(),
+        skolepenger: List<InternPeriode> = emptyList()
+) = InternePerioder(overgangsstønad, barnetilsyn, skolepenger)
+
+private fun lagResultatPeriode(fom: YearMonth, tom: YearMonth) =
+        PeriodeOvergangsstønad(
+                personIdent = ident,
+                fomDato = fom.atDay(1),
+                tomDato = tom.atEndOfMonth(),
+                datakilde = PeriodeOvergangsstønad.Datakilde.EF
+        )

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
@@ -40,7 +40,6 @@ class InfotrygdReplikaMock {
                     emptyList()
                 )
             }
-            every { client.hentPerioderArena(any()) } returns InfotrygdPerioderArenaResponse(emptyList())
             every { client.hentSaker(any()) } returns InfotrygdSakResponse(emptyList())
             every { client.hentInslagHosInfotrygd(any()) } answers { InfotrygdFinnesResponse(emptyList(), emptyList()) }
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/ArenaStønadsperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/ArenaStønadsperioderServiceTest.kt
@@ -2,13 +2,14 @@ package no.nav.familie.ef.sak.service
 
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.ekstern.arena.ArenaStønadsperioderService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
+import no.nav.familie.ef.sak.infotrygd.InfotrygdPeriodeTestUtil.lagInfotrygdPeriode
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
-import no.nav.familie.ef.sak.infrastruktur.exception.PdlNotFoundException
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.infotrygd.PeriodeService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
@@ -18,20 +19,21 @@ import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
 import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdArenaPeriode
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaRequest
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPerioderArenaResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad
 import no.nav.familie.kontrakter.felles.ef.PeriodeOvergangsstønad.Datakilde
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadRequest
 import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
-import java.time.LocalDate.parse
+import java.time.LocalDate.now
+import java.time.LocalDate.of
+import java.time.YearMonth
 
+@Disabled // TODO fiks denne når man tar i bruk ny tolkning av arena-perioder
 internal class ArenaStønadsperioderServiceTest {
 
     private val pdlClient = mockk<PdlClient>()
@@ -40,92 +42,108 @@ internal class ArenaStønadsperioderServiceTest {
     private val personopplysningerIntergasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
     private val fagsakService = mockk<FagsakService>()
+    private val periodeService = PeriodeService(pdlClient,
+                                                fagsakService,
+                                                behandlingService,
+                                                tilkjentYtelseService,
+                                                InfotrygdService(infotrygdReplikaClient, pdlClient))
 
-    private val service =
-            ArenaStønadsperioderService(infotrygdReplikaClient = infotrygdReplikaClient,
-                                        behandlingService = behandlingService,
-                                        pdlClient = pdlClient,
-                                        tilkjentYtelseService = tilkjentYtelseService,
-                                        personopplysningerIntegrasjonerClient = personopplysningerIntergasjonerClient,
-                                        fagsakService = fagsakService)
+    private val service = ArenaStønadsperioderService(
+            periodeService = periodeService,
+            personopplysningerIntegrasjonerClient = personopplysningerIntergasjonerClient)
 
     private val ident = "01234567890"
 
     private val fagsakOvergangsstønad = fagsak(stønadstype = Stønadstype.OVERGANGSSTØNAD)
-    private val fagsakBarnetilsyn = fagsak(stønadstype = Stønadstype.BARNETILSYN)
     private val behandlingOvergangsstønad = behandling(fagsakOvergangsstønad)
-    private val behandlingBarnetilsyn = behandling(fagsakBarnetilsyn)
 
     @BeforeEach
     internal fun setUp() {
+        every { personopplysningerIntergasjonerClient.hentInfotrygdPerioder(any()) } returns
+                PerioderOvergangsstønadResponse(emptyList())
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns InfotrygdPeriodeResponse(emptyList(),
+                                                                                              emptyList(),
+                                                                                              emptyList())
         every { behandlingService.finnSisteIverksatteBehandling(any()) } returns null
+        every { fagsakService.finnFagsak(any(), any()) } returns null
         every { fagsakService.finnFagsak(any(), Stønadstype.OVERGANGSSTØNAD) } returns fagsakOvergangsstønad
-        every { fagsakService.finnFagsak(any(), Stønadstype.BARNETILSYN) } returns fagsakBarnetilsyn
-        every { fagsakService.finnFagsak(any(), Stønadstype.SKOLEPENGER) } returns null
     }
 
     @Test
-    internal fun `hentPerioder henter perioder fra infotrygd med alle identer fra pdl`() {
-        val historiskIdent = "01234567890"
-        val fomDato = LocalDate.MIN
-        val tomDato = LocalDate.MAX
-        val request = PerioderOvergangsstønadRequest(ident, fomDato, tomDato)
-
-        mockPdl(historiskIdent)
-        every { infotrygdReplikaClient.hentPerioderArena(any()) } returns
-                infotrygdResponse(InfotrygdArenaPeriode(ident, LocalDate.now(), LocalDate.now(), 10f))
-
-        val hentPerioder = service.hentReplikaPerioder(request)
-
-        assertThat(hentPerioder).hasSize(1)
-
-        verify(exactly = 1) { pdlClient.hentPersonidenter(ident, true) }
-        verify(exactly = 1) {
-            val infotrygdRequest = InfotrygdPerioderArenaRequest(setOf(ident, historiskIdent), fomDato, tomDato)
-            infotrygdReplikaClient.hentPerioderArena(infotrygdRequest)
-        }
-    }
-
-    @Test
-    internal fun `skal ikke kalle infotrygd hvis pdl ikke finner personIdent med personIdent i requesten`() {
-        every { pdlClient.hentPersonidenter(any(), true) } throws PdlNotFoundException()
-
-        assertThrows<PdlNotFoundException> { service.hentReplikaPerioder(PerioderOvergangsstønadRequest(ident)) }
-        verify(exactly = 0) {
-            infotrygdReplikaClient.hentPerioderArena(InfotrygdPerioderArenaRequest(setOf(ident)))
-        }
-    }
-
-    @Test
-    internal fun `skal returnere perioder fra både infotrygd og ef`() {
+    internal fun `finner ikke perioder i infotrygd eller ny løsning`() {
         mockPdl()
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, now(), now()))
+        assertThat(perioder.perioder.isEmpty())
+    }
+
+    @Test
+    internal fun `finner kun perioder i infotrygd`() {
+        val fom = YearMonth.of(2021, 1)
+        val tom = YearMonth.of(2021, 3)
+        mockPdl()
+        mockInfotrygd(fom.atDay(1), tom.atEndOfMonth())
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, fom.atDay(1), tom.atEndOfMonth()))
+        assertThat(perioder.perioder).hasSize(1)
+        assertThat(perioder.perioder).containsExactly(lagResultatPeriode(fom, tom))
+    }
+
+    @Test
+    internal fun `finner kun perioder i ny løsning`() {
+        val fom = YearMonth.of(2021, 1)
+        val tom = YearMonth.of(2021, 3)
+        mockPdl()
+        mockNyLøsning(fom.atDay(1), tom.atEndOfMonth())
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, fom.atDay(1), tom.atEndOfMonth()))
+        assertThat(perioder.perioder).hasSize(1)
+        assertThat(perioder.perioder).containsExactly(lagResultatPeriode(fom, tom))
+    }
+
+    @Test
+    internal fun `finner sammenhengende perioder`() {
+        val fom = YearMonth.of(2021, 1)
+        val tom = YearMonth.of(2021, 3)
+        mockPdl()
+        mockInfotrygd(of(2021, 1, 1), of(2021, 1, 31))
+        mockNyLøsning(of(2021, 2, 1), of(2021, 3, 31))
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, fom.atDay(1), tom.atEndOfMonth()))
+        assertThat(perioder.perioder).hasSize(1)
+        assertThat(perioder.perioder).containsExactly(lagResultatPeriode(fom, tom))
+    }
+
+    @Test
+    internal fun `finner overlappende perioder`() {
+        val fom = YearMonth.of(2021, 1)
+        val tom = YearMonth.of(2021, 3)
+        mockPdl()
+        mockInfotrygd(fom.atDay(1), tom.atEndOfMonth())
+        mockNyLøsning(fom.atDay(1), tom.atEndOfMonth())
+        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, fom.atDay(1), tom.atEndOfMonth()))
+        assertThat(perioder.perioder).hasSize(1)
+        assertThat(perioder.perioder).containsExactly(lagResultatPeriode(fom, tom))
+    }
+
+    private fun mockInfotrygd(stønadFom: LocalDate, stønadTom: LocalDate) {
+        val infotrygdPeriode = lagInfotrygdPeriode(stønadFom = stønadFom, stønadTom = stønadTom)
+        val infotrygdPeriodeResponse = InfotrygdPeriodeResponse(listOf(infotrygdPeriode), emptyList(), emptyList())
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns infotrygdPeriodeResponse
+    }
+
+    private fun mockNyLøsning(stønadFom: LocalDate, stønadTom: LocalDate) {
         every { behandlingService.finnSisteIverksatteBehandling(fagsakOvergangsstønad.id) } returns behandlingOvergangsstønad
-        every { behandlingService.finnSisteIverksatteBehandling(fagsakBarnetilsyn.id) } returns behandlingBarnetilsyn
-
-        every { personopplysningerIntergasjonerClient.hentInfotrygdPerioder(any()) } returns PerioderOvergangsstønadResponse(
-                listOf(
-                        PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-01-31"), Datakilde.INFOTRYGD)))
         every { tilkjentYtelseService.hentForBehandling(behandlingOvergangsstønad.id) } returns
-                lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(1, parse("2021-01-01"), parse("2021-01-31"), ident)))
-        every { tilkjentYtelseService.hentForBehandling(behandlingBarnetilsyn.id) } returns
-                lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(2, parse("2021-02-01"), parse("2021-03-31"), ident)))
-
-        val perioder = service.hentPerioder(PerioderOvergangsstønadRequest(ident, parse("2020-01-01"), parse("2022-01-01")))
-        assertThat(perioder.perioder).containsExactly(
-                PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-01-31"), Datakilde.INFOTRYGD),
-                PeriodeOvergangsstønad(ident, parse("2021-01-01"), parse("2021-03-31"), Datakilde.EF),
-        )
-
+                lagTilkjentYtelse(listOf(lagAndelTilkjentYtelse(0, stønadFom, stønadTom, ident)))
     }
 
-    private fun mockPdl(historiskIdent: String? = null) {
-        val pdlIdenter = mutableListOf(PdlIdent(ident, false))
-        if (historiskIdent != null) {
-            pdlIdenter.add(PdlIdent(historiskIdent, true))
-        }
-        every { pdlClient.hentPersonidenter(ident, true) } returns PdlIdenter(pdlIdenter)
+    private fun mockPdl() {
+        every { pdlClient.hentPersonidenter(ident, true) } returns PdlIdenter(mutableListOf(PdlIdent(ident, false)))
     }
 
-    private fun infotrygdResponse(vararg infotrygdPeriodeOvergangsstønad: InfotrygdArenaPeriode) =
-            InfotrygdPerioderArenaResponse(infotrygdPeriodeOvergangsstønad.toList())
+    private fun lagResultatPeriode(fom: YearMonth, tom: YearMonth) =
+            PeriodeOvergangsstønad(
+                    personIdent = ident,
+                    fomDato = fom.atDay(1),
+                    tomDato = tom.atEndOfMonth(),
+                    datakilde = Datakilde.EF
+            )
+
 }


### PR DESCRIPTION
Først slåes de sammen for hvert type stønad, og senere slås de sammen tvers stønadstype.
Tar med perioder som har 0 i beløp, etter diskusjon med arena

https://nav-it.slack.com/archives/C01JAJ7HCBF/p1643199210010900
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7846

Dette blir bare logget i en første runde. Men har ikke så mye å si