### PR TITLE
Kast brukerfeil hvis:

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
@@ -17,9 +17,9 @@ class BeregningBarnetilsynService {
                                 kontantstøttePerioder: List<PeriodeMedBeløpDto>,
                                 tilleggsstønadsperioder: List<PeriodeMedBeløpDto>): List<BeløpsperiodeBarnetilsynDto> {
 
-        validerGyldigePerioder(utgiftsperioder.tilPerioder(),
-                               kontantstøttePerioder.tilPerioder(),
-                               tilleggsstønadsperioder.tilPerioder())
+        validerGyldigePerioder(utgiftsperioder,
+                               kontantstøttePerioder,
+                               tilleggsstønadsperioder)
 
         return utgiftsperioder.map { it.split() }
                 .flatten()
@@ -35,9 +35,14 @@ class BeregningBarnetilsynService {
                 it.tilPeriode()
             }
 
-    private fun validerGyldigePerioder(utgiftsperioder: List<Periode>,
-                                       kontantstøttePerioder: List<Periode>,
-                                       tilleggsstønadsperioder: List<Periode>) {
+    private fun validerGyldigePerioder(utgiftsperioderDto: List<UtgiftsperiodeDto>,
+                                       kontantstøttePerioderDto: List<PeriodeMedBeløpDto>,
+                                       tilleggsstønadsperioderDto: List<PeriodeMedBeløpDto>) {
+
+        val utgiftsperioder = utgiftsperioderDto.tilPerioder()
+        val kontantstøttePerioder = kontantstøttePerioderDto.tilPerioder()
+        val tilleggsstønadsperioder = tilleggsstønadsperioderDto.tilPerioder()
+
         brukerfeilHvis(utgiftsperioder.isEmpty()) { "Ingen utgiftsperioder" }
         brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, kontantstøttePerioder)){ "Urelevant kontantstøtteperiode kan fjernes" }
         brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, tilleggsstønadsperioder)){ "Urelevant tilleggsstønadsperiode kan fjernes" }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
@@ -43,14 +43,29 @@ class BeregningBarnetilsynService {
         val kontantstøttePerioder = kontantstøttePerioderDto.tilPerioder()
         val tilleggsstønadsperioder = tilleggsstønadsperioderDto.tilPerioder()
 
-        brukerfeilHvis(utgiftsperioder.isEmpty()) { "Ingen utgiftsperioder" }
-        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder,
-                                                     kontantstøttePerioder)) { "Urelevant kontantstøtteperiode kan fjernes" }
-        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder,
-                                                     tilleggsstønadsperioder)) { "Urelevant tilleggsstønadsperiode kan fjernes" }
-        brukerfeilHvis(utgiftsperioder.harOverlappende()) { "Utgiftsperioder $utgiftsperioder overlapper" }
-        brukerfeilHvis((kontantstøttePerioder.harOverlappende())) { "Kontantstøtteperioder $kontantstøttePerioder overlapper" }
-        brukerfeilHvis((tilleggsstønadsperioder.harOverlappende())) { "Tilleggsstønadsperioder $tilleggsstønadsperioder overlapper" }
+        brukerfeilHvis(utgiftsperioder.isEmpty()) {
+            "Ingen utgiftsperioder"
+        }
+
+        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, kontantstøttePerioder)) {
+            "Urelevant kontantstøtteperiode kan fjernes"
+        }
+
+        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, tilleggsstønadsperioder)) {
+            "Urelevant tilleggsstønadsperiode kan fjernes"
+        }
+
+        brukerfeilHvis(utgiftsperioder.harOverlappende()) {
+            "Utgiftsperioder $utgiftsperioder overlapper"
+        }
+
+        brukerfeilHvis((kontantstøttePerioder.harOverlappende())) {
+            "Kontantstøtteperioder $kontantstøttePerioder overlapper"
+        }
+
+        brukerfeilHvis((tilleggsstønadsperioder.harOverlappende())) {
+            "Tilleggsstønadsperioder $tilleggsstønadsperioder overlapper"
+        }
     }
 
     private fun harUrelevantReduksjonsPeriode(utgiftsperioder: List<Periode>, reduksjonsperioder: List<Periode>): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynService.kt
