### PR TITLE
Renamer metode til finnVedleggForPerson og henter 200 i stedet for de…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggController.kt
@@ -27,6 +27,6 @@ class VedleggController(private val vedleggService: VedleggService,
     @GetMapping("/person/{personIdent}")
     fun finnVedleggForPerson(@PathVariable personIdent: String): Ressurs<List<DokumentinfoDto>> {
         tilgangService.validerTilgangTilPerson(personIdent, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(vedleggService.finnDokumentInfo(personIdent))
+        return Ressurs.success(vedleggService.finnVedleggForPerson(personIdent))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedlegg/VedleggService.kt
@@ -39,8 +39,8 @@ class VedleggService(private val behandlingService: BehandlingService,
         return sistejournalposter + hentJournalposterTilBehandlingSomIkkeErFunnet(sistejournalposter, behandlingsjournalposter)
     }
 
-    fun finnDokumentInfo(personIdent: String): List<DokumentinfoDto> {
-        val journalposter = journalføringService.finnJournalposter(personIdent)
+    fun finnVedleggForPerson(personIdent: String): List<DokumentinfoDto> {
+        val journalposter = journalføringService.finnJournalposter(personIdent, antall = 200)
 
         return journalposter
                 .flatMap { journalpost -> journalpost.dokumenter?.map { tilDokumentInfoDto(it, journalpost) } ?: emptyList() }


### PR DESCRIPTION
…fault 20 vid uthenting av vedlegg

https://nav-it.slack.com/archives/C01087QRJ2U/p1651069509546969

Info: Grunnen til at det default er 20 er fordi det første bruket av denne var å hente siste 20 journalposten til behandlingen for å vise i høyrefanen. 