### PR TITLE
Endrer til at oppgaver for barn blir opprettet om barn blir 6/12 måne…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/ForberedOppgaverForBarnTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/ForberedOppgaverForBarnTask.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveforbarn
 
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.domene.TaskRepository
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -13,38 +11,31 @@ import java.time.format.DateTimeFormatter
 @Service
 @TaskStepBeskrivelse(
         taskStepType = ForberedOppgaverForBarnTask.TYPE,
-        beskrivelse = "Oppretter oppgave for barn som fyller 1/2 eller 1 år",
-
-        )
+        beskrivelse = "Oppretter oppgave for barn som fyller 1/2 eller 1 år")
 class ForberedOppgaverForBarnTask(val taskRepository: TaskRepository,
-                                  val forberedOppgaverForBarnService: ForberedOppgaverForBarnService,
-                                  val featureToggleService: FeatureToggleService) : AsyncTaskStep {
-
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    val DATE_FORMAT_ISO_YEAR_MONTH_DAY = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                                  val forberedOppgaverForBarnService: ForberedOppgaverForBarnService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        if (featureToggleService.isEnabled("familie.ef.iverksett.opprett-oppgaver-barnsomfylleraar")) {
-            val sisteKjøring = LocalDate.parse(task.payload)
-            forberedOppgaverForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(sisteKjøring)
-        } else {
-            logger.warn("Feature toggle opprett-oppgaver-barnsomfylleraar er ikke enablet")
-        }
+        val referansedato = LocalDate.parse(task.payload)
+        forberedOppgaverForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(referansedato)
     }
 
     override fun onCompletion(task: Task) {
-        opprettTaskForNesteUke()
+        val sisteKjøring = LocalDate.parse(task.payload)
+        opprettTaskForNesteUke(sisteKjøring)
     }
 