@@ -44,8 +44,10 @@ class BeregningBarnetilsynService {
         val tilleggsstønadsperioder = tilleggsstønadsperioderDto.tilPerioder()
 
         brukerfeilHvis(utgiftsperioder.isEmpty()) { "Ingen utgiftsperioder" }
-        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, kontantstøttePerioder)){ "Urelevant kontantstøtteperiode kan fjernes" }
-        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder, tilleggsstønadsperioder)){ "Urelevant tilleggsstønadsperiode kan fjernes" }
+        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder,
+                                                     kontantstøttePerioder)) { "Urelevant kontantstøtteperiode kan fjernes" }
+        brukerfeilHvis(harUrelevantReduksjonsPeriode(utgiftsperioder,
+                                                     tilleggsstønadsperioder)) { "Urelevant tilleggsstønadsperiode kan fjernes" }
         brukerfeilHvis(utgiftsperioder.harOverlappende()) { "Utgiftsperioder $utgiftsperioder overlapper" }
         brukerfeilHvis((kontantstøttePerioder.harOverlappende())) { "Kontantstøtteperioder $kontantstøttePerioder overlapper" }
         brukerfeilHvis((tilleggsstønadsperioder.harOverlappende())) { "Tilleggsstønadsperioder $tilleggsstønadsperioder overlapper" }

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/dto/Periode.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/dto/Periode.kt
@@ -7,7 +7,7 @@ data class Periode(val fradato: LocalDate,
                    val tildato: LocalDate) {
 
     init {
-        require(fradato <= tildato) {"Fradato må kommer før tildato i enn periode."}
+        require(fradato <= tildato) {"Fradato må komme før tildato i enn periode."}
     }
 
     fun omslutter(date: LocalDate): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakBarnetilsynDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakBarnetilsynDto.kt
@@ -23,15 +23,17 @@ data class PeriodeMedBeløpDto(
         val årMånedFra: YearMonth,
         val årMånedTil: YearMonth,
         val beløp: Int
-)
 
-data class UtgiftsperiodeDto(
+){
+    fun tilPeriode(): Periode = Periode(this.årMånedFra.atDay(1), this.årMånedTil.atEndOfMonth())
+}
+
+data class UtgiftsperiodeDto (
         val årMånedFra: YearMonth,
         val årMånedTil: YearMonth,
         val barn: List<UUID>,
         val utgifter: BigDecimal
 ) {
-
     fun tilPeriode(): Periode = Periode(this.årMånedFra.atDay(1), this.årMånedTil.atEndOfMonth())
 }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
@@ -40,7 +40,7 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal kaste feil når vi sender inn urelevant kontantstøtteperiode`() {
-        val januarTilApril = enUtgiftsperiode(januar2022, april2022)
+        val januarTilApril = listeMedEnUtgiftsperiode(januar2022, april2022)
         val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
         assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
@@ -51,7 +51,7 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal kaste feil når vi sender inn urelevant tilleggsstønadsperiode`() {
-        val januarTilApril = enUtgiftsperiode(januar2022, april2022)
+        val januarTilApril = listeMedEnUtgiftsperiode(januar2022, april2022)
         val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
         assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
@@ -59,17 +59,6 @@ internal class BeregningBarnetilsynServiceTest {
                                             tilleggsstønadsperioder = urelevant)
         }
     }
