### PR TITLE
Vil at logiske vedlegg skal sendes med dokumentinfo

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/DokumentinfoDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/DokumentinfoDto.kt
@@ -16,6 +16,6 @@ data class DokumentinfoDto(val dokumentinfoId: String,
                            val dato: LocalDateTime?,
                            val journalstatus: Journalstatus,
                            val journalposttype: Journalposttype,
-                           val logiskeVedlegg: List<LogiskVedleggDto>? = null)
+                           val logiskeVedlegg: List<LogiskVedleggDto>)
 
 data class LogiskVedleggDto(val tittel: String)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/DokumentinfoDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/DokumentinfoDto.kt
@@ -15,4 +15,7 @@ data class DokumentinfoDto(val dokumentinfoId: String,
                            val journalpostId: String,
                            val dato: LocalDateTime?,
                            val journalstatus: Journalstatus,
-                           val journalposttype: Journalposttype)
+                           val journalposttype: Journalposttype,
+                           val logiskeVedlegg: List<LogiskVedleggDto>? = null)
+
+data class LogiskVedleggDto(val tittel: String)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
@@ -65,7 +65,7 @@ class VedleggService(private val behandlingService: BehandlingService,
                 dato = mestRelevanteDato(journalpost),
                 journalstatus = journalpost.journalstatus,
                 journalposttype = journalpost.journalposttype,
-                logiskeVedlegg = dokumentInfo.logiskeVedlegg?.map { LogiskVedleggDto(tittel = it.tittel) }
+                logiskeVedlegg = dokumentInfo.logiskeVedlegg?.map { LogiskVedleggDto(tittel = it.tittel) } ?: emptyList()
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
@@ -64,7 +64,8 @@ class VedleggService(private val behandlingService: BehandlingService,
                 journalpostId = journalpost.journalpostId,
                 dato = mestRelevanteDato(journalpost),
                 journalstatus = journalpost.journalstatus,
-                journalposttype = journalpost.journalposttype
+                journalposttype = journalpost.journalposttype,
+                logiskeVedlegg = dokumentInfo.logiskeVedlegg?.map { LogiskVedleggDto(tittel = it.tittel) }
         )
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -22,7 +22,6 @@ import no.nav.familie.kontrakter.felles.BrukerIdType
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.dokarkiv.ArkiverDokumentResponse
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
-import no.nav.familie.kontrakter.felles.ef.PerioderOvergangsstønadResponse
 import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariant
@@ -30,6 +29,7 @@ import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariantformat
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
+import no.nav.familie.kontrakter.felles.journalpost.LogiskVedlegg
 import no.nav.familie.kontrakter.felles.journalpost.RelevantDato
 import no.nav.familie.kontrakter.felles.kodeverk.BeskrivelseDto
 import no.nav.familie.kontrakter.felles.kodeverk.BetydningDto
@@ -183,6 +183,16 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
                                                 brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
                                                 dokumentvarianter =
                                                 listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV))
+                                   ),
+                                   DokumentInfo(dokumentInfoId = "12345",
+                                                tittel = "Manuelt skannet dokument",
+                                                brevkode = DokumentBrevkode.OVERGANGSSTØNAD.verdi,
+                                                dokumentvarianter =
+                                                listOf(Dokumentvariant(variantformat = Dokumentvariantformat.ARKIV)),
+                                                logiskeVedlegg = listOf(LogiskVedlegg(logiskVedleggId = "1",
+                                                                                      tittel = "Manuelt skannet samværsavtale"),
+                                                                        LogiskVedlegg(logiskVedleggId = "2",
+                                                                                      tittel = "Annen fritekst fra gosys"))
                                    ),
                                    DokumentInfo(dokumentInfoId = "12345",
                                                 tittel = "EtFrykteligLangtDokumentNavnSomTroligIkkeBrekkerOgØdeleggerGUI",


### PR DESCRIPTION
Manuelt skannede dokumenter bruker logiske vedlegg for å beskrive innholdet i det sammensatte dokumentet