### PR TITLE
Vil ikke regenerere brev fra saksbehnalder i besluttersteg.

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -73,6 +73,7 @@ spec:
         - application: familie-brev
         - application: familie-ef-blankett
         - application: familie-ef-iverksett
+        - application: familie-dokument
         - application: familie-ef-proxy
           cluster: dev-fss
       external:

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -68,6 +68,7 @@ spec:
         - application: familie-brev
         - application: familie-ef-blankett
         - application: familie-ef-iverksett
+        - application: familie-dokument
         - application: familie-ef-proxy
           cluster: prod-fss
       external:

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
@@ -1,10 +1,13 @@
 package no.nav.familie.ef.sak.brev
 
 import com.fasterxml.jackson.databind.JsonNode
+import no.nav.familie.ef.sak.brev.VedtaksbrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
+import no.nav.familie.ef.sak.brev.domain.FRITEKST
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevRequestDto
 import no.nav.familie.ef.sak.brev.dto.VedtaksbrevDto
 import no.nav.familie.ef.sak.brev.dto.erFritekstType
 import no.nav.familie.ef.sak.felles.util.medContentTypeJsonUTF8
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.springframework.beans.factory.annotation.Qualifier
@@ -53,6 +56,29 @@ class BrevClient(@Value("\${FAMILIE_BREV_API_URL}")
                                                             null,
                                                             enhet),
                              HttpHeaders().medContentTypeJsonUTF8())