-
-
-    private fun enPeriodeMedBeløp(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(PeriodeMedBeløpDto(
-            årMånedFra = fra,
-            årMånedTil = til,
-            beløp = 10))
-
-    private fun enUtgiftsperiode(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(UtgiftsperiodeDto(fra,
-                                                                                                                       til,
-                                                                                                                       listOf(UUID.randomUUID()),
-                                                                                                                       TEN))
 
     @Test
     fun `Skal kaste feil hvis utgiftsperioder er overlappende`() {
@@ -88,7 +77,7 @@ internal class BeregningBarnetilsynServiceTest {
         val overlappende = enPeriodeMedBeløp(januar2022, april2022) + enPeriodeMedBeløp(april2022, april2022)
 
         val feil = assertThrows<ApiFeil> {
-            service.beregnYtelseBarnetilsyn(utgiftsperioder = enUtgiftsperiode(januar2022, april2022),
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = listeMedEnUtgiftsperiode(januar2022, april2022),
                                             kontantstøttePerioder = overlappende,
                                             tilleggsstønadsperioder = listOf())
         }
@@ -100,7 +89,7 @@ internal class BeregningBarnetilsynServiceTest {
     fun `Skal kaste brukerfeil hvis tilleggsstønadperioder er overlappende`() {
         val overlappendePerioder = enPeriodeMedBeløp(april2022, april2022) + enPeriodeMedBeløp(januar2022, april2022)
         val feil = assertThrows<ApiFeil> {
-            service.beregnYtelseBarnetilsyn(utgiftsperioder = enUtgiftsperiode(januar2022, april2022),
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = listeMedEnUtgiftsperiode(januar2022, april2022),
                                             kontantstøttePerioder = listOf(),
                                             tilleggsstønadsperioder = overlappendePerioder)
         }
@@ -383,5 +372,15 @@ internal class BeregningBarnetilsynServiceTest {
                                                                                                  tilleggsstønadsbeløp = ZERO,
                                                                                                  antallBarn = 1))
     }
+
+    private fun enPeriodeMedBeløp(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(PeriodeMedBeløpDto(
+            årMånedFra = fra,
+            årMånedTil = til,
+            beløp = 10))
+
+    private fun listeMedEnUtgiftsperiode(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(UtgiftsperiodeDto(fra,
+                                                                                                                               til,
+                                                                                                                               listOf(UUID.randomUUID()),
+                                                                                                                               TEN))
 
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
@@ -41,7 +41,7 @@ internal class BeregningBarnetilsynServiceTest {
     @Test
     fun `Skal kaste feil når vi sender inn urelevant kontantstøtteperiode`() {
         val januarTilApril = listeMedEnUtgiftsperiode(januar2022, april2022)
-        val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
+        val urelevant = listeMedEnPeriodeMedBeløp(juli2022, desember2022)
         assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
                                             kontantstøttePerioder = urelevant,
@@ -52,7 +52,7 @@ internal class BeregningBarnetilsynServiceTest {
     @Test
     fun `Skal kaste feil når vi sender inn urelevant tilleggsstønadsperiode`() {
         val januarTilApril = listeMedEnUtgiftsperiode(januar2022, april2022)
-        val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
+        val urelevant = listeMedEnPeriodeMedBeløp(juli2022, desember2022)
         assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
                                             kontantstøttePerioder = listOf(),
@@ -74,7 +74,7 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal kaste brukerfeil hvis kontantstøtteperioder er overlappende`() {
-        val overlappende = enPeriodeMedBeløp(januar2022, april2022) + enPeriodeMedBeløp(april2022, april2022)
+        val overlappende = listeMedEnPeriodeMedBeløp(januar2022, april2022) + listeMedEnPeriodeMedBeløp(april2022, april2022)
 
         val feil = assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = listeMedEnUtgiftsperiode(januar2022, april2022),
@@ -87,7 +87,7 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal kaste brukerfeil hvis tilleggsstønadperioder er overlappende`() {
-        val overlappendePerioder = enPeriodeMedBeløp(april2022, april2022) + enPeriodeMedBeløp(januar2022, april2022)
+        val overlappendePerioder = listeMedEnPeriodeMedBeløp(april2022, april2022) + listeMedEnPeriodeMedBeløp(januar2022, april2022)
         val feil = assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = listeMedEnUtgiftsperiode(januar2022, april2022),
                                             kontantstøttePerioder = listOf(),
@@ -373,7 +373,7 @@ internal class BeregningBarnetilsynServiceTest {
                                                                                                  antallBarn = 1))
     }
 
-    private fun enPeriodeMedBeløp(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(PeriodeMedBeløpDto(
+    private fun listeMedEnPeriodeMedBeløp(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(PeriodeMedBeløpDto(
             årMånedFra = fra,
             årMånedTil = til,
             beløp = 10))

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ef.sak.beregning.barnetilsyn
 
 import no.nav.familie.ef.sak.felles.dto.Periode
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.vedtak.dto.PeriodeMedBeløpDto
 import no.nav.familie.ef.sak.vedtak.dto.UtgiftsperiodeDto
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 import java.math.BigDecimal.ONE
 import java.math.BigDecimal.TEN
@@ -17,18 +19,101 @@ internal class BeregningBarnetilsynServiceTest {
 
     val service: BeregningBarnetilsynService = BeregningBarnetilsynService()
 
+    val januar2022 = YearMonth.of(2022, 1)
+    val februar2022 = YearMonth.of(2022, 2)
+    val mars2022 = YearMonth.of(2022, 3)
+    val april2022 = YearMonth.of(2022, 4)
+    val mai2022 = YearMonth.of(2022, 5)
+    val juli2022 = YearMonth.of(2022, 7)
+    val august2022 = YearMonth.of(2022, 8)
+    val september2022 = YearMonth.of(2022, 9)
+    val november2022 = YearMonth.of(2022, 11)
+    val desember2022 = YearMonth.of(2022, 12)
+
+    val januar2021 = YearMonth.of(2021, 1)
+    val desember2021 = YearMonth.of(2021, 12)
+
+    val januar2000 = YearMonth.of(2000, 1)
+    val februar2000 = YearMonth.of(2000, 2)
+    val mars2000 = YearMonth.of(2000, 3)
+
+
+    @Test
+    fun `Skal kaste feil når vi sender inn urelevant kontantstøtteperiode`() {
+        val januarTilApril = enUtgiftsperiode(januar2022, april2022)
+        val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
+        assertThrows<ApiFeil> {
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
+                                            kontantstøttePerioder = urelevant,
+                                            tilleggsstønadsperioder = listOf())
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil når vi sender inn urelevant tilleggsstønadsperiode`() {
+        val januarTilApril = enUtgiftsperiode(januar2022, april2022)
+        val urelevant = enPeriodeMedBeløp(juli2022, desember2022)
+        assertThrows<ApiFeil> {
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = januarTilApril,
+                                            kontantstøttePerioder = listOf(),
+                                            tilleggsstønadsperioder = urelevant)
+        }
+    }
+
+
+    private fun enPeriodeMedBeløp(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(PeriodeMedBeløpDto(
+            årMånedFra = fra,
+            årMånedTil = til,
+            beløp = 10))
+
+    private fun enUtgiftsperiode(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(UtgiftsperiodeDto(fra,
+                                                                                                                       til,
+                                                                                                                       listOf(UUID.randomUUID()),
+                                                                                                                       TEN))
+
+    @Test
+    fun `Skal kaste feil hvis utgiftsperioder er overlappende`() {
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, april2022, barn = listOf(UUID.randomUUID()), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(mars2022, juli2022, barn = listOf(UUID.randomUUID()), utgifter = TEN)
+        val feil = assertThrows<ApiFeil> {
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1, utgiftsperiode2),
+                                            kontantstøttePerioder = listOf(),
+                                            tilleggsstønadsperioder = listOf())
+        }
+        assertThat(feil.message).contains("Utgiftsperioder")
+    }
+
+    @Test
+    fun `Skal kaste brukerfeil hvis kontantstøtteperioder er overlappende`() {
+        val overlappende = enPeriodeMedBeløp(januar2022, april2022) + enPeriodeMedBeløp(april2022, april2022)
+
+        val feil = assertThrows<ApiFeil> {
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = enUtgiftsperiode(januar2022, april2022),
+                                            kontantstøttePerioder = overlappende,
+                                            tilleggsstønadsperioder = listOf())
+        }
+        assertThat(feil.message).contains("Kontantstøtteperioder [Periode(fradato=2022-01-01, tildato=2022-04-30), Periode(fradato=2022-04-01, tildato=2022-04-30)] overlapper")
+    }
+
+
+    @Test
+    fun `Skal kaste brukerfeil hvis tilleggsstønadperioder er overlappende`() {
+        val overlappendePerioder = enPeriodeMedBeløp(april2022, april2022) + enPeriodeMedBeløp(januar2022, april2022)
+        val feil = assertThrows<ApiFeil> {
+            service.beregnYtelseBarnetilsyn(utgiftsperioder = enUtgiftsperiode(januar2022, april2022),
+                                            kontantstøttePerioder = listOf(),
+                                            tilleggsstønadsperioder = overlappendePerioder)
+        }
+        assertThat(feil.message).contains("Tilleggsstønadsperioder")
+    }
+
+
     @Test
     fun `Skal lage tre perioder når tre forskjellige beløp i en 12,md periode`() {
-        val januar = YearMonth.of(2022, 1)
-        val mars = YearMonth.of(2022, 3)
-        val april = YearMonth.of(2022, 4)
-        val juli = YearMonth.of(2022, 7)
-        val aug = YearMonth.of(2022, 8)
-        val desember = YearMonth.of(2022, 12)
         val barnUUID = UUID.randomUUID()
-        val utgiftsperiode1 = UtgiftsperiodeDto(januar, mars, barn = listOf(barnUUID), utgifter = TEN)
-        val utgiftsperiode2 = UtgiftsperiodeDto(april, juli, barn = listOf(barnUUID), utgifter = ONE)
-        val utgiftsperiode3 = UtgiftsperiodeDto(aug, desember, barn = listOf(barnUUID), utgifter = TEN + TEN)
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, mars2022, barn = listOf(barnUUID), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(april2022, juli2022, barn = listOf(barnUUID), utgifter = ONE)
+        val utgiftsperiode3 = UtgiftsperiodeDto(august2022, desember2022, barn = listOf(barnUUID), utgifter = TEN + TEN)
 
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1,
                                                                                                utgiftsperiode2,
@@ -41,21 +126,16 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage seks perioder med tre forskjellige kontantstøtteperioder i en 12 mnd periode`() {
-        val januar = YearMonth.of(2022, 1)
-        val mars = YearMonth.of(2022, 3)
-        val april = YearMonth.of(2022, 4)
-        val juli = YearMonth.of(2022, 7)
-        val august = YearMonth.of(2022, 8)
         val desember = YearMonth.of(2022, 12)
         val barnUUID = UUID.randomUUID()
 
-        val utgiftsperiode1 = UtgiftsperiodeDto(januar, mars, barn = listOf(barnUUID), utgifter = TEN)
-        val utgiftsperiode2 = UtgiftsperiodeDto(april, juli, barn = listOf(barnUUID), utgifter = ONE)
-        val utgiftsperiode3 = UtgiftsperiodeDto(august, desember, barn = listOf(barnUUID), utgifter = TEN + TEN)
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, mars2022, barn = listOf(barnUUID), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(april2022, juli2022, barn = listOf(barnUUID), utgifter = ONE)
+        val utgiftsperiode3 = UtgiftsperiodeDto(august2022, desember, barn = listOf(barnUUID), utgifter = TEN + TEN)
 
-        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = januar, årMånedTil = januar, beløp = 10)
-        val kontantStøtteperiodeApril = PeriodeMedBeløpDto(årMånedFra = april, årMånedTil = april, beløp = 10)
-        val kontantStøtteperiodeAugust = PeriodeMedBeløpDto(årMånedFra = august, årMånedTil = august, beløp = 10)
+        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = januar2022, årMånedTil = januar2022, beløp = 10)
+        val kontantStøtteperiodeApril = PeriodeMedBeløpDto(årMånedFra = april2022, årMånedTil = april2022, beløp = 10)
+        val kontantStøtteperiodeAugust = PeriodeMedBeløpDto(årMånedFra = august2022, årMånedTil = august2022, beløp = 10)
 
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1,
                                                                                                utgiftsperiode2,
@@ -70,17 +150,14 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage fire perioder med to utgiftsperioder og med en overlappende kontantstøtteperiode`() {
-        val januar = YearMonth.of(2022, 1)
-        val juli = YearMonth.of(2022, 7)
-        val august = YearMonth.of(2022, 8)
-        val desember = YearMonth.of(2022, 12)
+
         val barnUUID = UUID.randomUUID()
 
-        val utgiftsperiode1 = UtgiftsperiodeDto(januar, juli, barn = listOf(barnUUID), utgifter = TEN)
-        val utgiftsperiode2 = UtgiftsperiodeDto(august, desember, barn = listOf(barnUUID), utgifter = ONE)
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, juli2022, barn = listOf(barnUUID), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(august2022, desember2022, barn = listOf(barnUUID), utgifter = ONE)
 
 
-        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = juli, årMånedTil = august, beløp = 10)
+        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = juli2022, årMånedTil = august2022, beløp = 10)
 
 
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1,
@@ -93,21 +170,15 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage seks perioder med to utgiftsperioder og en overlappende kontantstøtte og tilleggsstønadsperiodemed`() {
-        val januar = YearMonth.of(2022, 1)
-        val mai = YearMonth.of(2022, 5)
-        val juli = YearMonth.of(2022, 7)
-        val august = YearMonth.of(2022, 8)
-        val september = YearMonth.of(2022, 9)
-        val november = YearMonth.of(2022, 11)
-        val desember = YearMonth.of(2022, 12)
+
         val barnUUID = UUID.randomUUID()
 
-        val utgiftsperiode1 = UtgiftsperiodeDto(januar, juli, barn = listOf(barnUUID), utgifter = TEN)
-        val utgiftsperiode2 = UtgiftsperiodeDto(august, desember, barn = listOf(barnUUID), utgifter = ONE)
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, juli2022, barn = listOf(barnUUID), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(august2022, desember2022, barn = listOf(barnUUID), utgifter = ONE)
 
-        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = mai, årMånedTil = september, beløp = 10)
+        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = mai2022, årMånedTil = september2022, beløp = 10)
         val tilleggsstønadPeriodeDto =
-                PeriodeMedBeløpDto(årMånedFra = juli, årMånedTil = november, beløp = 10)
+                PeriodeMedBeløpDto(årMånedFra = juli2022, årMånedTil = november2022, beløp = 10)
 
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1,
                                                                                                utgiftsperiode2),
@@ -118,28 +189,22 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 9 perioder når tre forskjellige kontantstøtteperioder og tilleggsstønadsperioder i en 12 mnd periode`() {
-        val januar = YearMonth.of(2022, 1)
-        val mars = YearMonth.of(2022, 3)
-        val april = YearMonth.of(2022, 4)
-        val juli = YearMonth.of(2022, 7)
-        val august = YearMonth.of(2022, 8)
-        val desember = YearMonth.of(2022, 12)
         val barnUUID = UUID.randomUUID()
 
-        val utgiftsperiode1 = UtgiftsperiodeDto(januar, mars, barn = listOf(barnUUID), utgifter = TEN)
-        val utgiftsperiode2 = UtgiftsperiodeDto(april, juli, barn = listOf(barnUUID), utgifter = ONE)
-        val utgiftsperiode3 = UtgiftsperiodeDto(august, desember, barn = listOf(barnUUID), utgifter = TEN + TEN)
+        val utgiftsperiode1 = UtgiftsperiodeDto(januar2022, mars2022, barn = listOf(barnUUID), utgifter = TEN)
+        val utgiftsperiode2 = UtgiftsperiodeDto(april2022, juli2022, barn = listOf(barnUUID), utgifter = ONE)
+        val utgiftsperiode3 = UtgiftsperiodeDto(august2022, desember2022, barn = listOf(barnUUID), utgifter = TEN + TEN)
 
-        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = januar, årMånedTil = januar, beløp = 10)
-        val kontantStøtteperiodeApril = PeriodeMedBeløpDto(årMånedFra = april, årMånedTil = april, beløp = 10)
-        val kontantStøtteperiodeAugust = PeriodeMedBeløpDto(årMånedFra = august, årMånedTil = august, beløp = 10)
+        val kontantStøtteperiodeJanuar = PeriodeMedBeløpDto(årMånedFra = januar2022, årMånedTil = januar2022, beløp = 10)
+        val kontantStøtteperiodeApril = PeriodeMedBeløpDto(årMånedFra = april2022, årMånedTil = april2022, beløp = 10)
+        val kontantStøtteperiodeAugust = PeriodeMedBeløpDto(årMånedFra = august2022, årMånedTil = august2022, beløp = 10)
 
         val tilleggsstønadsperiodeMars =
-                PeriodeMedBeløpDto(årMånedFra = mars, årMånedTil = mars, 10)
+                PeriodeMedBeløpDto(årMånedFra = mars2022, årMånedTil = mars2022, 10)
         val tilleggsstønadsperiodeJuli =
-                PeriodeMedBeløpDto(årMånedFra = juli, årMånedTil = juli, 10)
+                PeriodeMedBeløpDto(årMånedFra = juli2022, årMånedTil = juli2022, 10)
         val tilleggsstønadsperiodeDesember =
-                PeriodeMedBeløpDto(årMånedFra = desember, årMånedTil = desember, 10)
+                PeriodeMedBeløpDto(årMånedFra = desember2022, årMånedTil = desember2022, 10)
 
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode1,
                                                                                                utgiftsperiode2,
@@ -157,14 +222,11 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 2 perioder når vi går over to satser over to år når man overskyter maksbeløp`() {
-        val januar = YearMonth.of(2021, 1)
-        val desember = YearMonth.of(2022, 12)
-
         val forventetBeløp2021 = 4195
         val forventetBeløp2022 = 4250
 
         val utgiftsperiode =
-                UtgiftsperiodeDto(januar, desember, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(1000000.0))
+                UtgiftsperiodeDto(januar2021, desember2022, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(1000000.0))
         val beregnYtelseBarnetilsyn = service.beregnYtelseBarnetilsyn(utgiftsperioder = listOf(utgiftsperiode),
                                                                       kontantstøttePerioder = listOf(),
                                                                       tilleggsstønadsperioder = listOf())
@@ -177,17 +239,12 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 2 perioder når vi går over to satser over to år med 2 barn når man overskyter maksbeløp`() {
-        val januar21 = YearMonth.of(2021, 1)
-        val desember21 = YearMonth.of(2021, 12)
-        val januar22 = YearMonth.of(2022, 1)
-        val desember22 = YearMonth.of(2022, 12)
-
-        val utgiftsperiode21 = UtgiftsperiodeDto(januar21,
-                                                 desember21,
+        val utgiftsperiode21 = UtgiftsperiodeDto(januar2021,
+                                                 desember2021,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(1000000.0))
-        val utgiftsperiode22 = UtgiftsperiodeDto(januar22,
-                                                 desember22,
+        val utgiftsperiode22 = UtgiftsperiodeDto(januar2022,
+                                                 desember2022,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(1000000.0))
         val beregnYtelseBarnetilsyn =
@@ -199,17 +256,12 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 1 perioder når vi går over to satser over to år med 2 barn når man ikke overskyter maksbeløp`() {
-        val januar21 = YearMonth.of(2021, 1)
-        val desember21 = YearMonth.of(2021, 12)
-        val januar22 = YearMonth.of(2022, 1)
-        val desember22 = YearMonth.of(2022, 12)
-
-        val utgiftsperiode21 = UtgiftsperiodeDto(januar21,
-                                                 desember21,
+        val utgiftsperiode21 = UtgiftsperiodeDto(januar2021,
+                                                 desember2021,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(1.0))
-        val utgiftsperiode22 = UtgiftsperiodeDto(januar22,
-                                                 desember22,
+        val utgiftsperiode22 = UtgiftsperiodeDto(januar2022,
+                                                 desember2022,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(1.0))
         val beregnYtelseBarnetilsyn =
@@ -221,15 +273,10 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 2 perioder når vi går over to satser over to år med 1 til 2 barn når man ikke overskyter maksbeløp`() {
-        val januar21 = YearMonth.of(2021, 1)
-        val desember21 = YearMonth.of(2021, 12)
-        val januar22 = YearMonth.of(2022, 1)
-        val desember22 = YearMonth.of(2022, 12)
-
         val utgiftsperiode21 =
-                UtgiftsperiodeDto(januar21, desember21, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(1.0))
-        val utgiftsperiode22 = UtgiftsperiodeDto(januar22,
-                                                 desember22,
+                UtgiftsperiodeDto(januar2021, desember2021, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(1.0))
+        val utgiftsperiode22 = UtgiftsperiodeDto(januar2022,
+                                                 desember2022,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(1.0))
         val beregnYtelseBarnetilsyn =
@@ -241,15 +288,10 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal lage 2 perioder når vi går over to satser over to år med 1 til 2 barn når man overskyter maksbeløp`() {
-        val januar21 = YearMonth.of(2021, 1)
-        val desember21 = YearMonth.of(2021, 12)
-        val januar22 = YearMonth.of(2022, 1)
-        val desember22 = YearMonth.of(2022, 12)
-
         val utgiftsperiode21 =
-                UtgiftsperiodeDto(januar21, desember21, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(100000.0))
-        val utgiftsperiode22 = UtgiftsperiodeDto(januar22,
-                                                 desember22,
+                UtgiftsperiodeDto(januar2021, desember2021, barn = listOf(UUID.randomUUID()), utgifter = BigDecimal(100000.0))
+        val utgiftsperiode22 = UtgiftsperiodeDto(januar2022,
+                                                 desember2022,
                                                  barn = listOf(UUID.randomUUID(), UUID.randomUUID()),
                                                  utgifter = BigDecimal(100000.0))
         val beregnYtelseBarnetilsyn =
@@ -261,11 +303,7 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `split en utgiftsperiode som varer fra januar til desember i 12 mnd`() {
-
-        val januar = YearMonth.of(2000, 1)
-        val desember = YearMonth.of(2000, 12)
-
-        val utgiftsperiodeDto = UtgiftsperiodeDto(januar, desember, barn = listOf(), utgifter = TEN)
+        val utgiftsperiodeDto = UtgiftsperiodeDto(januar2022, desember2022, barn = listOf(), utgifter = TEN)
         val resultat = utgiftsperiodeDto.split()
         assertThat(resultat).hasSize(12)
 
@@ -273,12 +311,11 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `merge to påfølgende måneder med like beløp, forvent én periode`() {
-        val januar = YearMonth.of(2000, 1)
-        val februar = YearMonth.of(2000, 2)
-        val forventetFraDato = januar.atDay(1)
-        val forventetTilDato = februar.atEndOfMonth()
-        val beløpsperioder = listOf(lagBeløpsperiode(forventetFraDato, januar.atEndOfMonth()),
-                                    lagBeløpsperiode(februar.atDay(1), forventetTilDato))
+
+        val forventetFraDato = januar2000.atDay(1)
+        val forventetTilDato = februar2000.atEndOfMonth()
+        val beløpsperioder = listOf(lagBeløpsperiode(forventetFraDato, januar2000.atEndOfMonth()),
+                                    lagBeløpsperiode(februar2000.atDay(1), forventetTilDato))
 
         val resultat = beløpsperioder.mergeSammenhengendePerioder()
 
@@ -289,14 +326,13 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `merge to påfølgende måneder med forskjellige beløp, forvent to perioder`() {
-        val januar = YearMonth.of(2000, 1)
-        val februar = YearMonth.of(2000, 2)
-        val forventetFraDato = januar.atDay(1)
-        val forventetTilDato = februar.atEndOfMonth()
+
+        val forventetFraDato = januar2000.atDay(1)
+        val forventetTilDato = februar2000.atEndOfMonth()
         val beløpsperioder = listOf(lagBeløpsperiode(fraDato = forventetFraDato,
-                                                     tilDato = januar.atEndOfMonth(),
+                                                     tilDato = januar2000.atEndOfMonth(),
                                                      beløp = BigDecimal(100)),
-                                    lagBeløpsperiode(fraDato = februar.atDay(1),
+                                    lagBeløpsperiode(fraDato = februar2000.atDay(1),
                                                      tilDato = forventetTilDato,
                                                      beløp = BigDecimal(200)))
 
@@ -309,14 +345,13 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `merge to påfølgende måneder med hull ifm fradatoer, forvent NotImplementedError`() {
-        val januar = YearMonth.of(2000, 1)
-        val mars = YearMonth.of(2000, 3)
-        val forventetFraDato = januar.atDay(1)
-        val forventetTilDato = mars.atEndOfMonth()
+
+        val forventetFraDato = januar2000.atDay(1)
+        val forventetTilDato = mars2000.atEndOfMonth()
         val beløpsperioder = listOf(lagBeløpsperiode(fraDato = forventetFraDato,
-                                                     tilDato = januar.atEndOfMonth(),
+                                                     tilDato = januar2000.atEndOfMonth(),
                                                      beløp = BigDecimal(100)),
-                                    lagBeløpsperiode(fraDato = mars.atDay(1),
+                                    lagBeløpsperiode(fraDato = mars2000.atDay(1),
                                                      tilDato = forventetTilDato,
                                                      beløp = BigDecimal(100)))
         assertThat(beløpsperioder.mergeSammenhengendePerioder()).hasSize(2)
@@ -325,14 +360,13 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `merge to påfølgende måneder med hull ifm fradatoer og forskjellige beløp, forvent NotImplementedError`() {
-        val januar = YearMonth.of(2000, 1)
-        val mars = YearMonth.of(2000, 3)
-        val forventetFraDato = januar.atDay(1)
-        val forventetTilDato = mars.atEndOfMonth()
+
+        val forventetFraDato = januar2000.atDay(1)
+        val forventetTilDato = mars2000.atEndOfMonth()
         val beløpsperioder = listOf(lagBeløpsperiode(fraDato = forventetFraDato,
-                                                     tilDato = januar.atEndOfMonth(),
+                                                     tilDato = januar2000.atEndOfMonth(),
                                                      beløp = BigDecimal(100)),
-                                    lagBeløpsperiode(fraDato = mars.atDay(1),
+                                    lagBeløpsperiode(fraDato = mars2000.atDay(1),
                                                      tilDato = forventetTilDato,
                                                      beløp = BigDecimal(200)))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynServiceTest.kt
@@ -87,7 +87,8 @@ internal class BeregningBarnetilsynServiceTest {
 
     @Test
     fun `Skal kaste brukerfeil hvis tilleggsstønadperioder er overlappende`() {
-        val overlappendePerioder = listeMedEnPeriodeMedBeløp(april2022, april2022) + listeMedEnPeriodeMedBeløp(januar2022, april2022)
+        val overlappendePerioder =
+                listeMedEnPeriodeMedBeløp(april2022, april2022) + listeMedEnPeriodeMedBeløp(januar2022, april2022)
         val feil = assertThrows<ApiFeil> {
             service.beregnYtelseBarnetilsyn(utgiftsperioder = listeMedEnUtgiftsperiode(januar2022, april2022),
                                             kontantstøttePerioder = listOf(),
@@ -378,9 +379,10 @@ internal class BeregningBarnetilsynServiceTest {
             årMånedTil = til,
             beløp = 10))
 
-    private fun listeMedEnUtgiftsperiode(fra: YearMonth = januar2022, til: YearMonth = februar2022) = listOf(UtgiftsperiodeDto(fra,
-                                                                                                                               til,
-                                                                                                                               listOf(UUID.randomUUID()),
-                                                                                                                               TEN))
+    private fun listeMedEnUtgiftsperiode(fra: YearMonth = januar2022,
+                                         til: YearMonth = februar2022) = listOf(UtgiftsperiodeDto(fra,
+                                                                                                  til,
+                                                                                                  listOf(UUID.randomUUID()),
+                                                                                                  TEN))
 
 }


### PR DESCRIPTION
* Ingen utgiftsperioder
* Urelevant reduksjonsperiode (tilegg/kontantstøtte)
* Overlappende utgiftsperioder
* Overlappende kontantstøttePerioder
* Overlappende tilleggsstønadsperioder

Spørsmål:
Refaktorerte - flyttet ut datoer som ble brukt av alle testmetoder (BeregningBarnetilsynServiceTest). Beklager - dette kunne jeg gjort i en egen PR - skal jeg splitte? 

Skal jeg legge på @Nested  i BeregningBarnetilsynServiceTest, eller går det greit? Ganske mange tester der nå.

