### PR TITLE
Skal ikke være mulig å slette eller lagre ny simulering hvis behandli…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -79,7 +79,7 @@ class BeregnYtelseSteg(private val tilkjentYtelseService: TilkjentYtelseService,
                 simuleringService.hentOgLagreSimuleringsresultat(saksbehandlingMedOppdatertIdent)
             }
             is Avslå -> {
-                simuleringService.slettSimuleringForBehandling(saksbehandlingMedOppdatertIdent.id)
+                simuleringService.slettSimuleringForBehandling(saksbehandlingMedOppdatertIdent)
                 tilbakekrevingService.slettTilbakekreving(saksbehandlingMedOppdatertIdent.id)
             }
             is Sanksjonert -> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
@@ -233,7 +233,7 @@ class DryRunSimuleringService(iverksettClient: IverksettClient,
         throw IllegalAccessException("Forventer ikke kall til hentLagretSimmuleringsresultat fra BeregnYtelseSteg.")
     }
 
-    override fun slettSimuleringForBehandling(behandlingId: UUID) {}
+    override fun slettSimuleringForBehandling(saksbehandling: Saksbehandling) {}
 
     override fun hentOgLagreSimuleringsresultat(saksbehandling: Saksbehandling): Simuleringsresultat {
         return Simuleringsresultat(behandlingId = UUID.randomUUID(),

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
@@ -16,8 +17,10 @@ import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.ef.iverksett.SimuleringDto
 import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
 import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Service
@@ -28,7 +31,9 @@ class SimuleringService(private val iverksettClient: IverksettClient,
                         private val tilkjentYtelseService: TilkjentYtelseService,
                         private val tilgangService: TilgangService) {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
 
+    @Transactional
     fun simuler(saksbehandling: Saksbehandling): Simuleringsoppsummering {
         return when (saksbehandling.type) {
             BehandlingType.BLANKETT -> simulerForBlankett(saksbehandling)
@@ -44,14 +49,24 @@ class SimuleringService(private val iverksettClient: IverksettClient,
         return simuleringsresultatRepository.findByIdOrThrow(behandlingId).beriketData
     }
 
-    fun slettSimuleringForBehandling(behandlingId: UUID) {
+    fun slettSimuleringForBehandling(saksbehandling: Saksbehandling) {
+        val behandlingId = saksbehandling.id
+        feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke slette simulering for behandling=$behandlingId då den er låst"
+        }
+        logger.info("Sletter simulering for behandling=$behandlingId")
         simuleringsresultatRepository.deleteById(behandlingId)
     }
 
     fun hentOgLagreSimuleringsresultat(saksbehandling: Saksbehandling): Simuleringsresultat {
         tilgangService.validerHarSaksbehandlerrolle()
-        simuleringsresultatRepository.deleteById(saksbehandling.id)
+
+        feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke hente og lagre simuleringsresultat då behandling=${saksbehandling.id} er låst"
+        }
+
         val beriketSimuleringsresultat = simulerMedTilkjentYtelse(saksbehandling)
+        simuleringsresultatRepository.deleteById(saksbehandling.id)
         return simuleringsresultatRepository.insert(Simuleringsresultat(
                 behandlingId = saksbehandling.id,
                 data = beriketSimuleringsresultat.detaljer,

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -58,6 +58,7 @@ class SimuleringService(private val iverksettClient: IverksettClient,
         simuleringsresultatRepository.deleteById(behandlingId)
     }
 
+    @Transactional
     fun hentOgLagreSimuleringsresultat(saksbehandling: Saksbehandling): Simuleringsresultat {
         tilgangService.validerHarSaksbehandlerrolle()
 


### PR DESCRIPTION
…ngen er låst.

Legger til transactional rundt simuler sånn att man ikke sletter og sen feiler insert sånn att simuleringen kun blir slettet

Feil fra prod:
Trigget simulering, som først sletter simuleringsresultat, sen kaller iverksett for å simulere
Kallet mot iverksett feilet, og slettingen ble ikke rullet tilbake