### PR TITLE
Fjerner telefonnummer fra søknad

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>1.20220406150627_c699e0a</felles.version>
         <prosessering.version>1.20220331123748_03bdb3b</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20220429151635_4bb9f6d</kontrakter.version>
+        <kontrakter.version>2.0_20220504092027_190334e</kontrakter.version>
         <cucumber.version>7.2.3</cucumber.version>
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -64,7 +64,7 @@ object SøknadsskjemaMapper {
         return SøknadsskjemaOvergangsstønad(fødselsnummer = kontraktsøknad.personalia.verdi.fødselsnummer.verdi.verdi,
                                             navn = kontraktsøknad.personalia.verdi.navn.verdi,
                                             type = SøknadType.OVERGANGSSTØNAD,
-                                            telefonnummer = kontraktsøknad.personalia.verdi.telefonnummer?.verdi,
+                                            telefonnummer = null, //TODO ikke i bruk - fjern fra tabell
                                             datoMottatt = kontraktsøknad.innsendingsdetaljer.verdi.datoMottatt.verdi,
                                             sivilstand = tilDomene(kontraktsøknad.sivilstandsdetaljer.verdi),
                                             medlemskap = tilDomene(kontraktsøknad.medlemskapsdetaljer.verdi),
@@ -81,7 +81,7 @@ object SøknadsskjemaMapper {
         return SøknadsskjemaBarnetilsyn(fødselsnummer = kontraktsøknad.personalia.verdi.fødselsnummer.verdi.verdi,
                                         navn = kontraktsøknad.personalia.verdi.navn.verdi,
                                         type = SøknadType.BARNETILSYN,
-                                        telefonnummer = kontraktsøknad.personalia.verdi.telefonnummer?.verdi,
+                                        telefonnummer = null,  //TODO ikke i bruk - fjern fra tabell
                                         datoMottatt = kontraktsøknad.innsendingsdetaljer.verdi.datoMottatt.verdi,
                                         sivilstand = tilDomene(kontraktsøknad.sivilstandsdetaljer.verdi),
                                         medlemskap = tilDomene(kontraktsøknad.medlemskapsdetaljer.verdi),
@@ -98,7 +98,7 @@ object SøknadsskjemaMapper {
         return SøknadsskjemaSkolepenger(fødselsnummer = kontraktsøknad.personalia.verdi.fødselsnummer.verdi.verdi,
                                         navn = kontraktsøknad.personalia.verdi.navn.verdi,
                                         type = SøknadType.SKOLEPENGER,
-                                        telefonnummer = kontraktsøknad.personalia.verdi.telefonnummer?.verdi,
+                                        telefonnummer = null,  //TODO ikke i bruk - fjern fra tabell
                                         datoMottatt = kontraktsøknad.innsendingsdetaljer.verdi.datoMottatt.verdi,
                                         medlemskap = tilDomene(kontraktsøknad.medlemskapsdetaljer.verdi),
                                         bosituasjon = tilDomene(kontraktsøknad.bosituasjon.verdi),


### PR DESCRIPTION
Oppdaterer kontrakt - fjern telefonnummer fra personalia fra søknad. 
Opprydding - (vi får ikke inn telefonnummer fra søknad - denne er fjernet fra kontrakter)
Versjon 1 - neste PR fjerner kolonne i db?

Spørsmål - beholde telefonnummer i database, eller fjerne? Vi bruker det ikke og kommer ikke til å få inn nye (etter mars 22).