### PR TITLE
Skal bruke startdato når man avkorter perioder fra infotrygd.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriode.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriode.kt
@@ -10,6 +10,12 @@ data class InternePerioder(
 )
 
 /**
+ * Holder for å sette startdato fra tilkjent ytelse sammen med internperioder
+ */
+data class EfInternPerioder(val startdato: LocalDate,
+                            val internperioder: List<InternPeriode>)
+
+/**
  * Brukes for å mappe interne ef-perioder og infotrygd perioder til ett felles format
  */
 data class InternPeriode(

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InternPeriodeUtil.kt
@@ -6,17 +6,18 @@ object InternPeriodeUtil {
      * Slår sammen perioder tvers kilder
      * Når vi skal slå sammen perioder fra infotrygd og EF så er det EF sine perioder som er de som skriver over infotrygd sine
      */
-    fun slåSammenPerioder(efPerioder: List<InternPeriode>, infotrygdperioder: List<InternPeriode>): List<InternPeriode> {
-        val førstePerioden = efPerioder.minByOrNull { it.stønadFom } ?: return infotrygdperioder
+    fun slåSammenPerioder(efPerioder: EfInternPerioder?,
+                          infotrygdperioder: List<InternPeriode>): List<InternPeriode> {
+        val startdato = efPerioder?.startdato ?: return infotrygdperioder
         val perioderFraInfotrygdSomBeholdes = infotrygdperioder.mapNotNull {
-            if (it.stønadFom >= førstePerioden.stønadFom) {
+            if (it.stønadFom >= startdato) {
                 null
-            } else if (it.stønadTom > førstePerioden.stønadFom) {
-                it.copy(stønadTom = førstePerioden.stønadFom.minusDays(1))
+            } else if (it.stønadTom > startdato) {
+                it.copy(stønadTom = startdato.minusDays(1))
             } else {
                 it
             }
         }
-        return efPerioder + perioderFraInfotrygdSomBeholdes
+        return efPerioder.internperioder + perioderFraInfotrygdSomBeholdes
     }
 }


### PR DESCRIPTION
Hvis ikke blir perioder som eventuellt blitt opphørt hos oss med, hvis saken er migrert


https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8396
https://nav-it.slack.com/archives/G012YEK9YQ1/p1648627442859329

Hvis en person har blitt migrert fra Infotrygd , og då eks har perioder
01.2021 - 05.2021
Så blir den migrert, vi tar over 05.2021
Så blir 05.2021 opphørt
Då settes startdato i tilkjent ytelse til 05.2021, og vi har ingen andeler hos oss

Når man då henter perioder fra oss + infotrygd så avkortet vi tidligere ikke periodene fra 04.2021, men fikk med siste måneden.