### PR TITLE
Annen forelder tidligere vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -86,7 +86,10 @@ class InfotrygdService(
             slåSammenPerioder(perioder).map { it.tilSummertInfotrygdperiodeDto() }
         )
 
-    private fun hentPerioderFraReplika(
+    /**
+     * ! Denne må brukes med alle identer for en person, bruk [hentPerioderFraReplika] hvis man skal hente på en ident
+     */
+    fun hentPerioderFraReplika(
         identer: Set<String>,
         stønadstyper: Set<StønadType> = StønadType.values().toSet()
     ): InfotrygdPeriodeResponse {

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
@@ -17,6 +17,7 @@ import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværSøknadsgrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnepassordningDto
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
 
 object BarnMedSamværMapper {
 
@@ -160,7 +161,8 @@ object BarnMedSamværMapper {
             fødselsdato = pdlAnnenForelder.fødsel.gjeldende().fødselsdato,
             dødsfall = pdlAnnenForelder.dødsfall.gjeldende()?.dødsdato,
             bosattINorge = pdlAnnenForelder.bostedsadresse.gjeldende()?.utenlandskAdresse?.let { false } ?: true,
-            land = pdlAnnenForelder.bostedsadresse.gjeldende()?.utenlandskAdresse?.landkode
+            land = pdlAnnenForelder.bostedsadresse.gjeldende()?.utenlandskAdresse?.landkode,
+            tidligereVedtaksperioder = pdlAnnenForelder.tidligereVedtaksperioder.tilDto()
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderService.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioderAnnenForelder
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
+import org.springframework.stereotype.Service
+
+@Service
+class TidligereVedaksperioderService(
+    private val fagsakPersonService: FagsakPersonService,
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+    private val tilkjentYtelseService: TilkjentYtelseService,
+    private val infotrygdService: InfotrygdService,
+) {
+
+    // TODO endre om til å bruke identer fra pdlSøker, då dette blir et ekstra kall for å hente identer
+    fun hentTidligereVedtaksperioder(ident: String): TidligereVedtaksperioder {
+        val tidligereInnvilgetVedtak = mapTidligereInnvilgetVedtak(infotrygdService.hentPerioderFraReplika(ident))
+        return TidligereVedtaksperioder(infotrygd = tidligereInnvilgetVedtak)
+    }
+
+    fun hentTidligereVedaksperioderAnnenForelder(identer: Set<String>): TidligereVedtaksperioderAnnenForelder {
+        val infotrygd = mapTidligereInnvilgetVedtak(infotrygdService.hentPerioderFraReplika(identer))
+        return TidligereVedtaksperioderAnnenForelder(
+            infotrygd = infotrygd,
+            efSak = harTidligereMottattStønadEf(identer)
+        )
+    }
+
+    private fun mapTidligereInnvilgetVedtak(periodeResponse: InfotrygdPeriodeResponse) =
+        TidligereInnvilgetVedtak(
+            harTidligereOvergangsstønad = periodeResponse.overgangsstønad.isNotEmpty(),
+            harTidligereBarnetilsyn = periodeResponse.barnetilsyn.isNotEmpty(),
+            harTidligereSkolepenger = periodeResponse.skolepenger.isNotEmpty(),
+        )
+
+    private fun harTidligereMottattStønadEf(identer: Set<String>): TidligereInnvilgetVedtak {
+        return fagsakPersonService.finnPerson(identer)
+            ?.let { fagsakService.finnFagsakerForFagsakPersonId(it.id) }
+            ?.let {
+                TidligereInnvilgetVedtak(
+                    harTidligereOvergangsstønad = hentTidligereVedtaksperioder(it.overgangsstønad),
+                    harTidligereBarnetilsyn = hentTidligereVedtaksperioder(it.barnetilsyn),
+                    harTidligereSkolepenger = hentTidligereVedtaksperioder(it.skolepenger)
+                )
+            } ?: TidligereInnvilgetVedtak()
+    }
+
+    private fun hentTidligereVedtaksperioder(fagsak: Fagsak?) = fagsak
+        ?.let { behandlingService.finnSisteIverksatteBehandling(it.id) }
+        ?.let {
+            val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(it.id)
+            tilkjentYtelse.andelerTilkjentYtelse.isNotEmpty()
+        } ?: false
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -71,7 +71,8 @@ data class AnnenForelderMedIdent(
     val dødsfall: List<Dødsfall>,
     val fødsel: List<Fødsel>,
     val navn: Navn,
-    val personIdent: String
+    val personIdent: String,
+    val tidligereVedtaksperioder: TidligereVedtaksperioderAnnenForelder?
 )
 
 data class BarnMedIdent(
@@ -110,8 +111,13 @@ data class FullmaktMedNavn(
 
 data class TidligereVedtaksperioder(val infotrygd: TidligereInnvilgetVedtak)
 
+data class TidligereVedtaksperioderAnnenForelder(
+    val efSak: TidligereInnvilgetVedtak,
+    val infotrygd: TidligereInnvilgetVedtak
+)
+
 data class TidligereInnvilgetVedtak(
-    val harTidligereOvergangsstønad: Boolean,
-    val harTidligereBarnetilsyn: Boolean,
-    val harTidligereSkolepenger: Boolean
+    val harTidligereOvergangsstønad: Boolean = false,
+    val harTidligereBarnetilsyn: Boolean = false,
+    val harTidligereSkolepenger: Boolean = false
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.ForelderBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.FullmaktMedNavn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.SivilstandMedNavn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Søker
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioderAnnenForelder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.KjønnType
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlAnnenForelder
@@ -35,7 +36,10 @@ object GrunnlagsdataMapper {
             personIdent = personIdent
         )
 
-    fun mapAnnenForelder(barneForeldre: Map<String, PdlAnnenForelder>) =
+    fun mapAnnenForelder(
+        barneForeldre: Map<String, PdlAnnenForelder>,
+        tidligereVedtaksperioderAnnenForelder: Map<String, TidligereVedtaksperioderAnnenForelder>
+    ) =
         barneForeldre.map {
             AnnenForelderMedIdent(
                 adressebeskyttelse = it.value.adressebeskyttelse,
@@ -43,7 +47,8 @@ object GrunnlagsdataMapper {
                 fødsel = it.value.fødsel,
                 bostedsadresse = it.value.bostedsadresse,
                 dødsfall = it.value.dødsfall,
-                navn = it.value.navn.gjeldende()
+                navn = it.value.navn.gjeldende(),
+                tidligereVedtaksperioder = tidligereVedtaksperioderAnnenForelder.getValue(it.key)
             )
         }
 
@@ -92,7 +97,10 @@ object GrunnlagsdataMapper {
                 ?: vergemaal
         }
 
-    private fun mapSivivilstand(pdlSøker: PdlSøker, andrePersoner: Map<String, PdlPersonKort>): List<SivilstandMedNavn> {
+    private fun mapSivivilstand(
+        pdlSøker: PdlSøker,
+        andrePersoner: Map<String, PdlPersonKort>
+    ): List<SivilstandMedNavn> {
 
         return pdlSøker.sivilstand.map {
             val person = andrePersoner[it.relatertVedSivilstand]

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -124,6 +124,7 @@ data class PdlAnnenForelder(
     override val bostedsadresse: List<Bostedsadresse>,
     @JsonProperty("doedsfall") val dødsfall: List<Dødsfall>,
     @JsonProperty("foedsel") override val fødsel: List<Fødsel>,
+    val folkeregisteridentifikator: List<FolkeregisteridentifikatorMedMetadata>,
     val navn: List<Navn>
 ) : PdlPerson
 
@@ -140,6 +141,12 @@ data class DeltBosted(
 data class Folkeregistermetadata(
     val gyldighetstidspunkt: LocalDateTime?,
     @JsonProperty("opphoerstidspunkt") val opphørstidspunkt: LocalDateTime?
+)
+
+data class FolkeregisteridentifikatorMedMetadata(
+    @JsonProperty("identifikasjonsnummer")
+    val ident: String,
+    val metadata: Metadata
 )
 
 data class Bostedsadresse(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.opplysninger.mapper.BarnMedSamværMapper
 import no.nav.familie.ef.sak.opplysninger.mapper.SivilstandMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadBarn
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søknadsverdier
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.AktivitetMapper
@@ -15,9 +14,8 @@ import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SagtOppEllerRedusertSti
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SivilstandsplanerMapper
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
-import no.nav.familie.ef.sak.vilkår.dto.TidligereInnvilgetVedtakDto
-import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.kontrakter.ef.søknad.Fødselsnummer
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
@@ -59,7 +57,7 @@ class VilkårGrunnlagService(
         val sagtOppEllerRedusertStilling = søknad?.situasjon?.let { SagtOppEllerRedusertStillingMapper.tilDto(situasjon = it) }
 
         return VilkårGrunnlagDto(
-            tidligereVedtaksperioder = mapTidligereVedtaksperioder(grunnlagsdata.tidligereVedtaksperioder),
+            tidligereVedtaksperioder = grunnlagsdata.tidligereVedtaksperioder.tilDto(),
             medlemskap = medlemskap,
             sivilstand = sivilstand,
             bosituasjon = søknad?.let { BosituasjonMapper.tilDto(it.bosituasjon) },
@@ -70,17 +68,6 @@ class VilkårGrunnlagService(
             lagtTilEtterFerdigstilling = registergrunnlagData.lagtTilEtterFerdigstilling,
             registeropplysningerOpprettetTid = registergrunnlagData.opprettetTidspunkt
         )
-    }
-
-    private fun mapTidligereVedtaksperioder(tidligereVedtaksperioder: TidligereVedtaksperioder?): TidligereVedtaksperioderDto {
-        val infotrygd = tidligereVedtaksperioder?.infotrygd?.let {
-            TidligereInnvilgetVedtakDto(
-                harTidligereOvergangsstønad = it.harTidligereOvergangsstønad,
-                harTidligereBarnetilsyn = it.harTidligereBarnetilsyn,
-                harTidligereSkolepenger = it.harTidligereSkolepenger
-            )
-        }
-        return TidligereVedtaksperioderDto(infotrygd = infotrygd)
     }
 
     private fun mapBarnMedSamvær(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -47,6 +47,7 @@ data class AnnenForelderDto(
     val bosattINorge: Boolean?,
     val land: String?,
     val dødsfall: LocalDate? = null,
+    val tidligereVedtaksperioder: TidligereVedtaksperioderAnnenForelderDto? = null
 )
 
 data class BarnepassDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
@@ -1,9 +1,35 @@
 package no.nav.familie.ef.sak.vilkår.dto
 
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioderAnnenForelder
+
 data class TidligereVedtaksperioderDto(val infotrygd: TidligereInnvilgetVedtakDto?)
+
+data class TidligereVedtaksperioderAnnenForelderDto(
+    val efSak: TidligereInnvilgetVedtakDto,
+    val infotrygd: TidligereInnvilgetVedtakDto
+)
 
 data class TidligereInnvilgetVedtakDto(
     val harTidligereOvergangsstønad: Boolean,
     val harTidligereBarnetilsyn: Boolean,
     val harTidligereSkolepenger: Boolean
 )
+
+fun TidligereVedtaksperioder?.tilDto() =
+    TidligereVedtaksperioderDto(infotrygd = this?.infotrygd?.tilDto())
+
+fun TidligereVedtaksperioderAnnenForelder?.tilDto() = this?.let {
+    TidligereVedtaksperioderAnnenForelderDto(
+        efSak = it.efSak.tilDto(),
+        infotrygd = it.infotrygd.tilDto()
+    )
+}
+
+fun TidligereInnvilgetVedtak.tilDto() =
+    TidligereInnvilgetVedtakDto(
+        harTidligereOvergangsstønad = this.harTidligereOvergangsstønad,
+        harTidligereBarnetilsyn = this.harTidligereBarnetilsyn,
+        harTidligereSkolepenger = this.harTidligereSkolepenger
+    )

--- a/src/main/resources/pdl/andreForeldre.graphql
+++ b/src/main/resources/pdl/andreForeldre.graphql
@@ -65,6 +65,12 @@ query($identer: [ID!]!){
                     historisk
                 }
             }
+            folkeregisteridentifikator(historikk: true) {
+                identifikasjonsnummer
+                metadata {
+                    historisk
+                }
+            }
             navn {
                 fornavn
                 mellomnavn

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
@@ -31,26 +31,29 @@ class InfotrygdReplikaMock {
         fun resetMock(client: InfotrygdReplikaClient) {
             clearMocks(client)
             every { client.hentPerioder(any()) } answers {
-                val firstArg = firstArg<InfotrygdPeriodeRequest>()
-                val personIdent = firstArg.personIdenter.first()
-                InfotrygdPeriodeResponse(
-                    overgangsstønad = listOf(lagInfotrygdPeriode()),
-                    barnetilsyn = listOf(
-                        lagInfotrygdPeriode(
-                            personIdent = personIdent,
-                            beløp = 234,
-                            inntektsgrunnlag = 321,
-                            samordningsfradrag = 0,
-                            utgifterBarnetilsyn = 1000,
-                            barnIdenter = listOf("123", "234")
-                        )
-                    ),
-                    skolepenger = emptyList()
-                )
+                hentPerioderDefaultResponse(firstArg())
             }
             every { client.hentSaker(any()) } returns InfotrygdSakResponse(emptyList())
             every { client.hentInslagHosInfotrygd(any()) } answers { InfotrygdFinnesResponse(emptyList(), emptyList()) }
             every { client.hentPersonerForMigrering(any()) } returns emptySet()
+        }
+
+        fun hentPerioderDefaultResponse(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse {
+            val personIdent = request.personIdenter.first()
+            return InfotrygdPeriodeResponse(
+                overgangsstønad = listOf(lagInfotrygdPeriode()),
+                barnetilsyn = listOf(
+                    lagInfotrygdPeriode(
+                        personIdent = personIdent,
+                        beløp = 234,
+                        inntektsgrunnlag = 321,
+                        samordningsfradrag = 0,
+                        utgifterBarnetilsyn = 1000,
+                        barnIdenter = listOf("123", "234")
+                    )
+                ),
+                skolepenger = emptyList()
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Bostedsadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Dødsfall
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Familierelasjonsrolle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Folkeregisteridentifikator
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.FolkeregisteridentifikatorMedMetadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Folkeregistermetadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.ForelderBarnRelasjon
@@ -210,6 +211,7 @@ class PdlClientConfig {
                 dødsfall = listOf(Dødsfall(LocalDate.of(2021, 9, 22))),
                 fødsel = listOf(fødsel(1994, 11, 1)),
                 navn = listOf(Navn("Bob", "", "Burger", metadataGjeldende)),
+                folkeregisteridentifikator = listOf(FolkeregisteridentifikatorMedMetadata("1", metadataGjeldende))
             )
 
         private fun forelderBarnRelasjoner(): List<ForelderBarnRelasjon> =

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -124,10 +124,10 @@ class PdlClientConfig {
 
         private val startdato = LocalDate.of(2020, 1, 1)
         private val sluttdato = LocalDate.of(2021, 1, 1)
-        private const val barnFnr = "01012067050"
-        private const val barn2Fnr = "14041385481"
-        private const val søkerFnr = "01010172272"
-        private const val annenForelderFnr = "17097926735"
+        const val barnFnr = "01012067050"
+        const val barn2Fnr = "14041385481"
+        const val søkerFnr = "01010172272"
+        const val annenForelderFnr = "17097926735"
         private const val fnrPåAdresseSøk = "01012067050"
 
         fun lagPersonKort(it: String) =
@@ -211,7 +211,12 @@ class PdlClientConfig {
                 dødsfall = listOf(Dødsfall(LocalDate.of(2021, 9, 22))),
                 fødsel = listOf(fødsel(1994, 11, 1)),
                 navn = listOf(Navn("Bob", "", "Burger", metadataGjeldende)),
-                folkeregisteridentifikator = listOf(FolkeregisteridentifikatorMedMetadata("1", metadataGjeldende))
+                folkeregisteridentifikator = listOf(
+                    FolkeregisteridentifikatorMedMetadata(
+                        annenForelderFnr,
+                        metadataGjeldende
+                    )
+                )
             )
 
         private fun forelderBarnRelasjoner(): List<ForelderBarnRelasjon> =

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
@@ -1,12 +1,30 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsaker
+import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakPerson
+import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 internal class TidligereVedaksperioderServiceTest {
 
@@ -14,7 +32,9 @@ internal class TidligereVedaksperioderServiceTest {
     private val fagsakService = mockk<FagsakService>()
     private val behandlingService = mockk<BehandlingService>()
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
-    private val infotrygdService = mockk<InfotrygdService>()
+    private val pdlClient = mockk<PdlClient>()
+    private val infotrygdReplikaClient = mockk<InfotrygdReplikaClient>()
+    private val infotrygdService = InfotrygdService(infotrygdReplikaClient, pdlClient)
 
     private val service = TidligereVedaksperioderService(
         fagsakPersonService,
@@ -24,8 +44,75 @@ internal class TidligereVedaksperioderServiceTest {
         infotrygdService
     )
 
+    private val infotrygdPeriodeRequestSlot = slot<InfotrygdPeriodeRequest>()
+
+    private val personIdent = "1"
+    private val identAnnenForelder = "2"
+
+    private val fagsakPerson = fagsakPerson(fagsakpersoner(identAnnenForelder))
+    private val fagsak = fagsak(person = fagsakPerson)
+    private val fagsaker = Fagsaker(fagsak, null, null)
+    private val behandling = behandling(fagsak)
+
+    @BeforeEach
+    internal fun setUp() {
+        every {
+            infotrygdReplikaClient.hentPerioder(capture(infotrygdPeriodeRequestSlot))
+        } answers { InfotrygdReplikaMock.hentPerioderDefaultResponse(firstArg()) }
+        every { pdlClient.hentPersonidenter(personIdent, true) } returns
+            PdlIdenter(listOf(PdlIdent(personIdent, false)))
+    }
+
     @Test
-    internal fun `skal sjekke hvis man har tidligere vedtak`() {
-        TODO("Not yet implemented")
+    internal fun `skal sjekke om søker har historikk i infotrygd`() {
+        val tidligereVedtaksperioder = service.hentTidligereVedtaksperioder(personIdent)
+
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereOvergangsstønad).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereBarnetilsyn).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereSkolepenger).isFalse
+
+        verify(exactly = 1) { infotrygdReplikaClient.hentPerioder(any()) }
+        verify(exactly = 0) { tilkjentYtelseService.hentForBehandling(any()) }
+        assertThat(infotrygdPeriodeRequestSlot.captured.personIdenter).containsExactly(personIdent)
+    }
+
+    @Test
+    internal fun `skal sjekke om annen forelder har historikk i ef-sak og infotrygd`() {
+        mockTidligereVedtakEfSak(harAndeler = true)
+
+        val tidligereVedtaksperioder = service.hentTidligereVedaksperioderAnnenForelder(setOf(personIdent))
+
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereOvergangsstønad).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereBarnetilsyn).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereSkolepenger).isFalse
+
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereOvergangsstønad).isTrue
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereBarnetilsyn).isFalse
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereSkolepenger).isFalse
+
+        verify(exactly = 1) { infotrygdReplikaClient.hentPerioder(any()) }
+        verify(exactly = 1) { tilkjentYtelseService.hentForBehandling(behandling.id) }
+
+        assertThat(infotrygdPeriodeRequestSlot.captured.personIdenter).containsExactly(personIdent)
+    }
+
+    @Test
+    internal fun `hvis en person ikke har noen aktive andeler så har man ikke tidligere vedtaksperioder i ef`() {
+        mockTidligereVedtakEfSak(harAndeler = false)
+
+        val tidligereVedtaksperioder = service.hentTidligereVedaksperioderAnnenForelder(setOf(personIdent))
+
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereOvergangsstønad).isFalse
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereBarnetilsyn).isFalse
+        assertThat(tidligereVedtaksperioder.efSak.harTidligereSkolepenger).isFalse
+    }
+
+    private fun mockTidligereVedtakEfSak(harAndeler: Boolean = true) {
+        every { fagsakPersonService.finnPerson(any()) } returns fagsakPerson
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsak.id) } returns behandling
+        val andelerTilkjentYtelse =
+            if (harAndeler) listOf(lagAndelTilkjentYtelse(100, LocalDate.now(), LocalDate.now())) else emptyList()
+        every { tilkjentYtelseService.hentForBehandling(behandling.id) } returns lagTilkjentYtelse(andelerTilkjentYtelse)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
+
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import org.junit.jupiter.api.Test
+
+internal class TidligereVedaksperioderServiceTest {
+
+    private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
+    private val infotrygdService = mockk<InfotrygdService>()
+
+    private val service = TidligereVedaksperioderService(
+        fagsakPersonService,
+        fagsakService,
+        behandlingService,
+        tilkjentYtelseService,
+        infotrygdService
+    )
+
+    @Test
+    internal fun `skal sjekke hvis man har tidligere vedtak`() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -40,7 +40,8 @@ object PdlTestdata {
         )
     )
 
-    private val adressebeskyttelse = listOf(Adressebeskyttelse(AdressebeskyttelseGradering.FORTROLIG, metadataGjeldende))
+    private val adressebeskyttelse =
+        listOf(Adressebeskyttelse(AdressebeskyttelseGradering.FORTROLIG, metadataGjeldende))
 
     private val bostedsadresse = listOf(
         Bostedsadresse(
@@ -58,7 +59,8 @@ object PdlTestdata {
 
     private val dødsfall = listOf(Dødsfall(LocalDate.now()))
 
-    private val familierelasjon = listOf(ForelderBarnRelasjon("", Familierelasjonsrolle.BARN, Familierelasjonsrolle.FAR))
+    private val familierelasjon =
+        listOf(ForelderBarnRelasjon("", Familierelasjonsrolle.BARN, Familierelasjonsrolle.FAR))
 
     private val fødsel = listOf(Fødsel(1, LocalDate.now(), "", "", "", metadataGjeldende))
 
@@ -168,7 +170,10 @@ object PdlTestdata {
             )
         )
 
-    val folkeregisteridentifikatorAnnenForelder = listOf(FolkeregisteridentifikatorMedMetadata("1", metadataGjeldende))
+    val ennenForelderIdentifikator = "2"
+
+    val folkeregisteridentifikatorAnnenForelder =
+        listOf(FolkeregisteridentifikatorMedMetadata(ennenForelderIdentifikator, metadataGjeldende))
 
     val pdlAnnenForelderData =
         PersonBolk(

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -168,6 +168,8 @@ object PdlTestdata {
             )
         )
 
+    val folkeregisteridentifikatorAnnenForelder = listOf(FolkeregisteridentifikatorMedMetadata("1", metadataGjeldende))
+
     val pdlAnnenForelderData =
         PersonBolk(
             listOf(
@@ -178,7 +180,8 @@ object PdlTestdata {
                         bostedsadresse,
                         dødsfall,
                         fødsel,
-                        navn
+                        folkeregisteridentifikatorAnnenForelder,
+                        navn,
                     )
                 )
             )

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -145,8 +145,13 @@ fun Behandling.innvilgetOgFerdigstilt() =
         status = BehandlingStatus.FERDIGSTILT
     )
 
+val defaultIdenter = setOf(PersonIdent("15"))
+fun fagsakPerson(
+    identer: Set<PersonIdent> = defaultIdenter
+) = FagsakPerson(identer = identer)
+
 fun fagsak(
-    identer: Set<PersonIdent> = setOf(PersonIdent("15")),
+    identer: Set<PersonIdent> = defaultIdenter,
     stønadstype: StønadType = StønadType.OVERGANGSSTØNAD,
     id: UUID = UUID.randomUUID(),
     eksternId: EksternFagsakId = EksternFagsakId(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
@@ -13,6 +12,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegist
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstandstype
@@ -38,11 +38,11 @@ internal class GrunnlagsdataServiceTest {
     private val søknadService = mockk<SøknadService>()
     private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
     private val infotrygdReplikaClient = InfotrygdReplikaMock().infotrygdReplikaClient()
-    private val infotrygdService = InfotrygdService(infotrygdReplikaClient, pdlClient)
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>()
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         pdlClient,
         personopplysningerIntegrasjonerClient,
-        infotrygdService
+        tidligereVedaksperioderService
     )
 
     private val søknad = SøknadsskjemaMapper.tilDomene(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -6,8 +6,6 @@ import io.mockk.verify
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
-import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
@@ -15,6 +13,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataServic
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.InnflyttingUtflyttingMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.PersonopplysningerMapper
@@ -39,6 +38,8 @@ internal class PersonopplysningerServiceTest {
     private lateinit var søknadService: SøknadService
     private lateinit var behandlingService: BehandlingService
 
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>()
+
     @BeforeEach
     internal fun setUp() {
         personopplysningerIntegrasjonerClient = mockk(relaxed = true)
@@ -48,11 +49,10 @@ internal class PersonopplysningerServiceTest {
         søknadService = mockk()
         val pdlClient = PdlClientConfig().pdlClient()
 
-        val infotrygdService = InfotrygdService(InfotrygdReplikaMock().infotrygdReplikaClient(), pdlClient)
         val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
             pdlClient,
             personopplysningerIntegrasjonerClient,
-            infotrygdService
+            tidligereVedaksperioderService
         )
 
         grunnlagsdataService = GrunnlagsdataService(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -38,7 +38,7 @@ internal class PersonopplysningerServiceTest {
     private lateinit var søknadService: SøknadService
     private lateinit var behandlingService: BehandlingService
 
-    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>()
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
 
     @BeforeEach
     internal fun setUp() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RegistergrunnlagTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RegistergrunnlagTest.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.service
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
 import no.nav.familie.kontrakter.felles.objectMapper
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
@@ -5,14 +5,13 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
-import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.tilSøknadsverdier
@@ -39,13 +38,13 @@ internal class VilkårGrunnlagServiceTest {
     private val søknadService = mockk<SøknadService>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val medlemskapMapper = MedlemskapMapper(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
-    private val infotrygdService = InfotrygdService(InfotrygdReplikaMock().infotrygdReplikaClient(), pdlClient)
     private val behandlingService = mockk<BehandlingService>()
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>()
 
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         pdlClient,
         personopplysningerIntegrasjonerClient,
-        infotrygdService
+        tidligereVedaksperioderService
     )
 
     private val fagsakService = mockk<FagsakService>()

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
@@ -39,7 +39,7 @@ internal class VilkårGrunnlagServiceTest {
     private val featureToggleService = mockk<FeatureToggleService>()
     private val medlemskapMapper = MedlemskapMapper(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
     private val behandlingService = mockk<BehandlingService>()
-    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>()
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
 
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         pdlClient,

--- a/src/test/resources/json/andreForeldre.json
+++ b/src/test/resources/json/andreForeldre.json
@@ -57,6 +57,14 @@
               }
             }
           ],
+          "folkeregisteridentifikator": [
+            {
+              "identifikasjonsnummer": "11111111111",
+              "metadata":  {
+                "historisk": false
+              }
+            }
+          ],
           "navn": [
             {
               "fornavn": "BRÅKETE",

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -1409,6 +1409,57 @@
         "name" : "personIdent",
         "type" : "String",
         "nullable" : false
+      },
+      "tidligereVedtaksperioder" : {
+        "name" : "tidligereVedtaksperioder",
+        "type" : "Object",
+        "fields" : {
+          "efSak" : {
+            "name" : "efSak",
+            "type" : "Object",
+            "fields" : {
+              "harTidligereOvergangsstønad" : {
+                "name" : "harTidligereOvergangsstønad",
+                "type" : "Boolean",
+                "nullable" : false
+              },
+              "harTidligereBarnetilsyn" : {
+                "name" : "harTidligereBarnetilsyn",
+                "type" : "Boolean",
+                "nullable" : false
+              },
+              "harTidligereSkolepenger" : {
+                "name" : "harTidligereSkolepenger",
+                "type" : "Boolean",
+                "nullable" : false
+              }
+            },
+            "nullable" : false
+          },
+          "infotrygd" : {
+            "name" : "infotrygd",
+            "type" : "Object",
+            "fields" : {
+              "harTidligereOvergangsstønad" : {
+                "name" : "harTidligereOvergangsstønad",
+                "type" : "Boolean",
+                "nullable" : false
+              },
+              "harTidligereBarnetilsyn" : {
+                "name" : "harTidligereBarnetilsyn",
+                "type" : "Boolean",
+                "nullable" : false
+              },
+              "harTidligereSkolepenger" : {
+                "name" : "harTidligereSkolepenger",
+                "type" : "Boolean",
+                "nullable" : false
+              }
+            },
+            "nullable" : false
+          }
+        },
+        "nullable" : true
       }
     },
     "nullable" : false


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9055

* Flytter ut metode fra `GrunnlagsdataRegisterService->hentTidligereVedtaksperioder` i til `TidligereVedaksperioderService`
* Henter identer til annen forelder, for å kunne kalle Infotrygd med alle identene til en person
* Legger till `val tidligereVedtaksperioder: TidligereVedtaksperioderAnnenForelder?` i `GrunnlagsdataDomene` då vi ønsker å lagre ned hva saksbehandler såg når man såg på vilkåret

Merges til master når denne er merget:
* https://github.com/navikt/familie-ef-sak/pull/1638