-    fun opprettTaskForNesteUke() {
-        val nesteUke = LocalDate.now().plusWeeks(1)
-        val triggerTid = nesteUke.atTime(5, 0)
-        taskRepository.save(Task(TYPE, LocalDate.now().format(DATE_FORMAT_ISO_YEAR_MONTH_DAY)).medTriggerTid(triggerTid))
+    fun opprettTaskForNesteUke(sisteKjøring: LocalDate) {
+        val nesteUke = sisteKjøring.plusWeeks(1)
+        taskRepository.save(opprettTask(nesteUke))
     }
 
     companion object {
 
         const val TYPE = "forberedOppgaverForBarnTask"
+
+        fun opprettTask(dato: LocalDate): Task {
+            return Task(TYPE, dato.format(DateTimeFormatter.ISO_LOCAL_DATE)).medTriggerTid(dato.atTime(5, 0))
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/InitForberedOppgaverForBarnTaskController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/InitForberedOppgaverForBarnTaskController.kt
@@ -1,32 +1,30 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveforbarn
 
-import no.nav.familie.prosessering.domene.Task
-import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.http.HttpStatus
+import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
-import java.util.Properties
 
 @RestController
 @RequestMapping(
         path = ["/api/oppgaverforbarn"],
         produces = [MediaType.APPLICATION_JSON_VALUE]
 )
-@ProtectedWithClaims(issuer = "azuread")
-class InitForberedOppgaverForBarnTaskController(private val forberedOppgaverForBarnTask: ForberedOppgaverForBarnTask) {
-
-    val DATE_FORMAT_ISO_YEAR_MONTH_DAY = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+@Unprotected
+class InitForberedOppgaverForBarnTaskController(
+        private val forberedOppgaverForBarnTask: ForberedOppgaverForBarnTask,
+        private val forberedOppgaverForBarnService: ForberedOppgaverForBarnService
+) {
 
     @PostMapping("/initialiser")
-    fun opprettTask(): ResponseEntity<Unit> {
-        forberedOppgaverForBarnTask.doTask(Task(ForberedOppgaverForBarnTask.TYPE,
-                                                LocalDate.now().minusWeeks(1).format(DATE_FORMAT_ISO_YEAR_MONTH_DAY),
-                                                Properties()))
-        return ResponseEntity(HttpStatus.OK)
+    fun opprettTask() {
+        forberedOppgaverForBarnTask.doTask(ForberedOppgaverForBarnTask.opprettTask(LocalDate.of(2022, 5, 20)))
+    }
+
+    @PostMapping("/dry-run")
+    fun dryRun() {
+        forberedOppgaverForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(LocalDate.of(2022, 5, 20), dryRun = true)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/ForberedOppgaverForBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/ForberedOppgaverForBarnServiceTest.kt
@@ -36,7 +36,7 @@ internal class ForberedOppgaverForBarnServiceTest {
     private val opprettOppgaveForBarnService =
             ForberedOppgaverForBarnService(gjeldendeBarnRepository, behandlingRepository, iverksettClient)
 
-    private val SISTE_KJØRING_EN_UKE_SIDEN = LocalDate.now().minusWeeks(1)
+    private val REFERANSEDATO = LocalDate.now()
 
     private val oppgaveSlot = slot<OppgaverForBarnDto>()
     private val eksterneIderSlot = slot<Set<UUID>>()
@@ -65,7 +65,7 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
@@ -76,7 +76,7 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
@@ -87,19 +87,30 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
     @Test
-    fun `barn blir seks mnd om 1 uke, sjekk om fyller innen 1 uke, forvent beskrivelseBarnBlirSeksMnd`() {
-        val fødselsdato = LocalDate.now().minusDays(182).plusWeeks(1)
+    fun `barn blir seks mnd om 7 dager, sjekk om fyller innen 1 uke, forvent 0 beskrivelseBarnBlirSeksMnd`() {
+        val fødselsdato = LocalDate.now().minusDays(182).plusDays(7)
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
-        verify { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
+        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
+        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
+    }
+
+    @Test
+    fun `barn blir seks mnd om 6 dager, sjekk om fyller innen 1 uke, forvent beskrivelseBarnBlirSeksMnd`() {
+        val fødselsdato = LocalDate.now().minusDays(182).plusDays(6)
+        every {
+            gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
+        } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
+        verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
@@ -109,7 +120,7 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
@@ -122,30 +133,30 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(barn)
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN, kjøreDato)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(kjøreDato)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
     }
 
     @Test
-    fun `8 av 14 barn blir 6 mnd innen 1 uke, sjekk fyller innen 1 uke, forvent 8 kall til beskrivelseBarnBlirSeksMnd`() {
-        val fødselsdatoer = (0..14).asSequence().map { LocalDate.now().minusDays(182).plusDays(it.toLong()) }.toList()
+    fun `7 av 16 barn blir 6 mnd innen 1 uke, sjekk fyller innen 1 uke, forvent 8 kall til beskrivelseBarnBlirSeksMnd`() {
+        val fødselsdatoer = (-1..14).asSequence().map { LocalDate.now().minusDays(182).plusDays(it.toLong()) }.toList()
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns fødselsdatoer.map { opprettBarn(fødselsnummer = FnrGenerator.generer(it)) }
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
-        verify(exactly = 8) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
+        verify(exactly = 7) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
     }
 
     @Test
-    fun `8 av 14 barn blir 1 år innen 1 uke, sjekk fyller innen 1 uke, forvent 8 kall til beskrivelseBarnFyllerEttÅr`() {
-        val fødselsdatoer = (0..14).asSequence().map { LocalDate.now().minusYears(1).plusDays(it.toLong()) }.toList()
+    fun `7 av 16 barn blir 1 år innen 1 uke, sjekk fyller innen 1 uke, forvent 8 kall til beskrivelseBarnFyllerEttÅr`() {
+        val fødselsdatoer = (-1..14).asSequence().map { LocalDate.now().minusYears(1).plusDays(it.toLong()) }.toList()
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns fødselsdatoer.map { opprettBarn(fødselsnummer = FnrGenerator.generer(it)) }
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
-        verify(exactly = 8) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
+        verify(exactly = 7) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
     }
 
@@ -155,7 +166,7 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
@@ -166,31 +177,31 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
     @Test
-    fun `barn blir 1 år om 7 dager, sjekk om fyller innen 1 uke, forvent kall til beskrivelseBarnFyllerEttÅr`() {
+    fun `barn blir 1 år om 6 dager, sjekk om fyller innen 1 uke, forvent 1 kall til beskrivelseBarnFyllerEttÅr`() {
+        val fødselsdato = LocalDate.now().minusYears(1).plusDays(6)
+        every {
+            gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
+        } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
+        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
+        verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
+    }
+
+    @Test
+    fun `barn blir 1 år om 7 dager, sjekk om fyller innen 1 uke, forvent 0 kall til beskrivelseBarnFyllerEttÅr`() {
         val fødselsdato = LocalDate.now().minusYears(1).plusDays(7)
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
-        verify { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
-    }
-
-    @Test
-    fun `barn ble 1 år i går, for sen kjøring med 2 dager, sjekk om fyller innen 1 uke, forvent kall til beskrivelseBarnFyllerEttÅr`() {
-        val fødselsdato = LocalDate.now().minusYears(1).minusDays(1)
-        every {
-            gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
-        } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN.minusDays(2))
-        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
-        verify { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
+        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
     @Test
@@ -199,61 +210,50 @@ internal class ForberedOppgaverForBarnServiceTest {
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN.minusDays(2))
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO.minusDays(2))
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
     @Test
-    fun `for tidlig kjøring med 7 dager, barn fyller om 7 dager, forvent kall til beskrivelseBarnFyllerEttÅr`() {
-        val fødselsdato = LocalDate.now().minusYears(1).plusDays(7)
-        every {
-            gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
-        } returns listOf(opprettBarn(fødselsnummer = FnrGenerator.generer(fødselsdato)))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN.minusDays(7))
-        verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
-        verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
-    }
-
-    @Test
     fun `barn med bare termindato fyller 1 år i morgen, forvent kall til beskrivelseBarnFyllerEttÅr og ingen unntak`() {
-        val termindato = LocalDate.now().minusYears(1).plusDays(7)
+        val termindato = LocalDate.now().minusYears(1).plusDays(1)
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(fødselsnummer = null, termindato = termindato))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         verify(exactly = 0) { OppgaveBeskrivelse.beskrivelseBarnBlirSeksMnd() }
         verify(exactly = 1) { OppgaveBeskrivelse.beskrivelseBarnFyllerEttÅr() }
     }
 
     @Test
     fun `to barn som fyller år på samme behandling, forvent at bare en oppgave er gjeldende`() {
-        val termindato = LocalDate.now().minusYears(1).plusDays(7)
+        val termindato = LocalDate.now().minusYears(1).plusDays(6)
         val behandlingId = UUID.randomUUID()
 
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(behandlingId = behandlingId, fødselsnummer = null, termindato = termindato),
                          opprettBarn(behandlingId = behandlingId, fødselsnummer = null, termindato = termindato))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         assertThat(eksterneIderSlot.captured.size).isEqualTo(1)
     }
 
     @Test
     fun `to barn som fyller år på forskjellige behandlinger, forvent at to oppgaver er gjeldende`() {
-        val termindato = LocalDate.now().minusYears(1).plusDays(7)
+        val termindato = LocalDate.now().minusYears(1).plusDays(6)
 
         every {
             gjeldendeBarnRepository.finnBarnAvGjeldendeIverksatteBehandlinger(StønadType.OVERGANGSSTØNAD, any())
         } returns listOf(opprettBarn(behandlingId = UUID.randomUUID(), fødselsnummer = null, termindato = termindato),
                          opprettBarn(behandlingId = UUID.randomUUID(), fødselsnummer = null, termindato = termindato))
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
         assertThat(eksterneIderSlot.captured.size).isEqualTo(2)
     }
 
     @Test
     fun `barn fra vanlige behandlinger og migrerte fagsaker blir med i listen over oppgaver`() {
-        val termindato = LocalDate.now().minusYears(1).plusDays(7)
+        val termindato = LocalDate.now().minusYears(1).plusDays(6)
         val fødselsdato = LocalDate.now().minusDays(182)
 
         val behandlingId = UUID.randomUUID()
@@ -268,7 +268,7 @@ internal class ForberedOppgaverForBarnServiceTest {
                                      fødselsnummer = FnrGenerator.generer(fødselsdato),
                                      fraMigrering = true))
 
-        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(SISTE_KJØRING_EN_UKE_SIDEN)
+        opprettOppgaveForBarnService.forberedOppgaverForAlleBarnSomFyllerAarNesteUke(REFERANSEDATO)
 
         val oppgaverForBarn = oppgaveSlot.captured.oppgaverForBarn
         assertThat(oppgaverForBarn).hasSize(2)


### PR DESCRIPTION
…der idag og 6 dager frem.

Neste sjekk som gjøres om 7 dager og får med seg de som fyller om 7 dager

Tidligere ble det opprettet oppgaver for barn for idag + 7 dager frem, dvs man risikerer at det blir opprettet oppgaver for barn 2 ganger.

Endret også til at man lagrer et refderansedato i tasken, og det er denne som brukes for å sjekke om barn fyller år fra det datoet.