### PR TITLE
Dependabot oppdateringer 20220607-154731

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <java.version>17</java.version>
         <kotlin.version>1.6.21</kotlin.version>
         <kotlin-coroutines.version>1.6.2</kotlin-coroutines.version>
-        <springdoc.version>1.6.8</springdoc.version>
+        <springdoc.version>1.6.9</springdoc.version>
         <mockk.version>1.12.4</mockk.version>
         <felles.version>1.20220503150007_21cbfef</felles.version>
         <prosessering.version>1.20220601142131_cd00230</prosessering.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.6.7</version>
     </parent>
     <repositories>
         <repository>


### PR DESCRIPTION
Erstatter:
 - https://github.com/navikt/familie-ef-sak/pull/1563
 - https://github.com/navikt/familie-ef-sak/pull/1562
 - https://github.com/navikt/familie-ef-sak/pull/1561
 - https://github.com/navikt/familie-ef-sak/pull/1560
 - https://github.com/navikt/familie-ef-sak/pull/1540
 - https://github.com/navikt/familie-ef-sak/pull/1516
 - https://github.com/navikt/familie-ef-sak/pull/1515
 - https://github.com/navikt/familie-ef-sak/pull/1514

Notere at spring-versjonen ble rullet tilbake, ønsker ikke x.x.0 versjonen nå