### PR TITLE
Skal endre stønadTom hvis perioder overlapper med perioder fra enslig…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriodeUtil.kt
@@ -11,8 +11,10 @@ object InternPeriodeUtil {
         val perioderFraInfotrygdSomBeholdes = infotrygdperioder.mapNotNull {
             if (it.stønadFom >= førstePerioden.stønadFom) {
                 null
-            } else {
+            } else if (it.stønadTom > førstePerioden.stønadFom) {
                 it.copy(stønadTom = førstePerioden.stønadFom.minusDays(1))
+            } else {
+                it
             }
         }
         return efPerioder + perioderFraInfotrygdSomBeholdes


### PR DESCRIPTION
… forsørger.

Vi ska alltså ikke sette tom-dato på alle perioder, det blir fort feil

Det som skjedde då var att vi satte tom-dato på perioder til dagens dato, og får då overlapp av perioder. Som blir feil hos Infotrygd - og risikerer att det generellt blir feil når vi endrer tom-dato på alle perioder.. 🙄 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8146