### PR TITLE
Feil i loggen fra prod - Legger til validering av dokument som hentes ved hentDokumentSomPdf, …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringController.kt
@@ -51,8 +51,9 @@ class JournalføringController(private val journalføringService: Journalføring
 
     @GetMapping("/{journalpostId}/dokument-pdf/{dokumentInfoId}", produces = [MediaType.APPLICATION_PDF_VALUE])
     fun hentDokumentSomPdf(@PathVariable journalpostId: String, @PathVariable dokumentInfoId: String): ByteArray {
-        val (_, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
+        val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.ACCESS)
+        validerDokumentKanHentes(journalpost, dokumentInfoId, journalpostId)
         return journalføringService.hentDokument(journalpostId, dokumentInfoId)
     }
 


### PR DESCRIPTION
…som allerede er i bruk hentDokument for å unngå at vi prøver å hente infotrygd-dokumenter som er i arbeid som skal åpnes på en spesiell måte