### PR TITLE
Feature/html for fritekstbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
@@ -30,6 +30,7 @@ class BrevClient(@Value("\${FAMILIE_BREV_API_URL}")
         operations.optionsForAllow(pingUri)
     }
 
+    @Deprecated("Skal slettes når fritekstbrev har tatt i bruk html")
     fun genererBrev(vedtaksbrev: VedtaksbrevDto): ByteArray {
 
         val url = when (vedtaksbrev.erFritekstType()) {
@@ -79,6 +80,16 @@ class BrevClient(@Value("\${FAMILIE_BREV_API_URL}")
                              ),
                              HttpHeaders().medContentTypeJsonUTF8()
         )
+    }
+
+    fun genererHtmlFritekstbrev(fritekstBrev: FrittståendeBrevRequestDto, saksbehandlerNavn: String, enhet: String): String {
+        val url = URI.create("$familieBrevUri/api/fritekst-brev/html")
+        return postForEntity(url,
+                             FritekstBrevRequestMedSignatur(fritekstBrev,
+                                                            saksbehandlerNavn,
+                                                            BESLUTTER_SIGNATUR_PLACEHOLDER,
+                                                            enhet),
+                             HttpHeaders().medContentTypeJsonUTF8())
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
@@ -30,7 +29,6 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                          private val behandlingService: BehandlingService,
                          private val personopplysningerService: PersonopplysningerService,
                          private val brevsignaturService: BrevsignaturService,
-                         private val featureToggleService: FeatureToggleService,
                          private val familieDokumentClient: FamilieDokumentClient) {
 
     fun hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId: UUID): ByteArray {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -142,11 +142,11 @@ class VedtaksbrevService(private val brevClient: BrevClient,
         val behandling = behandlingService.hentBehandling(fritekstbrevDto.behandlingId)
         validerRedigerbarBehandling(behandling)
         val ident = behandlingService.hentAktivIdent(fritekstbrevDto.behandlingId)
-        val navn = personopplysningerService.hentGjeldeneNavn(listOf(ident))
+        val navn : String = personopplysningerService.hentGjeldeneNavn(listOf(ident)).getValue(ident)
         val request = FrittståendeBrevRequestDto(overskrift = fritekstbrevDto.overskrift,
                                                  avsnitt = fritekstbrevDto.avsnitt,
                                                  personIdent = ident,
-                                                 navn = navn[ident]!!)
+                                                 navn = navn)
 
         val signaturMedEnhet = brevsignaturService.lagSignaturMedEnhet(behandling.fagsakId)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -157,9 +157,6 @@ class VedtaksbrevService(private val brevClient: BrevClient,
                                                       saksbehandlerNavn = signaturMedEnhet.navn,
                                                       enhet = signaturMedEnhet.enhet)
 
-        println("html: $html")
-
-
         lagreEllerOppdaterSaksbehandlerVedtaksbrev(behandlingId = fritekstbrevDto.behandlingId,
                                                    brevrequest = "", // TODO: Dette feltet skal fjernes senere
                                                    brevmal = FRITEKST,

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -25,6 +25,7 @@ fun main(args: Array<String>) {
                       "mock-ereg",
                       "mock-aareg",
                       "mock-brev",
+                      "mock-dokument",
                       "mock-tilbakekreving")
             .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -28,6 +28,7 @@ fun main(args: Array<String>) {
                       "mock-ereg",
                       "mock-aareg",
                       "mock-brev",
+                      "mock-dokument",
                       "mock-tilbakekreving")
             .properties(properties)
             .run(*args)

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/BrevClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/BrevClientMock.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.infrastruktur.config
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.brev.BrevClient
-import no.nav.familie.ef.sak.brev.VedtaksbrevService
 import no.nav.familie.ef.sak.brev.VedtaksbrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -19,9 +18,9 @@ class BrevClientMock {
     fun brevClient(): BrevClient {
         val brevClient: BrevClient = mockk()
         val dummyPdf = this::class.java.classLoader.getResource("dummy/pdf_dummy.pdf")!!.readBytes()
-        every { brevClient.genererBrev(any()) } returns dummyPdf
         every { brevClient.genererBrev(any(), any(), "NAV Arbeid og ytelser") } returns dummyPdf
         every { brevClient.genererHtml(any(), any(), any(), any(), any()) } returns "<h1>Hei $BESLUTTER_SIGNATUR_PLACEHOLDER</h1>"
+        every { brevClient.genererHtmlFritekstbrev(any(), any(), any()) } returns "<h1>Hei $BESLUTTER_SIGNATUR_PLACEHOLDER</h1>"
         return brevClient
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.service
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.TextNode
 import io.mockk.every
 import io.mockk.mockk
@@ -22,7 +21,6 @@ import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -44,7 +42,6 @@ internal class VedtaksbrevServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val personopplysningerService = mockk<PersonopplysningerService>()
     private val brevsignaturService = mockk<BrevsignaturService>()
-    private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
     private val familieDokumentClient = mockk<FamilieDokumentClient>()
 
     private val vedtaksbrevService =
@@ -53,7 +50,6 @@ internal class VedtaksbrevServiceTest {
                                behandlingService,
                                personopplysningerService,
                                brevsignaturService,
-                               featureToggleService,
                                familieDokumentClient)
 
     private val vedtaksbrev: Vedtaksbrev = lagVedtaksbrev("malnavn")
@@ -65,7 +61,6 @@ internal class VedtaksbrevServiceTest {
         mockBrukerContext(beslutterNavn)
         val signaturDto = SignaturDto(beslutterNavn, "enhet", false)
         every { brevsignaturService.lagSignaturMedEnhet(any()) } returns signaturDto
-        every { featureToggleService.isEnabled(any()) } returns true
     }
 
     @AfterEach


### PR DESCRIPTION
Vil følge samme flyt for fritekstbrev som for sanitybrev: Lag html i familie-brev, ef-sak lagrer html og lager pdf mot familie-dokument ved behov.

Plan videre: 
1. Rydde - vente til alle gamle fritekstbrev er ute av beslutter-loop. Slette kode som ikke lenger brukes. 
2. Kodeforbedringer: noe funksjonalitet har sneket seg inn i klient. Dette ønsker vi flytte til service. 
3. Kanskje implementere invariant: ikke lagre beslutterpdf før beslutter godkjenner. (nå lagrer vi beslutterpdf hver gang beslutter ser på pdf. 