### PR TITLE
Tar med _type i konstruktøren til VedtakDto.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
@@ -30,7 +30,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataServic
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vedtak.dto.tilPerioder
 import no.nav.familie.ef.sak.vilkår.VurderingService
@@ -156,10 +156,10 @@ class MigreringService(
         val vedtaksperioder = vedtaksperioder(fra, til, erReellArbeidssøker)
         val inntekter = inntekter(fra, inntektsgrunnlag, samordningsfradrag)
         val saksbehandling = behandlingService.hentSaksbehandling(behandling.id)
-        beregnYtelseSteg.utførSteg(saksbehandling, Innvilget(periodeBegrunnelse = null,
-                                                             inntektBegrunnelse = null,
-                                                             perioder = vedtaksperioder,
-                                                             inntekter = inntekter))
+        beregnYtelseSteg.utførSteg(saksbehandling, InnvilgelseOvergangsstønad(periodeBegrunnelse = null,
+                                                                              inntektBegrunnelse = null,
+                                                                              perioder = vedtaksperioder,
+                                                                              inntekter = inntekter))
         validerSimulering(behandling)
 
         behandlingService.oppdaterResultatPåBehandling(behandling.id, BehandlingResultat.INNVILGET)

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.tilBeløpsperiode
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.tilPerioder
@@ -60,7 +60,7 @@ class BeregningController(private val stegService: StegService,
     }
 
     private fun validerAlleVilkårOppfyltDersomInvilgelse(vedtak: VedtakDto, behandlingId: UUID) {
-        if (vedtak is Innvilget) {
+        if (vedtak is InnvilgelseOvergangsstønad) {
             brukerfeilHvisIkke(vurderingService.erAlleVilkårOppfylt(behandlingId)) { "Kan ikke fullføre en behandling med resultat innvilget hvis ikke alle vilkår er oppfylt" }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/VedtaBlankettSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/VedtaBlankettSteg.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.dto.Avslå
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
@@ -24,7 +24,7 @@ class VedtaBlankettSteg(private val vedtakService: VedtakService, private val bl
 
     override fun utførSteg(saksbehandling: Saksbehandling, data: VedtakDto) {
         when (data) {
-            is Innvilget, is Avslå -> {
+            is InnvilgelseOvergangsstønad, is Avslå -> {
                 vedtakService.slettVedtakHvisFinnes(saksbehandling.id)
                 vedtakService.lagreVedtak(vedtakDto = data, behandlingId = saksbehandling.id)
                 blankettRepository.deleteById(saksbehandling.id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/ObjectMapperProvider.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/ObjectMapperProvider.kt
@@ -3,9 +3,7 @@ package no.nav.familie.ef.sak.infrastruktur.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDtoModule
 
-class ObjectMapperProvider {
-    companion object {
+object ObjectMapperProvider {
 
-        val objectMapper: ObjectMapper = no.nav.familie.kontrakter.felles.objectMapper.registerModule(VedtakDtoModule())
-    }
+    val objectMapper: ObjectMapper = no.nav.familie.kontrakter.felles.objectMapper.registerModule(VedtakDtoModule())
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/BlankettSimuleringsService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/BlankettSimuleringsService.kt
@@ -8,7 +8,7 @@ import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelseType
 import no.nav.familie.ef.sak.tilkjentytelse.tilTilkjentYtelseMedMetaData
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.tilPerioder
 import no.nav.familie.kontrakter.ef.iverksett.TilkjentYtelseMedMetadata
@@ -21,7 +21,7 @@ class BlankettSimuleringsService(val beregningService: BeregningService) {
     fun genererTilkjentYtelseForBlankett(vedtak: VedtakDto?,
                                          saksbehandling: Saksbehandling): TilkjentYtelseMedMetadata {
         val andeler = when (vedtak) {
-            is Innvilget -> {
+            is InnvilgelseOvergangsstønad -> {
                 beregningService.beregnYtelse(vedtak.perioder.tilPerioder(),
                                               vedtak.inntekter.tilInntektsperioder())
                         .map {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
@@ -46,36 +46,38 @@ fun ResultatType.tilVedtaksresultat(): Vedtaksresultat = when (this) {
     ResultatType.SANKSJONERE -> Vedtaksresultat.INNVILGET
 }
 
-sealed class VedtakDto(val resultatType: ResultatType) {
+/*@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+              include = JsonTypeInfo.As.PROPERTY,
+              property = "_type")*/
+sealed class VedtakDto(val resultatType: ResultatType, val _type: String) {
 
     fun erInnvilgeMedOpphør(): Boolean {
-        return this is Innvilget && this.perioder.any { it.periodeType == VedtaksperiodeType.MIDLERTIDIG_OPPHØR }
+        return this is InnvilgelseOvergangsstønad && this.perioder.any { it.periodeType == VedtaksperiodeType.MIDLERTIDIG_OPPHØR }
     }
 }
 
-class Innvilget(val periodeBegrunnelse: String?,
-                val inntektBegrunnelse: String?,
-                val perioder: List<VedtaksperiodeDto> = emptyList(),
-                val inntekter: List<Inntekt> = emptyList(),
-                val samordningsfradragType: SamordningsfradragType? = null) : VedtakDto(ResultatType.INNVILGE)
+data class InnvilgelseOvergangsstønad(val periodeBegrunnelse: String?,
+                                      val inntektBegrunnelse: String?,
+                                      val perioder: List<VedtaksperiodeDto> = emptyList(),
+                                      val inntekter: List<Inntekt> = emptyList(),
+                                      val samordningsfradragType: SamordningsfradragType? = null) : VedtakDto(ResultatType.INNVILGE, "InnvilgelseOvergangsstønad")
 
+data class Avslå(val avslåÅrsak: AvslagÅrsak?,
+                 val avslåBegrunnelse: String?) : VedtakDto(ResultatType.AVSLÅ, "Avslå")
 
-class Avslå(val avslåÅrsak: AvslagÅrsak?,
-            val avslåBegrunnelse: String?) : VedtakDto(ResultatType.AVSLÅ)
+data class Opphør(val opphørFom: YearMonth,
+                  val begrunnelse: String?) : VedtakDto(ResultatType.OPPHØRT, "Opphør")
 
-class Opphør(val opphørFom: YearMonth,
-             val begrunnelse: String?) : VedtakDto(ResultatType.OPPHØRT)
-
-class Sanksjonert(val sanksjonsårsak: Sanksjonsårsak,
-                  val periode: VedtaksperiodeDto,
-                  val internBegrunnelse: String) : VedtakDto(ResultatType.SANKSJONERE)
+data class Sanksjonert(val sanksjonsårsak: Sanksjonsårsak,
+                       val periode: VedtaksperiodeDto,
+                       val internBegrunnelse: String) : VedtakDto(ResultatType.SANKSJONERE, "Sanksjonert")
 
 fun VedtakDto.tilVedtak(behandlingId: UUID): Vedtak = when (this) {
     is Avslå -> Vedtak(behandlingId = behandlingId,
                        avslåÅrsak = this.avslåÅrsak,
                        avslåBegrunnelse = this.avslåBegrunnelse,
                        resultatType = this.resultatType)
-    is Innvilget ->
+    is InnvilgelseOvergangsstønad ->
         Vedtak(behandlingId = behandlingId,
                periodeBegrunnelse = this.periodeBegrunnelse,
                inntektBegrunnelse = this.inntektBegrunnelse,
@@ -98,7 +100,7 @@ fun VedtakDto.tilVedtak(behandlingId: UUID): Vedtak = when (this) {
 
 fun Vedtak.tilVedtakDto(): VedtakDto =
         when (this.resultatType) {
-            ResultatType.INNVILGE -> Innvilget(
+            ResultatType.INNVILGE -> InnvilgelseOvergangsstønad(
                     periodeBegrunnelse = this.periodeBegrunnelse,
                     inntektBegrunnelse = this.inntektBegrunnelse,
                     perioder = (this.perioder ?: PeriodeWrapper(emptyList())).perioder.fraDomene(),
@@ -127,7 +129,7 @@ private class VedtakDtoDeserializer : StdDeserializer<VedtakDto>(VedtakDto::clas
         val mapper = p.codec as ObjectMapper
         val node: JsonNode = mapper.readTree(p)
         return when (ResultatType.valueOf(node.get("resultatType").asText())) {
-            ResultatType.INNVILGE -> mapper.treeToValue(node, Innvilget::class.java)
+            ResultatType.INNVILGE -> mapper.treeToValue(node, InnvilgelseOvergangsstønad::class.java)
             ResultatType.AVSLÅ -> mapper.treeToValue(node, Avslå::class.java)
             ResultatType.OPPHØRT -> mapper.treeToValue(node, Opphør::class.java)
             ResultatType.SANKSJONERE -> mapper.treeToValue(node, Sanksjonert::class.java)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
@@ -63,14 +63,14 @@ data class InnvilgelseOvergangsstønad(val periodeBegrunnelse: String?,
                                       val samordningsfradragType: SamordningsfradragType? = null) : VedtakDto(ResultatType.INNVILGE, "InnvilgelseOvergangsstønad")
 
 data class Avslå(val avslåÅrsak: AvslagÅrsak?,
-                 val avslåBegrunnelse: String?) : VedtakDto(ResultatType.AVSLÅ, "Avslå")
+                 val avslåBegrunnelse: String?) : VedtakDto(ResultatType.AVSLÅ, "Avslag")
 
 data class Opphør(val opphørFom: YearMonth,
                   val begrunnelse: String?) : VedtakDto(ResultatType.OPPHØRT, "Opphør")
 
 data class Sanksjonert(val sanksjonsårsak: Sanksjonsårsak,
                        val periode: VedtaksperiodeDto,
-                       val internBegrunnelse: String) : VedtakDto(ResultatType.SANKSJONERE, "Sanksjonert")
+                       val internBegrunnelse: String) : VedtakDto(ResultatType.SANKSJONERE, "Sanksjonering")
 
 fun VedtakDto.tilVedtak(behandlingId: UUID): Vedtak = when (this) {
     is Avslå -> Vedtak(behandlingId = behandlingId,

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
@@ -38,7 +38,7 @@ import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.BeslutteVedtakDto
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -501,10 +501,10 @@ internal class MigreringServiceTest : OppslagSpringRunnerTest() {
                                                periodeType = VedtaksperiodeType.HOVEDPERIODE)
 
         val inntekt = Inntekt(migrerFraDato, forventetInntekt = forventetInntekt, samordningsfradrag = samordningsfradrag)
-        val innvilget = Innvilget(periodeBegrunnelse = null,
-                                  inntektBegrunnelse = null,
-                                  perioder = listOf(vedtaksperiode),
-                                  inntekter = listOf(inntekt))
+        val innvilget = InnvilgelseOvergangsstønad(periodeBegrunnelse = null,
+                                                   inntektBegrunnelse = null,
+                                                   perioder = listOf(vedtaksperiode),
+                                                   inntekter = listOf(inntekt))
         val brevrequest = objectMapper.readTree("123")
         testWithBrukerContext(groups = listOf(rolleConfig.saksbehandlerRolle)) {
             stegService.håndterBeregnYtelseForStønad(saksbehandling, innvilget)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegIntegrationTest.kt
@@ -17,7 +17,7 @@ import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -89,10 +89,10 @@ internal class BeregnYtelseStegIntegrationTest : OppslagSpringRunnerTest() {
     private fun innvilg(saksbehandling: Saksbehandling,
                         vedtaksperioder: List<VedtaksperiodeDto>,
                         inntekter: List<Inntekt> = listOf(Inntekt(vedtaksperioder.first().årMånedFra, null, null))) {
-        val vedtak = Innvilget(perioder = vedtaksperioder,
-                               inntekter = inntekter,
-                               periodeBegrunnelse = null,
-                               inntektBegrunnelse = null)
+        val vedtak = InnvilgelseOvergangsstønad(perioder = vedtaksperioder,
+                                                inntekter = inntekter,
+                                                periodeBegrunnelse = null,
+                                                inntektBegrunnelse = null)
         beregnYtelseSteg.utførSteg(saksbehandling, vedtak)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -30,7 +30,7 @@ import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.AvslagÅrsak
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.Avslå
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.Opphør
 import no.nav.familie.ef.sak.vedtak.dto.Sanksjonert
 import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
@@ -1252,10 +1252,10 @@ internal class BeregnYtelseStegTest {
 
     private fun innvilget(perioder: List<VedtaksperiodeDto>,
                           inntekter: List<Inntekt>) =
-            Innvilget(perioder = perioder,
-                      inntekter = inntekter,
-                      inntektBegrunnelse = "null",
-                      periodeBegrunnelse = "null")
+            InnvilgelseOvergangsstønad(perioder = perioder,
+                                       inntekter = inntekter,
+                                       inntektBegrunnelse = "null",
+                                       periodeBegrunnelse = "null")
 
     private fun sanksjon(årMåned: YearMonth) =
             Sanksjonert(sanksjonsårsak = Sanksjonsårsak.SAGT_OPP_STILLING,
@@ -1318,8 +1318,8 @@ internal class BeregnYtelseStegTest {
                     samordningsfradrag = BigDecimal.ZERO)
 
     private fun utførSteg(type: BehandlingType,
-                          vedtak: VedtakDto = Innvilget(periodeBegrunnelse = "",
-                                                        inntektBegrunnelse = ""),
+                          vedtak: VedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "",
+                                                                         inntektBegrunnelse = ""),
                           forrigeBehandlingId: UUID? = null) {
         val fagsak = fagsak()
         steg.utførSteg(saksbehandling(fagsak, behandling(fagsak(), type = type, forrigeBehandlingId = forrigeBehandlingId)),

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ef.sak.repository.saksbehandling
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -52,11 +52,11 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
                              forventetInntekt = BigDecimal(12345),
                              samordningsfradrag = BigDecimal(2))
         stegService.håndterBeregnYtelseForStønad(saksbehandling(fagsak, behandling),
-                                                 vedtak = Innvilget(periodeBegrunnelse = "ok",
-                                                                    inntektBegrunnelse = "okok",
-                                                                    perioder = listOf(vedtaksperiode),
-                                                                    inntekter = listOf(inntek),
-                                                                    samordningsfradragType = SamordningsfradragType.UFØRETRYGD))
+                                                 vedtak = InnvilgelseOvergangsstønad(periodeBegrunnelse = "ok",
+                                                                                     inntektBegrunnelse = "okok",
+                                                                                     perioder = listOf(vedtaksperiode),
+                                                                                     inntekter = listOf(inntek),
+                                                                                     samordningsfradragType = SamordningsfradragType.UFØRETRYGD))
 
         assertThat(behandlingshistorikkRepository.findByBehandlingIdOrderByEndretTidDesc(behandling.id).first().steg)
                 .isEqualTo(StegType.BEREGNE_YTELSE)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VedtaBlankettStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/VedtaBlankettStegTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.saksbehandling
 import no.nav.familie.ef.sak.vedtak.VedtakService
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -30,7 +30,7 @@ internal class VedtaBlankettStegTest {
                                     steg = StegType.VILKÅR,
                                     status = BehandlingStatus.UTREDES,
                                     type = BehandlingType.BLANKETT)
-        val request = Innvilget(
+        val request = InnvilgelseOvergangsstønad(
                 "En periodebegrunnelse",
                 "En inntektBegrunnelse",
                 emptyList(),
@@ -62,7 +62,7 @@ internal class VedtaBlankettStegTest {
                                     steg = StegType.VILKÅR,
                                     status = BehandlingStatus.UTREDES,
                                     type = BehandlingType.FØRSTEGANGSBEHANDLING)
-        val request = Innvilget(
+        val request = InnvilgelseOvergangsstønad(
                 "En periodebegrunnelse",
                 "En inntektBegrunnelse",
                 emptyList(),
@@ -96,7 +96,7 @@ internal class VedtaBlankettStegTest {
                                     steg = StegType.VILKÅR,
                                     status = BehandlingStatus.UTREDES,
                                     type = BehandlingType.BLANKETT)
-        val request = Innvilget(
+        val request = InnvilgelseOvergangsstønad(
                 "En periodebegrunnelse",
                 "En inntektBegrunnelse",
                 emptyList(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
@@ -21,7 +21,7 @@ import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.Avslå
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
@@ -84,8 +84,8 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
                                                                 steg = StegType.VEDTA_BLANKETT,
                                                                 type = BehandlingType.BLANKETT,
                                                                 status = BehandlingStatus.UTREDES))
-        val vedtakDto = Innvilget(periodeBegrunnelse = "periode begrunnelse",
-                                  inntektBegrunnelse = "inntekt begrunnelse")
+        val vedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "periode begrunnelse",
+                                                   inntektBegrunnelse = "inntekt begrunnelse")
 
         val respons: ResponseEntity<Ressurs<UUID>> = fatteVedtak(behandling.id, vedtakDto)
         val vedtak = Vedtak(behandlingId = behandling.id,
@@ -103,8 +103,8 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
     internal fun `Skal returnere riktig feilmelding i response når fullfør ikke er mulig pga valideringsfeil`() {
         val (_, behandling) = lagFagsakOgBehandling()
 
-        val vedtakDto = Innvilget(periodeBegrunnelse = "periode begrunnelse",
-                                  inntektBegrunnelse = "inntekt begrunnelse")
+        val vedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "periode begrunnelse",
+                                                   inntektBegrunnelse = "inntekt begrunnelse")
 
         vilkårsvurderingService.hentEllerOpprettVurderinger(behandlingId = behandling.id) // ingen ok.
 
@@ -150,13 +150,13 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
                                                        beløp = 10_000,
                                                        tilOgMed = LocalDate.of(2022, 4, 30),
                                                )))
-        val vedtakDto = Innvilget(periodeBegrunnelse = "periode begrunnelse",
-                                  inntektBegrunnelse = "inntekt begrunnelse",
-                                  perioder = listOf(VedtaksperiodeDto(årMånedFra = YearMonth.of(2022, 1),
+        val vedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "periode begrunnelse",
+                                                   inntektBegrunnelse = "inntekt begrunnelse",
+                                                   perioder = listOf(VedtaksperiodeDto(årMånedFra = YearMonth.of(2022, 1),
                                                                       årMånedTil = YearMonth.of(2022, 4),
                                                                       aktivitet = AktivitetType.BARN_UNDER_ETT_ÅR,
                                                                       periodeType = VedtaksperiodeType.HOVEDPERIODE)),
-                                  inntekter = emptyList())
+                                                   inntekter = emptyList())
 
 
 
@@ -185,13 +185,13 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
                                                                 kildeBehandlingId = revurdering.id,
                                                                 tilOgMed = LocalDate.of(2022, 6, 30))))
 
-        val vedtakDto = Innvilget(periodeBegrunnelse = "periode begrunnelse",
-                                  inntektBegrunnelse = "inntekt begrunnelse",
-                                  perioder = listOf(VedtaksperiodeDto(årMånedFra = YearMonth.of(2022, 3),
+        val vedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "periode begrunnelse",
+                                                   inntektBegrunnelse = "inntekt begrunnelse",
+                                                   perioder = listOf(VedtaksperiodeDto(årMånedFra = YearMonth.of(2022, 3),
                                                                       årMånedTil = YearMonth.of(2022, 6),
                                                                       aktivitet = AktivitetType.BARN_UNDER_ETT_ÅR,
                                                                       periodeType = VedtaksperiodeType.HOVEDPERIODE)),
-                                  inntekter = emptyList())
+                                                   inntekter = emptyList())
         tilkjentYtelseRepository.insert(tilkjentYtelse)
         vedtakService.lagreVedtak(vedtakDto, revurdering.id)
         return revurdering

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.vedtak.VedtakRepository
 import no.nav.familie.ef.sak.vedtak.VedtakService
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -38,8 +38,8 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
                                                                 type = BehandlingType.BLANKETT))
 
         val tomBegrunnelse = ""
-        val vedtakRequest = Innvilget(tomBegrunnelse,
-                                      tomBegrunnelse, emptyList(), emptyList())
+        val vedtakRequest = InnvilgelseOvergangsstønad(tomBegrunnelse,
+                                                       tomBegrunnelse, emptyList(), emptyList())
 
         /** Skal ikke gjøre noe når den ikke er opprettet **/
         vedtakService.slettVedtakHvisFinnes(behandling.id)
@@ -53,7 +53,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
         assertThat(vedtakLagret?.periodeBegrunnelse).isEqualTo(tomBegrunnelse)
 
         /** Slett og opprett ny **/
-        val vedtakRequestMedPeriodeBegrunnelse = Innvilget("Begrunnelse", tomBegrunnelse, emptyList(), emptyList())
+        val vedtakRequestMedPeriodeBegrunnelse = InnvilgelseOvergangsstønad("Begrunnelse", tomBegrunnelse, emptyList(), emptyList())
         vedtakService.slettVedtakHvisFinnes(behandling.id)
         assertThat(vedtakRepository.findAll()).isEmpty()
         vedtakService.lagreVedtak(vedtakRequestMedPeriodeBegrunnelse, behandling.id)
@@ -74,7 +74,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
                                                                 type = BehandlingType.BLANKETT))
 
         val tomBegrunnelse = ""
-        val vedtakDto = Innvilget(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
+        val vedtakDto = InnvilgelseOvergangsstønad(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
 
         vedtakService.lagreVedtak(vedtakDto, behandling.id)
 
@@ -90,7 +90,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
                                                                 type = BehandlingType.BLANKETT))
 
         val tomBegrunnelse = ""
-        val vedtakDto = Innvilget(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
+        val vedtakDto = InnvilgelseOvergangsstønad(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
 
         vedtakService.lagreVedtak(vedtakDto, behandling.id)
         val saksbehandlerIdent = "S123456"
@@ -107,7 +107,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
                                                                 type = BehandlingType.BLANKETT))
 
         val tomBegrunnelse = ""
-        val vedtakDto = Innvilget(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
+        val vedtakDto = InnvilgelseOvergangsstønad(tomBegrunnelse, tomBegrunnelse, emptyList(), emptyList())
 
         vedtakService.lagreVedtak(vedtakDto, behandling.id)
         val beslutterIdent = "B123456"
@@ -127,10 +127,10 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak)).id
         val behandling2 = behandlingRepository.insert(behandling(fagsak)).id
-        val vedtakDto = Innvilget(periodeBegrunnelse = "",
-                                  inntektBegrunnelse = "tomBegrunnelse",
-                                  perioder = emptyList(),
-                                  inntekter = emptyList())
+        val vedtakDto = InnvilgelseOvergangsstønad(periodeBegrunnelse = "",
+                                                   inntektBegrunnelse = "tomBegrunnelse",
+                                                   perioder = emptyList(),
+                                                   inntekter = emptyList())
         vedtakService.lagreVedtak(vedtakDto, behandling)
         vedtakService.lagreVedtak(vedtakDto, behandling2)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
@@ -27,7 +27,7 @@ import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.kontrakter.ef.iverksett.SimuleringDto
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -114,16 +114,16 @@ internal class SimuleringServiceTest {
         val årMånedFraStart = YearMonth.of(2021, 1)
         val årMånedGEndring = YearMonth.of(2021, 5)
         val årMånedFraSlutt = YearMonth.of(2021, 12)
-        val vedtak = Innvilget(periodeBegrunnelse = "Ok",
-                               inntektBegrunnelse = "ok",
-                               perioder = listOf(VedtaksperiodeDto(årMånedFra = årMånedFraStart,
+        val vedtak = InnvilgelseOvergangsstønad(periodeBegrunnelse = "Ok",
+                                                inntektBegrunnelse = "ok",
+                                                perioder = listOf(VedtaksperiodeDto(årMånedFra = årMånedFraStart,
                                                                    årMånedTil = årMånedFraSlutt,
                                                                    aktivitet = AktivitetType.BARN_UNDER_ETT_ÅR,
                                                                    periodeType = VedtaksperiodeType.HOVEDPERIODE)),
-                               inntekter = listOf(Inntekt(årMånedFra = årMånedFraStart,
+                                                inntekter = listOf(Inntekt(årMånedFra = årMånedFraStart,
                                                           forventetInntekt = BigDecimal(300000),
                                                           samordningsfradrag = BigDecimal(300))),
-                               samordningsfradragType = SamordningsfradragType.UFØRETRYGD
+                                                samordningsfradragType = SamordningsfradragType.UFØRETRYGD
 
         )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakDtoMapperTest.kt
@@ -1,0 +1,93 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vedtak
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.beregning.Inntekt
+import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
+import no.nav.familie.ef.sak.vedtak.domain.AvslagÅrsak
+import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
+import no.nav.familie.ef.sak.vedtak.dto.Avslå
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
+import no.nav.familie.ef.sak.vedtak.dto.Opphør
+import no.nav.familie.ef.sak.vedtak.dto.Sanksjonert
+import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
+import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
+import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.YearMonth
+
+class VedtakDtoMapperTest {
+
+    @Test
+    fun `deserialiser og serialiser innvilget overgangsstønad vedtak dto`() {
+        val vedtakJson = readFile("OvergangsstønadInnvilgetVedtakDto.json")
+
+        val vedtak = innvilgelseOvergangsstønad()
+        assertErLik(vedtak, vedtakJson)
+        assertErLikUtenType(vedtak, vedtakJson)
+    }
+
+    @Test
+    fun `deserialiser og serialiser avslå vedtak dto`() {
+        val vedtakJson = readFile("AvslåVedtakDto.json")
+
+        val vedtak = Avslå(AvslagÅrsak.BARN_OVER_ÅTTE_ÅR, "en god begrunnelse")
+        assertErLik(vedtak, vedtakJson)
+        assertErLikUtenType(vedtak, vedtakJson)
+    }
+
+    @Test
+    fun `deserialiser og serialiser opphør vedtak dto`() {
+        val vedtakJson = readFile("OpphørVedtakDto.json")
+
+        val vedtak = Opphør(YearMonth.of(2022, 1), "en god begrunnelse")
+        assertErLik(vedtak, vedtakJson)
+        assertErLikUtenType(vedtak, vedtakJson)
+    }
+
+    @Test
+    fun `deserialiser og serialiser sanksjon vedtak dto`() {
+        val vedtakJson = readFile("SanksjonVedtakDto.json")
+
+        val vedtak = Sanksjonert(Sanksjonsårsak.SAGT_OPP_STILLING, vedtaksperiode(), "begrunnelse")
+        assertErLik(vedtak, vedtakJson)
+        assertErLikUtenType(vedtak, vedtakJson)
+    }
+
+    private fun innvilgelseOvergangsstønad() =
+            InnvilgelseOvergangsstønad("periodebegrunnelse",
+                                       "inntektsbegrunnelse",
+                                       listOf(vedtaksperiode()),
+                                       listOf(Inntekt(årMånedFra = YearMonth.of(2021, 1),
+                                                      forventetInntekt = BigDecimal(100_000),
+                                                      samordningsfradrag = BigDecimal(500))),
+                                       SamordningsfradragType.GJENLEVENDEPENSJON)
+
+    private fun vedtaksperiode() =
+            VedtaksperiodeDto(YearMonth.of(2021, 1),
+                              YearMonth.of(2021, 12),
+                              AktivitetType.BARN_UNDER_ETT_ÅR,
+                              VedtaksperiodeType.HOVEDPERIODE)
+
+
+    private fun assertErLik(vedtakDto: VedtakDto, vedtakJson: String) {
+        val serialisertVedtak = objectMapper.writeValueAsString(vedtakDto)
+        assertThat(objectMapper.readTree(serialisertVedtak)).isEqualTo(objectMapper.readTree(vedtakJson))
+        assertThat(objectMapper.readValue<VedtakDto>(vedtakJson)).isEqualTo(vedtakDto)
+    }
+
+    private fun assertErLikUtenType(vedtakDto: VedtakDto, vedtakJson: String) {
+        val tree = objectMapper.readTree(vedtakJson)
+        (tree as ObjectNode).remove("_type")
+        val vedtakJsonUtenType = objectMapper.writeValueAsString(tree)
+        assertThat(objectMapper.readValue<VedtakDto>(vedtakJsonUtenType)).isEqualTo(vedtakDto)
+    }
+
+    private fun readFile(filnavn: String): String {
+        return this::class.java.getResource("/vedtak/$filnavn")!!.readText()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
@@ -37,7 +37,7 @@ import no.nav.familie.ef.sak.vedtak.domain.AktivitetType.BARNET_ER_SYKT
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType.FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
-import no.nav.familie.ef.sak.vedtak.dto.Innvilget
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vedtak.dto.tilDomene
 import no.nav.familie.prosessering.domene.TaskRepository
@@ -483,10 +483,10 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
                         behandling: Behandling,
                         vedtaksperioder: List<VedtaksperiodeDto>,
                         inntekter: List<Inntekt> = listOf(Inntekt(vedtaksperioder.first().årMånedFra, null, null))) {
-        val vedtak = Innvilget(perioder = vedtaksperioder,
-                               inntekter = inntekter,
-                               periodeBegrunnelse = null,
-                               inntektBegrunnelse = null)
+        val vedtak = InnvilgelseOvergangsstønad(perioder = vedtaksperioder,
+                                                inntekter = inntekter,
+                                                periodeBegrunnelse = null,
+                                                inntektBegrunnelse = null)
         beregnYtelseSteg.utførSteg(saksbehandling(fagsak, behandling), vedtak)
     }
 

--- a/src/test/resources/vedtak/AvslåVedtakDto.json
+++ b/src/test/resources/vedtak/AvslåVedtakDto.json
@@ -2,5 +2,5 @@
   "avslåÅrsak": "BARN_OVER_ÅTTE_ÅR",
   "avslåBegrunnelse": "en god begrunnelse",
   "resultatType": "AVSLÅ",
-  "_type": "Avslå"
+  "_type": "Avslag"
 }

--- a/src/test/resources/vedtak/AvslåVedtakDto.json
+++ b/src/test/resources/vedtak/AvslåVedtakDto.json
@@ -1,0 +1,6 @@
+{
+  "avslåÅrsak": "BARN_OVER_ÅTTE_ÅR",
+  "avslåBegrunnelse": "en god begrunnelse",
+  "resultatType": "AVSLÅ",
+  "_type": "Avslå"
+}

--- a/src/test/resources/vedtak/OpphørVedtakDto.json
+++ b/src/test/resources/vedtak/OpphørVedtakDto.json
@@ -1,0 +1,6 @@
+{
+  "opphørFom": "2022-01",
+  "begrunnelse": "en god begrunnelse",
+  "resultatType": "OPPHØRT",
+  "_type": "Opphør"
+}

--- a/src/test/resources/vedtak/OvergangsstønadInnvilgetVedtakDto.json
+++ b/src/test/resources/vedtak/OvergangsstønadInnvilgetVedtakDto.json
@@ -1,0 +1,22 @@
+{
+  "_type": "InnvilgelseOvergangsstønad",
+  "periodeBegrunnelse": "periodebegrunnelse",
+  "inntektBegrunnelse": "inntektsbegrunnelse",
+  "perioder": [
+    {
+      "årMånedFra": "2021-01",
+      "årMånedTil": "2021-12",
+      "aktivitet": "BARN_UNDER_ETT_ÅR",
+      "periodeType": "HOVEDPERIODE"
+    }
+  ],
+  "inntekter": [
+    {
+      "årMånedFra": "2021-01",
+      "forventetInntekt": 100000,
+      "samordningsfradrag": 500
+    }
+  ],
+  "samordningsfradragType": "GJENLEVENDEPENSJON",
+  "resultatType": "INNVILGE"
+}

--- a/src/test/resources/vedtak/SanksjonVedtakDto.json
+++ b/src/test/resources/vedtak/SanksjonVedtakDto.json
@@ -8,5 +8,5 @@
   },
   "internBegrunnelse": "begrunnelse",
   "resultatType": "SANKSJONERE",
-  "_type": "Sanksjonert"
+  "_type": "Sanksjonering"
 }

--- a/src/test/resources/vedtak/SanksjonVedtakDto.json
+++ b/src/test/resources/vedtak/SanksjonVedtakDto.json
@@ -1,0 +1,12 @@
+{
+  "sanksjonsårsak": "SAGT_OPP_STILLING",
+  "periode": {
+    "årMånedFra": "2021-01",
+    "årMånedTil": "2021-12",
+    "aktivitet": "BARN_UNDER_ETT_ÅR",
+    "periodeType": "HOVEDPERIODE"
+  },
+  "internBegrunnelse": "begrunnelse",
+  "resultatType": "SANKSJONERE",
+  "_type": "Sanksjonert"
+}


### PR DESCRIPTION
Enhetstester på serialisering av forskjellige VedtakDto-klasser
Renaming til InnvilgelseOvergangsstønad som subclass av VedtakDto

Tanken er å ta i bruk 
```kotlin
/*@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
              include = JsonTypeInfo.As.PROPERTY,
              property = "_type")*/
```

Som kommer erstatte `VedtakDtoDeserializer` som idag serialisererer/deserialiserer basert på resultattype, som ikke er mulig når vi sen har flere ulike Innvilge (InnvilgelseOvergangsstønad/InnvilgelseBarnetilsyn), og alle er av samme `resultattype = ResultatType.INNVILGE`