### PR TITLE
Pga random rekkefølge i vilkårslisten så feiler testen jevnt og trutt…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -113,18 +113,19 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
         val iverksettDtoSlot = slot<IverksettOvergangsstønadDto>()
         verify { iverksettClient.iverksettUtenBrev(capture(iverksettDtoSlot)) }
 
-        val expectedIverksettDto = iverksettMedOppdaterteIder(fagsak, behandling, iverksettDtoSlot.captured.vedtak.vedtakstidspunkt)
-        assertThat(iverksettDtoSlot.captured.vedtak).isEqualTo(expectedIverksettDto.vedtak)
-        assertThat(iverksettDtoSlot.captured.fagsak).isEqualTo(expectedIverksettDto.fagsak)
-        assertThat(iverksettDtoSlot.captured.søker).isEqualTo(expectedIverksettDto.søker)
-        assertThat(iverksettDtoSlot.captured.behandling.aktivitetspliktInntrefferDato).isEqualTo(expectedIverksettDto.behandling.aktivitetspliktInntrefferDato)
-        assertThat(iverksettDtoSlot.captured.behandling.behandlingId).isEqualTo(expectedIverksettDto.behandling.behandlingId)
-        assertThat(iverksettDtoSlot.captured.behandling.behandlingType).isEqualTo(expectedIverksettDto.behandling.behandlingType)
-        assertThat(iverksettDtoSlot.captured.behandling.behandlingÅrsak).isEqualTo(expectedIverksettDto.behandling.behandlingÅrsak)
-        assertThat(iverksettDtoSlot.captured.behandling.eksternId).isEqualTo(expectedIverksettDto.behandling.eksternId)
-        assertThat(iverksettDtoSlot.captured.behandling.forrigeBehandlingId).isEqualTo(expectedIverksettDto.behandling.forrigeBehandlingId)
-        assertThat(iverksettDtoSlot.captured.behandling.kravMottatt).isEqualTo(expectedIverksettDto.behandling.kravMottatt)
-        assertThat(iverksettDtoSlot.captured.behandling.vilkårsvurderinger).hasSameElementsAs(expectedIverksettDto.behandling.vilkårsvurderinger)
+        val iverksettDto = iverksettDtoSlot.captured
+        val expectedIverksettDto = iverksettMedOppdaterteIder(fagsak, behandling, iverksettDto.vedtak.vedtakstidspunkt)
+        assertThat(iverksettDto.vedtak).isEqualTo(expectedIverksettDto.vedtak)
+        assertThat(iverksettDto.fagsak).isEqualTo(expectedIverksettDto.fagsak)
+        assertThat(iverksettDto.søker).isEqualTo(expectedIverksettDto.søker)
+        assertThat(iverksettDto.behandling.aktivitetspliktInntrefferDato).isEqualTo(expectedIverksettDto.behandling.aktivitetspliktInntrefferDato)
+        assertThat(iverksettDto.behandling.behandlingId).isEqualTo(expectedIverksettDto.behandling.behandlingId)
+        assertThat(iverksettDto.behandling.behandlingType).isEqualTo(expectedIverksettDto.behandling.behandlingType)
+        assertThat(iverksettDto.behandling.behandlingÅrsak).isEqualTo(expectedIverksettDto.behandling.behandlingÅrsak)
+        assertThat(iverksettDto.behandling.eksternId).isEqualTo(expectedIverksettDto.behandling.eksternId)
+        assertThat(iverksettDto.behandling.forrigeBehandlingId).isEqualTo(expectedIverksettDto.behandling.forrigeBehandlingId)
+        assertThat(iverksettDto.behandling.kravMottatt).isEqualTo(expectedIverksettDto.behandling.kravMottatt)
+        assertThat(iverksettDto.behandling.vilkårsvurderinger).hasSameElementsAs(expectedIverksettDto.behandling.vilkårsvurderinger)
         assertThat(søknadService.hentSøknadsgrunnlag(nyBehandling.id)).isNotNull
         assertThat(barnRepository.findByBehandlingId(nyBehandling.id).single().personIdent).isEqualTo(barn.personIdent)
         assertThat(


### PR DESCRIPTION
…. Må derfor sjekke eksplisitt alle verdier og at vilkårsvurderingen sine elementer inneholder riktige elementer