### PR TITLE
Fjerner unntak når det ikke finnes fagsak for person i ef

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynService.kt
@@ -41,7 +41,7 @@ class BisysBarnetilsynService(
 
         val personIdenter = personService.hentPersonIdenter(personIdent).identer()
         val fagsak: Fagsak = fagsakService.finnFagsak(personIdenter, StønadType.BARNETILSYN)
-            ?: error("Kunne ikke finne fagsak for personident")
+            ?: return emptyList()
 
         val historikk = tilkjentYtelseService.hentHistorikk(fagsak.id, null)
             .filter { it.erIkkeFjernet() }

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
@@ -268,6 +268,40 @@ internal class BisysBarnetilsynServiceTest {
         assertThat(perioder).hasSize(1)
         assertThat(perioder.first().datakilde).isEqualTo(Datakilde.INFOTRYGD)
     }
+
+    @Test
+    fun `en infotrygdperiode, og ingen fagsak for person, forvent ingen feil og kun infotrygdperiode`() {
+        every {
+            fagsakService.finnFagsak(any(), StønadType.BARNETILSYN)
+        } returns null
+        every {
+            infotrygdService.hentPerioderFraReplika(
+                any(),
+                setOf(StønadType.BARNETILSYN)
+            ).barnetilsyn
+        } returns listOf(
+            lagInfotrygdPeriode(
+                vedtakId = 1,
+                stønadTom = LocalDate.now()
+                    .plusMonths(
+                        1
+                    ),
+                beløp = 10
+            )
+        )
+        every {
+            tilkjentYtelseService.hentHistorikk(any(), any())
+        } returns emptyList()
+
+        val fomDato = LocalDate.now()
+        val perioder =
+            barnetilsynBisysService.hentBarnetilsynperioderFraEfOgInfotrygd(
+                personident,
+                fomDato
+            ).barnetilsynBisysPerioder
+        assertThat(perioder).hasSize(1)
+        assertThat(perioder.first().datakilde).isEqualTo(Datakilde.INFOTRYGD)
+    }
 }
 
 fun lagAndelHistorikkDto(


### PR DESCRIPTION
Fjerner unntak når det ikke finnes fagsak for person i ef, og returnerer tom liste i stedet, for å evt kunne hente bare infotrygdperioder