### PR TITLE
Fjerner logging av data sendt til konsistensavstemming fordi den ikke…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/avstemming/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/avstemming/AvstemmingService.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.sak.avstemming
 
 import no.nav.familie.ef.sak.fagsak.domain.Stønadstype
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.kontrakter.ef.felles.StønadType
@@ -14,11 +13,9 @@ import java.time.LocalDate
 
 @Service
 class AvstemmingService(private val iverksettClient: IverksettClient,
-                        private val tilkjentYtelseService: TilkjentYtelseService,
-                        private val featureToggleService: FeatureToggleService) {
+                        private val tilkjentYtelseService: TilkjentYtelseService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun konsistensavstemOppdrag(stønadstype: Stønadstype, datoForAvstemming: LocalDate) {
         val tilkjenteYtelser = tilkjentYtelseService
@@ -30,20 +27,6 @@ class AvstemmingService(private val iverksettClient: IverksettClient,
     private fun loggKonsistensavstemming(konsistensavstemming: List<KonsistensavstemmingTilkjentYtelseDto>) {
         val beløp = konsistensavstemming.sumOf { it.andelerTilkjentYtelse.sumOf(AndelTilkjentYtelseDto::beløp) }
         logger.info("Konsistensavstemming antall=${konsistensavstemming.size} beløp=$beløp")
-
-        if (featureToggleService.isEnabled("familie.ef.sak.konsistensavstemming-logg")) {
-            if (konsistensavstemming.size > 100) {
-                logger.error("På tide å fjerne denne eller vurdere å lagre konsistensavstemming i databasen")
-                return
-            }
-            konsistensavstemming.forEach {
-                val andeler = it.andelerTilkjentYtelse.map { aty -> "beløp=${aty.beløp} fom=${aty.fraOgMed} tom=${aty.tilOgMed}" }
-                secureLogger.info("Konsistensavstemming" +
-                                  " behandling=${it.behandlingId}" +
-                                  " fagsak=${it.eksternFagsakId}" +
-                                  " andeler=$andeler")
-            }
-        }
     }
 
 }


### PR DESCRIPTION
… lengre trenges

Den logget nå error i seneste konsistensavstemmingen, det var fint å ha med de første gangene men nå trengs den ikke. Det går å gjøre en spørring i ettertid for å finne ut hvilke som ble konsistensavstemt hvis det er behov for det.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8131