### PR TITLE
Brevflyt opprydding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
@@ -4,12 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode
 import no.nav.familie.ef.sak.brev.VedtaksbrevService.Companion.BESLUTTER_SIGNATUR_PLACEHOLDER
 import no.nav.familie.ef.sak.brev.domain.FRITEKST
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevRequestDto
-import no.nav.familie.ef.sak.brev.dto.VedtaksbrevDto
-import no.nav.familie.ef.sak.brev.dto.erFritekstType
 import no.nav.familie.ef.sak.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.http.client.AbstractPingableRestClient
-import no.nav.familie.kontrakter.felles.objectMapper
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
@@ -28,23 +25,6 @@ class BrevClient(@Value("\${FAMILIE_BREV_API_URL}")
 
     override fun ping() {
         operations.optionsForAllow(pingUri)
-    }
-
-    @Deprecated("Skal slettes når fritekstbrev har tatt i bruk html")
-    fun genererBrev(vedtaksbrev: VedtaksbrevDto): ByteArray {
-
-        val url = when (vedtaksbrev.erFritekstType()) {
-            false -> URI.create("$familieBrevUri/api/ef-brev/avansert-dokument/bokmaal/${vedtaksbrev.brevmal}/pdf")
-            true -> URI.create("$familieBrevUri/api/fritekst-brev")
-        }
-        return postForEntity(url,
-                             BrevRequestMedSignaturer(objectMapper.readTree(vedtaksbrev.saksbehandlerBrevrequest),
-                                                      vedtaksbrev.saksbehandlersignatur,
-                                                      vedtaksbrev.besluttersignatur,
-                                                      vedtaksbrev.enhet,
-                                                      vedtaksbrev.skjulBeslutterSignatur
-                             ),
-                             HttpHeaders().medContentTypeJsonUTF8())
     }
 
     fun genererBrev(fritekstBrev: FrittståendeBrevRequestDto,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Vedtaksbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Vedtaksbrev.kt
@@ -1,14 +1,13 @@
 package no.nav.familie.ef.sak.brev.domain
 
 
-import no.nav.familie.ef.sak.brev.dto.VedtaksbrevDto
 import no.nav.familie.ef.sak.felles.domain.Fil
 import org.springframework.data.annotation.Id
 import java.util.UUID
 
 data class Vedtaksbrev(@Id
                        val behandlingId: UUID,
-                       val saksbehandlerBrevrequest: String,
+                      // val saksbehandlerBrevrequest: String,
                        val saksbehandlerHtml: String? = null,
                        val brevmal: String,
                        val saksbehandlersignatur: String,
@@ -16,17 +15,6 @@ data class Vedtaksbrev(@Id
                        val beslutterPdf: Fil? = null,
                        val enhet: String? = null,
                        val saksbehandlerident: String,
-                       val beslutterident: String? = null) {
-
-
-}
-
-fun Vedtaksbrev.tilDto(skjulBeslutterSignatur: Boolean): VedtaksbrevDto = VedtaksbrevDto(saksbehandlerBrevrequest = this.saksbehandlerBrevrequest,
-                                                                                         brevmal = this.brevmal,
-                                                                                         saksbehandlersignatur = this.saksbehandlersignatur,
-                                                                                         besluttersignatur = this.besluttersignatur,
-                                                                                         enhet = this.enhet,
-                                                                                         skjulBeslutterSignatur = skjulBeslutterSignatur
-)
+                       val beslutterident: String? = null)
 
 const val FRITEKST = "fritekst"

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
@@ -74,8 +74,8 @@ internal class BeslutteVedtakStegTest {
 
     private val innloggetBeslutter = "sign2"
     private val vedtaksbrev = Vedtaksbrev(behandlingId = UUID.randomUUID(),
-                                          saksbehandlerBrevrequest = "123",
                                           brevmal = "mal",
+                                          saksbehandlerHtml = "",
                                           saksbehandlersignatur = "sign1",
                                           besluttersignatur = innloggetBeslutter,
                                           beslutterPdf = Fil("123".toByteArray()),

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
@@ -90,12 +90,12 @@ internal class SendTilBeslutterStegTest {
                                 identer = setOf(PersonIdent(ident = "12345678901")))
     private val saksbehandlerNavn = "saksbehandlernavn"
     private val vedtaksbrev = Vedtaksbrev(behandlingId = UUID.randomUUID(),
-                                          saksbehandlerBrevrequest = "",
                                           brevmal = "",
                                           saksbehandlersignatur = saksbehandlerNavn,
                                           beslutterPdf = null,
                                           enhet = "enhet",
-                                          saksbehandlerident = saksbehandlerNavn)
+                                          saksbehandlerident = saksbehandlerNavn,
+                                          saksbehandlerHtml = "")
 
     private val behandling = saksbehandling(fagsak, Behandling(fagsakId = fagsak.id,
                                                                type = BehandlingType.FØRSTEGANGSBEHANDLING,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VedtaksbrevRepositoryTest.kt
@@ -18,8 +18,7 @@ internal class VedtaksbrevRepositoryTest : OppslagSpringRunnerTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val vedtaksbrev = Vedtaksbrev(behandlingId = behandling.id,
-                                      saksbehandlerBrevrequest = "testhallo",
-                                      saksbehandlerHtml = null,
+                                      saksbehandlerHtml = "",
                                       brevmal = "brevmalnavn",
                                       saksbehandlersignatur = "Sakliga Behandlersen",
                                       besluttersignatur = "",

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
@@ -68,24 +68,6 @@ internal class VedtaksbrevServiceTest {
     }
 
     @Test
-    internal fun `skal legge på signatur og lage pdf ved lagBeslutterBrev`() {
-        val vedtaksbrevSlot = slot<Vedtaksbrev>()
-
-
-        every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
-        every { vedtaksbrevRepository.update(capture(vedtaksbrevSlot)) } returns vedtaksbrev
-
-        vedtaksbrevService.lagBeslutterBrev(saksbehandling(fagsak, behandlingForBeslutter))
-
-        assertThat(vedtaksbrevSlot.captured.besluttersignatur).isEqualTo(beslutterNavn)
-        assertThat(vedtaksbrevSlot.captured).usingRecursiveComparison()
-                .ignoringFields("besluttersignatur", "beslutterPdf", "beslutterident", "enhet")
-                .isEqualTo(vedtaksbrev)
-        assertThat(vedtaksbrevSlot.captured.saksbehandlerHtml).isEqualTo(null)
-
-    }
-
-    @Test
     internal fun `skal legge på signatur og lage pdf ved lagSaksbehandlerFritekstbrev`() {
         val vedtaksbrevSlot = slot<Vedtaksbrev>()
 
@@ -156,7 +138,7 @@ internal class VedtaksbrevServiceTest {
                                                         steg = StegType.SEND_TIL_BESLUTTER)
 
     private fun lagVedtaksbrev(brevmal: String, saksbehandlerIdent: String = "123") = Vedtaksbrev(behandlingId = behandling.id,
-                                                                                                  saksbehandlerHtml = "",
+                                                                                                  saksbehandlerHtml = "Brev med $BESLUTTER_SIGNATUR_PLACEHOLDER",
                                                                                                   brevmal = brevmal,
                                                                                                   saksbehandlersignatur = "Saksbehandler Signatur",
                                                                                                   besluttersignatur = null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
@@ -73,7 +73,6 @@ internal class VedtaksbrevServiceTest {
 
 
         every { vedtaksbrevRepository.findByIdOrThrow(any()) } returns vedtaksbrev
-        every { brevClient.genererBrev(any()) } returns "enPdf".toByteArray()
         every { vedtaksbrevRepository.update(capture(vedtaksbrevSlot)) } returns vedtaksbrev
 
         vedtaksbrevService.lagBeslutterBrev(saksbehandling(fagsak, behandlingForBeslutter))
@@ -83,7 +82,6 @@ internal class VedtaksbrevServiceTest {
                 .ignoringFields("besluttersignatur", "beslutterPdf", "beslutterident", "enhet")
                 .isEqualTo(vedtaksbrev)
         assertThat(vedtaksbrevSlot.captured.saksbehandlerHtml).isEqualTo(null)
-        assertThat(vedtaksbrevSlot.captured.saksbehandlerBrevrequest).isNotBlank()
 
     }
 
@@ -158,8 +156,7 @@ internal class VedtaksbrevServiceTest {
                                                         steg = StegType.SEND_TIL_BESLUTTER)
 
     private fun lagVedtaksbrev(brevmal: String, saksbehandlerIdent: String = "123") = Vedtaksbrev(behandlingId = behandling.id,
-                                                                                                  saksbehandlerBrevrequest = "123",
-                                                                                                  saksbehandlerHtml = null,
+                                                                                                  saksbehandlerHtml = "",
                                                                                                   brevmal = brevmal,
                                                                                                   saksbehandlersignatur = "Saksbehandler Signatur",
                                                                                                   besluttersignatur = null,
@@ -220,8 +217,5 @@ internal class VedtaksbrevServiceTest {
                                                       "brevmal")
 
         assertThat(vedtaksbrevSlot.captured.saksbehandlerHtml).isEqualTo(html)
-        assertThat(vedtaksbrevSlot.captured.saksbehandlerBrevrequest).isEmpty()
     }
-
-
 }


### PR DESCRIPTION
Opprydding etter ny brevflyt. https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8174

**VI har sjekket prod der ingen "gamle" vedtaksbrev ligger til beslutting**

Vi bruker nå feltet `saksbehandleHtml` istedenfor `saksbehandlerBrevrequest` og kan dermed fjerne feltet og koden som bruker dette.

Vi fjerner saksbehandlerBrevrequest fra databasen i egen PR.