+    }
+
+    fun genererHtml(brevmal: String,
+                    saksbehandlerBrevrequest: JsonNode,
+                    saksbehandlersignatur: String,
+                    enhet: String?,
+                    skjulBeslutterSignatur: Boolean): String {
+
+        feilHvis(brevmal === FRITEKST) {
+            "HTML-generering av fritekstbrev er ikke implementert"
+        }
+
+        val url = URI.create("$familieBrevUri/api/ef-brev/avansert-dokument/bokmaal/${brevmal}/html")
+
+        return postForEntity(url,
+                             BrevRequestMedSignaturer(brevFraSaksbehandler = saksbehandlerBrevrequest,
+                                                      saksbehandlersignatur = saksbehandlersignatur,
+                                                      besluttersignatur = BESLUTTER_SIGNATUR_PLACEHOLDER,
+                                                      enhet = enhet,
+                                                      skjulBeslutterSignatur = skjulBeslutterSignatur
+                             ),
+                             HttpHeaders().medContentTypeJsonUTF8()
+        )
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.brev.dto.SignaturDto
 import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
@@ -1,19 +1,22 @@
 package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.brev.dto.SignaturDto
+import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 
 @Service
-class BrevsignaturService(val personopplysningerService: PersonopplysningerService) {
+class BrevsignaturService(val personopplysningerService: PersonopplysningerService, val fagsakService: FagsakService) {
 
 
-    fun lagSignaturMedEnhet(fagsak: Fagsak): SignaturDto {
+    fun lagSignaturMedEnhet(fagsakId: UUID): SignaturDto {
+        val fagsak = fagsakService.hentFagsak(fagsakId)
         val harStrengtFortroligAdresse: Boolean =
                 personopplysningerService.hentStrengesteAdressebeskyttelseForPersonMedRelasjoner(fagsak.hentAktivIdent())
                         .let { it == STRENGT_FORTROLIG || it == STRENGT_FORTROLIG_UTLAND }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FamilieDokumentClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FamilieDokumentClient.kt
@@ -1,0 +1,43 @@
+package no.nav.familie.ef.sak.brev
+
+import no.nav.familie.http.client.AbstractPingableRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+@Component
+class FamilieDokumentClient(@Value("\${FAMILIE_DOKUMENT_URL}")
+                            private val familieDokumentUrl: String,
+                            @Qualifier("utenAuth")
+                            private val restOperations: RestOperations) : AbstractPingableRestClient(restOperations,
+                                                                                                     "familie.dokument") {
+
+    fun genererPdfFraHtml(html: String): ByteArray {
+
+        val htmlTilPdfURI = URI.create("$familieDokumentUrl/$HTML_TIL_PDF")
+
+        return postForEntity(uri = htmlTilPdfURI,
+                             payload =  html.encodeToByteArray(),
+                             httpHeaders = HttpHeaders().apply {
+                                 this.contentType = MediaType.TEXT_HTML
+                                 this.accept = listOf(MediaType.APPLICATION_PDF)
+                             })
+    }
+
+
+
+    override val pingUri: URI = URI.create("$familieDokumentUrl/api/status")
+
+    override fun ping() {
+        operations.optionsForAllow(pingUri)
+    }
+
+    companion object {
+
+        const val HTML_TIL_PDF = "api/html-til-pdf"
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FamilieDokumentClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FamilieDokumentClient.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.brev
 
-import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.http.client.AbstractRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -13,7 +13,7 @@ import java.net.URI
 class FamilieDokumentClient(@Value("\${FAMILIE_DOKUMENT_URL}")
                             private val familieDokumentUrl: String,
                             @Qualifier("utenAuth")
-                            private val restOperations: RestOperations) : AbstractPingableRestClient(restOperations,
+                            private val restOperations: RestOperations) : AbstractRestClient(restOperations,
                                                                                                      "familie.dokument") {
 
     fun genererPdfFraHtml(html: String): ByteArray {
@@ -26,14 +26,6 @@ class FamilieDokumentClient(@Value("\${FAMILIE_DOKUMENT_URL}")
                                  this.contentType = MediaType.TEXT_HTML
                                  this.accept = listOf(MediaType.APPLICATION_PDF)
                              })
-    }
-
-
-
-    override val pingUri: URI = URI.create("$familieDokumentUrl/api/status")
-
-    override fun ping() {
-        operations.optionsForAllow(pingUri)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
@@ -56,7 +56,7 @@ class FrittståendeBrevService(private val brevClient: BrevClient,
         val fagsak = fagsakService.hentFagsak(frittståendeBrevDto.fagsakId)
         val aktivIdent = fagsak.hentAktivIdent()
         val request = lagFrittståendeBrevRequest(frittståendeBrevDto, aktivIdent)
-        val signatur = brevsignaturService.lagSignaturMedEnhet(fagsak)
+        val signatur = brevsignaturService.lagSignaturMedEnhet(frittståendeBrevDto.fagsakId)
         val brev = brevClient.genererBrev(request, signatur.navn, signatur.enhet)
         return brev
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -136,14 +136,14 @@ class VedtaksbrevService(private val brevClient: BrevClient,
 
     private fun lagBeslutterPdfMedSignatur(besluttervedtaksbrev: Vedtaksbrev,
                                            signaturMedEnhet: SignaturDto) =
-            when (besluttervedtaksbrev.saksbehandlerHtml != null) {
+            when (besluttervedtaksbrev.saksbehandlerHtml != null) { // TODO: saksbehandlerHtml skal kanskje bli ikke-nullable.
                 true -> {
                     val htmlMedBeslutterSignatur = settInnBeslutterSignaturIHtml(html = besluttervedtaksbrev.saksbehandlerHtml,
                                                                                  beslutterSignatur = besluttervedtaksbrev.besluttersignatur)
                     Fil(familieDokumentClient.genererPdfFraHtml(htmlMedBeslutterSignatur))
 
                 }
-                false ->
+                false -> // TODO: Denne branchen kan fjernes når gamle brev er besluttet
                     Fil(brevClient.genererBrev(besluttervedtaksbrev.tilDto(signaturMedEnhet.skjulBeslutter)))
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -67,10 +67,7 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                                                        saksbehandlersignatur.enhet,
                                                        html)
 
-
-            val pdf = familieDokumentClient.genererPdfFraHtml(html)
-
-            return pdf
+            return familieDokumentClient.genererPdfFraHtml(html)
 
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -11,12 +11,10 @@ import no.nav.familie.ef.sak.brev.domain.tilDto
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevRequestDto
 import no.nav.familie.ef.sak.brev.dto.SignaturDto
 import no.nav.familie.ef.sak.brev.dto.VedtaksbrevFritekstDto
-import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.domain.Fil
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
-import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Vedtaksbrev.kt
@@ -9,6 +9,7 @@ import java.util.UUID
 data class Vedtaksbrev(@Id
                        val behandlingId: UUID,
                        val saksbehandlerBrevrequest: String,
+                       val saksbehandlerHtml: String? = null,
                        val brevmal: String,
                        val saksbehandlersignatur: String,
                        val besluttersignatur: String? = null,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,6 +171,7 @@ AZUREAD_TOKEN_ENDPOINT_URL: https://login.microsoftonline.com/${AZURE_APP_TENANT
 FAMILIE_BREV_API_URL: http://familie-brev
 FAMILIE_BLANKETT_API_URL: http://familie-ef-blankett
 FAMILIE_EF_IVERKSETT_URL: http://familie-ef-iverksett
+FAMILIE_DOKUMENT_URL: http://familie-dokument
 
 
 FAMILIE_TILBAKE_URL: http://familie-tilbake

--- a/src/main/resources/db/migration/V98__html_i_vedtaksbrev.sql
+++ b/src/main/resources/db/migration/V98__html_i_vedtaksbrev.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vedtaksbrev ADD COLUMN saksbehandler_html VARCHAR;

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -66,7 +66,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
                 "mock-inntekt",
                 "mock-ereg",
                 "mock-aareg",
-                "mock-tilbakekreving")
+                "mock-tilbakekreving",
+                "mock-dokument")
 @EnableMockOAuth2Server
 abstract class OppslagSpringRunnerTest {
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturServiceTest.kt
@@ -2,22 +2,37 @@ package no.nav.familie.ef.sak.brev
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
 
 internal class BrevsignaturServiceTest {
 
+    val personopplysningerService = mockk<PersonopplysningerService>()
+    val fagsakService = mockk<FagsakService>()
+
+    val brevsignaturService = BrevsignaturService(personopplysningerService, fagsakService)
+
+    @BeforeEach
+    fun setUp(){
+        every { fagsakService.hentFagsak(any()) } returns fagsak(identer = setOf(PersonIdent("123")))
+    }
+
     @Test
     fun `skal sende frittstående brev med NAV Vikafossen signatur `() {
-        val personopplysningerService = mockk<PersonopplysningerService>()
-        val brevsignaturService = BrevsignaturService(personopplysningerService)
         every { personopplysningerService.hentStrengesteAdressebeskyttelseForPersonMedRelasjoner(any()) } returns ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
-        val signaturMedEnhet = brevsignaturService.lagSignaturMedEnhet(fagsak(identer = fagsakpersoner(setOf("123"))))
+        val signaturMedEnhet = brevsignaturService.lagSignaturMedEnhet(UUID.randomUUID())
         Assertions.assertThat(signaturMedEnhet.enhet).isEqualTo(BrevsignaturService.ENHET_VIKAFOSSEN)
         Assertions.assertThat(signaturMedEnhet.navn).isEqualTo(BrevsignaturService.NAV_ANONYM_NAVN)
     }
@@ -26,12 +41,9 @@ internal class BrevsignaturServiceTest {
     fun `skal sende frittstående brev med vanlig nay signatur når søkeradressebeskyttelse er ugradert `() {
         val fortventetSaksbehandlerNavn = "Ole Olsen"
         BrukerContextUtil.mockBrukerContext(fortventetSaksbehandlerNavn)
-        val personopplysningerService = mockk<PersonopplysningerService>()
-        val brevsignaturService = BrevsignaturService(personopplysningerService)
-
         every { personopplysningerService.hentStrengesteAdressebeskyttelseForPersonMedRelasjoner(any()) } returns ADRESSEBESKYTTELSEGRADERING.UGRADERT
 
-        val signaturMedEnhet = brevsignaturService.lagSignaturMedEnhet(fagsak(identer = fagsakpersoner(setOf("123"))))
+        val signaturMedEnhet = brevsignaturService.lagSignaturMedEnhet(UUID.randomUUID())
 
         Assertions.assertThat(signaturMedEnhet.enhet).isEqualTo(BrevsignaturService.ENHET_NAY)
         Assertions.assertThat(signaturMedEnhet.navn).isEqualTo(fortventetSaksbehandlerNavn)

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/BrevClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/BrevClientMock.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ef.sak.infrastruktur.config
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.brev.BrevClient
+import no.nav.familie.ef.sak.brev.VedtaksbrevService
+import no.nav.familie.ef.sak.brev.VedtaksbrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -19,6 +21,7 @@ class BrevClientMock {
         val dummyPdf = this::class.java.classLoader.getResource("dummy/pdf_dummy.pdf")!!.readBytes()
         every { brevClient.genererBrev(any()) } returns dummyPdf
         every { brevClient.genererBrev(any(), any(), "NAV Arbeid og ytelser") } returns dummyPdf
+        every { brevClient.genererHtml(any(), any(), any(), any(), any()) } returns "<h1>Hei $BESLUTTER_SIGNATUR_PLACEHOLDER</h1>"
         return brevClient
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieDokumentClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieDokumentClientMock.kt
@@ -1,0 +1,23 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.brev.FamilieDokumentClient
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("mock-dokument")
+class FamilieDokumentClientMock {
+
+    @Bean
+    @Primary
+    fun familieDokument(): FamilieDokumentClient {
+        val familieDokumentClient: FamilieDokumentClient = mockk()
+        val dummyPdf = this::class.java.classLoader.getResource("dummy/pdf_dummy.pdf")!!.readBytes()
+        every { familieDokumentClient.genererPdfFraHtml(any()) } returns dummyPdf
+        return  familieDokumentClient
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
@@ -19,10 +19,14 @@ internal class VedtaksbrevRepositoryTest : OppslagSpringRunnerTest() {
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val vedtaksbrev = Vedtaksbrev(behandlingId = behandling.id,
                                       saksbehandlerBrevrequest = "testhallo",
+                                      saksbehandlerHtml = null,
                                       brevmal = "brevmalnavn",
                                       saksbehandlersignatur = "Sakliga Behandlersen",
                                       besluttersignatur = "",
-                                      beslutterPdf = null, "", "", "")
+                                      beslutterPdf = null,
+                                      enhet = "",
+                                      saksbehandlerident = "",
+                                      beslutterident = "")
 
         vedtaksbrevRepository.insert(vedtaksbrev)
 

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -25,6 +25,7 @@ FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BLANKETT_API_URL: http://localhost:8033
 FAMILIE_EF_IVERKSETT_URL: http://localhost:8094
 FAMILIE_EF_PROXY_URL: http://localhost:8002
+FAMILIE_DOKUMENT_URL: http://localhost:8082
 
 AZURE_APP_TENANT_ID: navq.onmicrosoft.com
 AZURE_APP_CLIENT_ID: ${AZURE_CLIENT_ID}


### PR DESCRIPTION
Plan:
1. (Denne PR) Lagrer html av saksbehandlerbrev, lager pdf av html mot familie-dokument og bruker dette i besluttersteget.
2. Fullføre samme flyt for fritekstbrev
3. Vente til alle gamle brev er ute av loop (ferdig besluttet) 
4. Fjerne lagring av brevRequest (ikke lenger nødvendig) 
5. Forbedring av kode (flytte en del logikk ut av client til service, bedre validering i kontroller rett steg/status for forskjellige endepunkt) 



### Ny flyt
```mermaid
sequenceDiagram
sak-frontend->>sak-backend: saksbehandlerbrev(request): flettefelter, valgfelt, osv...
loop
    sak-backend->>sak-backend: lag saksbehandler signatur
end
sak-backend->>familie-brev: brevrequest med signatur
loop
    familie-brev-->>familie-brev: lag html med saksbehandlersignatur og placeholder for beslutter
end
familie-brev-->>sak-backend: returner html
loop
    sak-backend->>sak-backend: lagre html av saksbehandlerbrev
end
sak-backend->>familie-dokument: html
familie-dokument-->>sak-backend: pdf
sak-backend-->>sak-frontend: saksbehandler-pdf
sak-frontend->>sak-backend: lagBeslutterBrev()
loop
    sak-backend->>sak-backend: hent lagret html fra db, og sett inn i besluttersignatur
end
sak-backend->>familie-dokument: html
familie-dokument-->>sak-backend: pdf
loop
    sak-backend->>sak-backend: lagre beslutter-pdf
end
sak-backend-->>sak-frontend: beslutter-pdf
```
### Gammel flyt
```mermaid
sequenceDiagram
sak-frontend->>sak-backend: saksbehandlerbrev(request): flettefelter, valgfelt, osv...
loop
    sak-backend->>sak-backend: lag saksbehandler signatur, og lagre brevrequest
end
sak-backend->>familie-brev: brevrequest med signatur
loop
    familie-brev-->>familie-brev: lag html med saksbehandlersignatur
end
familie-brev->>familie-dokument: html
familie-dokument-->>familie-brev: pdf
familie-brev-->>sak-backend: pdf

sak-backend-->>sak-frontend: saksbehandler-pdf
sak-frontend->>sak-backend: lagBeslutterBrev()
loop
    sak-backend->>sak-backend: hent lagret brevrequest (fletefelter, valgfelter) fra db og lag besluttersignatur
end
sak-backend->>familie-brev: brevrequest + signaturer
familie-brev-->>sak-backend: pdf
loop
    sak-backend->>sak-backend: lagre beslutter-pdf
end
sak-backend-->>sak-frontend: beslutter-pdf

```