### PR TITLE
Cucumber håndtering av både årmåned og dato i fra/til og med dato for…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/BasisDomeneParser.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/BasisDomeneParser.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.cucumber.domeneparser
 import io.cucumber.datatable.DataTable
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.SaksbehandlingDomeneBegrep
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.ÅrMånedEllerDato
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType
@@ -32,6 +33,10 @@ fun parseÅrMåned(domenebegrep: Domenenøkkel, rad: Map<String, String?>): Year
 }
 
 fun parseValgfriÅrMåned(domenebegrep: Domenenøkkel, rad: Map<String, String?>): YearMonth? {
+    return parseValgfriÅrMåned(domenebegrep.nøkkel(), rad)
+}
+
+fun parseValgfriÅrMånedEllerDato(domenebegrep: Domenenøkkel, rad: Map<String, String?>): YearMonth? {
     return parseValgfriÅrMåned(domenebegrep.nøkkel(), rad)
 }
 
@@ -126,6 +131,19 @@ fun parseÅrMåned(verdi: String): YearMonth {
     }
 }
 
+fun parseValgriÅrMånedEllerDato(domenebegrep: Domenenøkkel, rad: Map<String, String?>): ÅrMånedEllerDato? {
+    val verdi = rad[domenebegrep.nøkkel()]
+    if (verdi == null || verdi == "") {
+        return null
+    }
+    val dato = when (verdi.toList().count { it == '.' || it == '-' }) {
+        2 -> parseDato(verdi)
+        1 -> parseÅrMåned(verdi)
+        else -> error("Er datoet=$verdi riktigt formatert? Trenger å være på norskt eller iso-format")
+    }
+    return ÅrMånedEllerDato(dato)
+}
+
 fun verdi(nøkkel: String, rad: Map<String, String>): String {
     val verdi = rad[nøkkel]
 
@@ -141,7 +159,7 @@ fun valgfriVerdi(nøkkel: String, rad: Map<String, String>): String? {
 }
 
 fun parseInt(domenebegrep: Domenenøkkel, rad: Map<String, String>): Int {
-    val verdi = verdi(domenebegrep.nøkkel(), rad)
+    val verdi = verdi(domenebegrep.nøkkel(), rad).replace("_", "")
 
     return Integer.parseInt(verdi)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/CucumberDatoUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/CucumberDatoUtil.kt
@@ -1,0 +1,36 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser
+
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import java.time.LocalDate
+import java.time.YearMonth
+
+data class ÅrMånedEllerDato(val dato: Any) {
+
+    fun førsteDagenIMåneden(): LocalDate {
+        return if (dato is LocalDate) {
+            feilHvis(dato.dayOfMonth != 1) { "Må være første dagen i måneden - $dato" }
+            dato
+        } else if (dato is YearMonth) {
+            dato.atDay(1)
+        } else {
+            error("Typen er feil - ${dato::class.java.simpleName}")
+        }
+    }
+
+    fun sisteDagenIMåneden(): LocalDate {
+        return if (dato is LocalDate) {
+            feilHvis(dato != YearMonth.from(dato).atEndOfMonth()) { "Må være siste dagen i måneden - $dato" }
+            dato
+        } else if (dato is YearMonth) {
+            dato.atEndOfMonth()
+        } else {
+            error("Typen er feil - ${dato::class.java.simpleName}")
+        }
+    }
+}
+
+fun ÅrMånedEllerDato?.førsteDagenIMånedenEllerDefault(dato: LocalDate = YearMonth.now().atDay(1)) =
+        this?.førsteDagenIMåneden() ?: dato
+
+fun ÅrMånedEllerDato?.sisteDagenIMånedenEllerDefault(dato: LocalDate = YearMonth.now().atEndOfMonth()) =
+        this?.sisteDagenIMåneden() ?: dato

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/DomeneParser.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/DomeneParser.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ef.sak.cucumber.domeneparser
 
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.førsteDagenIMånedenEllerDefault
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.sisteDagenIMånedenEllerDefault
+
 enum class Domenebegrep(val nøkkel: String) : Domenenøkkel {
     BEHANDLING_ID("BehandlingId"),
     FRA_OG_MED_DATO("Fra og med dato"),
@@ -9,3 +12,9 @@ enum class Domenebegrep(val nøkkel: String) : Domenenøkkel {
         return nøkkel
     }
 }
+
+fun parseFraOgMed(rad: Map<String, String>) =
+        parseValgriÅrMånedEllerDato(Domenebegrep.FRA_OG_MED_DATO, rad).førsteDagenIMånedenEllerDefault()
+
+fun parseTilOgMed(rad: Map<String, String>) =
+        parseValgriÅrMånedEllerDato(Domenebegrep.TIL_OG_MED_DATO, rad).sisteDagenIMånedenEllerDefault()

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/VedtakDomeneParser.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/domeneparser/VedtakDomeneParser.kt
@@ -240,12 +240,6 @@ object VedtakDomeneParser {
             val sanksjonsårsak: Sanksjonsårsak?,
     )
 
-    private fun parseFraOgMed(rad: Map<String, String>) =
-            parseValgfriÅrMåned(VedtakDomenebegrep.FRA_OG_MED_DATO, rad)?.atDay(1) ?: LocalDate.now()
-
-    private fun parseTilOgMed(rad: Map<String, String>) =
-            parseValgfriÅrMåned(VedtakDomenebegrep.TIL_OG_MED_DATO, rad)?.atEndOfMonth() ?: LocalDate.now()
-
     class BehandlingForHistorikkEndringMapper {
 
         fun mapRad(rad: Map<String, String>, stønadstype: StønadType): ForventetHistorikk {
@@ -260,10 +254,8 @@ object VedtakDomeneParser {
                                 vedtakstidspunkt = LocalDateTime.now()
                         )
                     },
-                    stønadFra = parseValgfriÅrMåned(VedtakDomenebegrep.FRA_OG_MED_DATO, rad)?.atDay(1) ?: YearMonth.now()
-                            .atDay(1),
-                    stønadTil = parseValgfriÅrMåned(VedtakDomenebegrep.TIL_OG_MED_DATO, rad)?.atEndOfMonth() ?: YearMonth.now()
-                            .atEndOfMonth(),
+                    stønadFra = parseFraOgMed(rad),
+                    stønadTil = parseTilOgMed(rad),
                     inntekt = parseValgfriInt(VedtakDomenebegrep.INNTEKT, rad),
                     beløp = parseValgfriInt(VedtakDomenebegrep.BELØP, rad),
                     aktivitetType = aktivitetType,
@@ -289,8 +281,6 @@ enum class VedtakDomenebegrep(val nøkkel: String) : Domenenøkkel {
     SAMORDNINGSFRADRAG("Samordningsfradrag"),
     BELØP("Beløp"),
     BELØP_MELLOM("Beløp mellom"),
-    FRA_OG_MED_DATO("Fra og med dato"),
-    TIL_OG_MED_DATO("Til og med dato"),
     AKTIVITET_TYPE("Aktivitet"),
     ARBEID_AKTIVITET("Arbeid aktivitet"), //Inngangsvilkår i barnetilsyn
     VEDTAKSPERIODE_TYPE("Vedtaksperiode"),


### PR DESCRIPTION
… å få enklere tester

Dette gjør det mulig å bruke alle disse som dato, 
```
2022-01
2022-01-01
01.2021
01.01.2021
```