### PR TITLE
Endrer til dedikert cpu og mer minne for databasen i prod.

### DIFF
--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -37,6 +37,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_12 # IF This is changed, all data will be lost. Read on nais.io how to upgrade
+        tier: db-custom-1-3840
         diskAutoresize: true
         cascadingDelete: false
         highAvailability: true


### PR DESCRIPTION
Dette øker antall connections og, som idag er maks 25, og vi kan maks bruke 20-24 av disse
Pga att vi har en del transactions, som låser en connection og gjør eksterne kall så holder vi iblant på en connection litt lenge


Prodsettes etter arbeidstid då vi får nedetid vid endringer i databasen