### PR TITLE
Skal sjekke om personen har fått tidligere vedtak i EF. Kommer legge …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -1,9 +1,6 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapAnnenForelder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapSøker
@@ -18,7 +15,7 @@ import org.springframework.stereotype.Service
 class GrunnlagsdataRegisterService(
     private val pdlClient: PdlClient,
     private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
-    private val infotrygdService: InfotrygdService
+    private val tidligereVedaksperioderService: TidligereVedaksperioderService
 ) {
 
     fun hentGrunnlagsdataFraRegister(
@@ -32,25 +29,15 @@ class GrunnlagsdataRegisterService(
 
         val medlUnntak = personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(ident = personIdent)
 
+        val tidligereVedtaksperioder = tidligereVedaksperioderService.hentTidligereVedtaksperioder(personIdent)
+
         return GrunnlagsdataDomene(
             søker = mapSøker(pdlSøker, dataTilAndreIdenter),
             annenForelder = mapAnnenForelder(barneForeldre),
             medlUnntak = medlUnntak,
             barn = mapBarn(pdlBarn),
-            tidligereVedtaksperioder = hentTidligereVedtaksperioder(personIdent)
+            tidligereVedtaksperioder = tidligereVedtaksperioder
         )
-    }
-
-    // TODO endre om til å bruke identer fra pdlSøker, då dette blir et ekstra kall for å hente identer
-    private fun hentTidligereVedtaksperioder(personIdent: String): TidligereVedtaksperioder {
-        return infotrygdService.hentPerioderFraReplika(personIdent).let {
-            val infotrygd = TidligereInnvilgetVedtak(
-                harTidligereOvergangsstønad = it.overgangsstønad.isNotEmpty(),
-                harTidligereBarnetilsyn = it.barnetilsyn.isNotEmpty(),
-                harTidligereSkolepenger = it.skolepenger.isNotEmpty(),
-            )
-            TidligereVedtaksperioder(infotrygd = infotrygd)
-        }
     }
 
     private fun hentPdlBarn(pdlSøker: PdlSøker): Map<String, PdlBarn> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderService.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
+import org.springframework.stereotype.Service
+
+@Service
+class TidligereVedaksperioderService(
+    private val fagsakPersonService: FagsakPersonService,
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+    private val tilkjentYtelseService: TilkjentYtelseService,
+    private val infotrygdService: InfotrygdService,
+) {
+
+    // TODO endre om til å bruke identer fra pdlSøker, då dette blir et ekstra kall for å hente identer
+    fun hentTidligereVedtaksperioder(personIdent: String): TidligereVedtaksperioder {
+        val tidligereInnvilgetVedtak = mapTidligereInnvilgetVedtak(infotrygdService.hentPerioderFraReplika(personIdent))
+        return TidligereVedtaksperioder(
+            infotrygd = tidligereInnvilgetVedtak,
+            sak = harTidligereMottattStønadEf(setOf(personIdent))
+        )
+    }
+
+    private fun mapTidligereInnvilgetVedtak(periodeResponse: InfotrygdPeriodeResponse) =
+        TidligereInnvilgetVedtak(
+            harTidligereOvergangsstønad = periodeResponse.overgangsstønad.isNotEmpty(),
+            harTidligereBarnetilsyn = periodeResponse.barnetilsyn.isNotEmpty(),
+            harTidligereSkolepenger = periodeResponse.skolepenger.isNotEmpty(),
+        )
+
+    private fun harTidligereMottattStønadEf(identer: Set<String>): TidligereInnvilgetVedtak {
+        return fagsakPersonService.finnPerson(identer)
+            ?.let { fagsakService.finnFagsakerForFagsakPersonId(it.id) }
+            ?.let {
+                TidligereInnvilgetVedtak(
+                    harTidligereOvergangsstønad = hentTidligereVedtaksperioder(it.overgangsstønad),
+                    harTidligereBarnetilsyn = hentTidligereVedtaksperioder(it.barnetilsyn),
+                    harTidligereSkolepenger = hentTidligereVedtaksperioder(it.skolepenger)
+                )
+            } ?: TidligereInnvilgetVedtak(false, false, false)
+    }
+
+    private fun hentTidligereVedtaksperioder(fagsak: Fagsak?) = fagsak
+        ?.let { behandlingService.finnSisteIverksatteBehandling(it.id) }
+        ?.let {
+            val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(it.id)
+            tilkjentYtelse.andelerTilkjentYtelse.isNotEmpty()
+        } ?: false
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -108,7 +108,10 @@ data class FullmaktMedNavn(
     val navn: String?
 )
 
-data class TidligereVedtaksperioder(val infotrygd: TidligereInnvilgetVedtak)
+data class TidligereVedtaksperioder(
+    val infotrygd: TidligereInnvilgetVedtak,
+    val sak: TidligereInnvilgetVedtak? = null
+)
 
 data class TidligereInnvilgetVedtak(
     val harTidligereOvergangsstønad: Boolean,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.ForelderBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.FullmaktMedNavn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.SivilstandMedNavn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Søker
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.KjønnType
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlAnnenForelder

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.opplysninger.mapper.BarnMedSamværMapper
 import no.nav.familie.ef.sak.opplysninger.mapper.SivilstandMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadBarn
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søknadsverdier
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.AktivitetMapper
@@ -15,9 +14,8 @@ import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SagtOppEllerRedusertSti
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SivilstandsplanerMapper
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
-import no.nav.familie.ef.sak.vilkår.dto.TidligereInnvilgetVedtakDto
-import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.kontrakter.ef.søknad.Fødselsnummer
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
@@ -59,7 +57,7 @@ class VilkårGrunnlagService(
         val sagtOppEllerRedusertStilling = søknad?.situasjon?.let { SagtOppEllerRedusertStillingMapper.tilDto(situasjon = it) }
 
         return VilkårGrunnlagDto(
-            tidligereVedtaksperioder = mapTidligereVedtaksperioder(grunnlagsdata.tidligereVedtaksperioder),
+            tidligereVedtaksperioder = grunnlagsdata.tidligereVedtaksperioder.tilDto(),
             medlemskap = medlemskap,
             sivilstand = sivilstand,
             bosituasjon = søknad?.let { BosituasjonMapper.tilDto(it.bosituasjon) },
@@ -70,17 +68,6 @@ class VilkårGrunnlagService(
             lagtTilEtterFerdigstilling = registergrunnlagData.lagtTilEtterFerdigstilling,
             registeropplysningerOpprettetTid = registergrunnlagData.opprettetTidspunkt
         )
-    }
-
-    private fun mapTidligereVedtaksperioder(tidligereVedtaksperioder: TidligereVedtaksperioder?): TidligereVedtaksperioderDto {
-        val infotrygd = tidligereVedtaksperioder?.infotrygd?.let {
-            TidligereInnvilgetVedtakDto(
-                harTidligereOvergangsstønad = it.harTidligereOvergangsstønad,
-                harTidligereBarnetilsyn = it.harTidligereBarnetilsyn,
-                harTidligereSkolepenger = it.harTidligereSkolepenger
-            )
-        }
-        return TidligereVedtaksperioderDto(infotrygd = infotrygd)
     }
 
     private fun mapBarnMedSamvær(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
@@ -1,9 +1,29 @@
 package no.nav.familie.ef.sak.vilkår.dto
 
-data class TidligereVedtaksperioderDto(val infotrygd: TidligereInnvilgetVedtakDto?)
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
+
+data class TidligereVedtaksperioderDto(
+    val infotrygd: TidligereInnvilgetVedtakDto?,
+    val sak: TidligereInnvilgetVedtakDto?
+)
 
 data class TidligereInnvilgetVedtakDto(
     val harTidligereOvergangsstønad: Boolean,
     val harTidligereBarnetilsyn: Boolean,
     val harTidligereSkolepenger: Boolean
 )
+
+fun TidligereVedtaksperioder?.tilDto(): TidligereVedtaksperioderDto = this?.let {
+    TidligereVedtaksperioderDto(
+        infotrygd = it.infotrygd.tilDto(),
+        sak = it.sak?.tilDto()
+    )
+} ?: TidligereVedtaksperioderDto(null, null)
+
+fun TidligereInnvilgetVedtak.tilDto() =
+    TidligereInnvilgetVedtakDto(
+        harTidligereOvergangsstønad = this.harTidligereOvergangsstønad,
+        harTidligereBarnetilsyn = this.harTidligereBarnetilsyn,
+        harTidligereSkolepenger = this.harTidligereSkolepenger
+    )

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InfotrygdReplikaMock.kt
@@ -31,26 +31,29 @@ class InfotrygdReplikaMock {
         fun resetMock(client: InfotrygdReplikaClient) {
             clearMocks(client)
             every { client.hentPerioder(any()) } answers {
-                val firstArg = firstArg<InfotrygdPeriodeRequest>()
-                val personIdent = firstArg.personIdenter.first()
-                InfotrygdPeriodeResponse(
-                    overgangsstønad = listOf(lagInfotrygdPeriode()),
-                    barnetilsyn = listOf(
-                        lagInfotrygdPeriode(
-                            personIdent = personIdent,
-                            beløp = 234,
-                            inntektsgrunnlag = 321,
-                            samordningsfradrag = 0,
-                            utgifterBarnetilsyn = 1000,
-                            barnIdenter = listOf("123", "234")
-                        )
-                    ),
-                    skolepenger = emptyList()
-                )
+                hentPerioderDefaultResponse(firstArg())
             }
             every { client.hentSaker(any()) } returns InfotrygdSakResponse(emptyList())
             every { client.hentInslagHosInfotrygd(any()) } answers { InfotrygdFinnesResponse(emptyList(), emptyList()) }
             every { client.hentPersonerForMigrering(any()) } returns emptySet()
+        }
+
+        fun hentPerioderDefaultResponse(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse {
+            val personIdent = request.personIdenter.first()
+            return InfotrygdPeriodeResponse(
+                overgangsstønad = listOf(lagInfotrygdPeriode()),
+                barnetilsyn = listOf(
+                    lagInfotrygdPeriode(
+                        personIdent = personIdent,
+                        beløp = 234,
+                        inntektsgrunnlag = 321,
+                        samordningsfradrag = 0,
+                        utgifterBarnetilsyn = 1000,
+                        barnIdenter = listOf("123", "234")
+                    )
+                ),
+                skolepenger = emptyList()
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -140,8 +140,8 @@ class PdlClientConfig {
         private val sluttdato = LocalDate.of(2021, 1, 1)
         private const val barnFnr = "01012067050"
         private const val barn2Fnr = "14041385481"
-        private const val søkerFnr = "01010172272"
-        private const val annenForelderFnr = "17097926735"
+        const val søkerFnr = "01010172272"
+        const val annenForelderFnr = "17097926735"
         private const val fnrPåAdresseSøk = "01012067050"
 
         fun lagPersonKort(it: String) =

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedaksperioderServiceTest.kt
@@ -1,0 +1,107 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsaker
+import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakPerson
+import no.nav.familie.ef.sak.repository.fagsakpersoner
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+internal class TidligereVedaksperioderServiceTest {
+
+    private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
+    private val pdlClient = mockk<PdlClient>()
+    private val infotrygdReplikaClient = mockk<InfotrygdReplikaClient>()
+    private val infotrygdService = InfotrygdService(infotrygdReplikaClient, pdlClient)
+
+    private val service = TidligereVedaksperioderService(
+        fagsakPersonService,
+        fagsakService,
+        behandlingService,
+        tilkjentYtelseService,
+        infotrygdService
+    )
+
+    private val infotrygdPeriodeRequestSlot = slot<InfotrygdPeriodeRequest>()
+
+    private val personIdent = "1"
+    private val identAnnenForelder = "2"
+
+    private val fagsakPerson = fagsakPerson(fagsakpersoner(identAnnenForelder))
+    private val fagsak = fagsak(person = fagsakPerson)
+    private val fagsaker = Fagsaker(fagsak, null, null)
+    private val behandling = behandling(fagsak)
+
+    @BeforeEach
+    internal fun setUp() {
+        every {
+            infotrygdReplikaClient.hentPerioder(capture(infotrygdPeriodeRequestSlot))
+        } answers { InfotrygdReplikaMock.hentPerioderDefaultResponse(firstArg()) }
+        every { pdlClient.hentPersonidenter(personIdent, true) } returns
+            PdlIdenter(listOf(PdlIdent(personIdent, false)))
+    }
+
+    @Test
+    internal fun `skal sjekke om personIdent har historikk i ef-sak og infotrygd`() {
+        mockTidligereVedtakEfSak(harAndeler = true)
+
+        val tidligereVedtaksperioder = service.hentTidligereVedtaksperioder(personIdent)
+
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereOvergangsstønad).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereBarnetilsyn).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereSkolepenger).isFalse
+
+        val sak = tidligereVedtaksperioder.sak ?: error("Forventet at sak ikke er null")
+        assertThat(sak.harTidligereOvergangsstønad).isTrue
+        assertThat(sak.harTidligereBarnetilsyn).isFalse
+        assertThat(sak.harTidligereSkolepenger).isFalse
+
+        verify(exactly = 1) { infotrygdReplikaClient.hentPerioder(any()) }
+        verify(exactly = 1) { tilkjentYtelseService.hentForBehandling(behandling.id) }
+
+        assertThat(infotrygdPeriodeRequestSlot.captured.personIdenter).containsExactly(personIdent)
+    }
+
+    @Test
+    internal fun `hvis en person ikke har noen aktive andeler så har man ikke tidligere vedtaksperioder i ef`() {
+        mockTidligereVedtakEfSak(harAndeler = false)
+
+        val tidligereVedtaksperioder = service.hentTidligereVedtaksperioder(personIdent)
+
+        val sak = tidligereVedtaksperioder.sak ?: error("Forventet at sak ikke er null")
+        assertThat(sak.harTidligereOvergangsstønad).isFalse
+        assertThat(sak.harTidligereBarnetilsyn).isFalse
+        assertThat(sak.harTidligereSkolepenger).isFalse
+    }
+
+    private fun mockTidligereVedtakEfSak(harAndeler: Boolean = true) {
+        every { fagsakPersonService.finnPerson(any()) } returns fagsakPerson
+        every { fagsakService.finnFagsakerForFagsakPersonId(any()) } returns fagsaker
+        every { behandlingService.finnSisteIverksatteBehandling(fagsak.id) } returns behandling
+        val andelerTilkjentYtelse =
+            if (harAndeler) listOf(lagAndelTilkjentYtelse(100, LocalDate.now(), LocalDate.now())) else emptyList()
+        every { tilkjentYtelseService.hentForBehandling(behandling.id) } returns lagTilkjentYtelse(andelerTilkjentYtelse)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -145,8 +145,13 @@ fun Behandling.innvilgetOgFerdigstilt() =
         status = BehandlingStatus.FERDIGSTILT
     )
 
+val defaultIdenter = setOf(PersonIdent("15"))
+fun fagsakPerson(
+    identer: Set<PersonIdent> = defaultIdenter
+) = FagsakPerson(identer = identer)
+
 fun fagsak(
-    identer: Set<PersonIdent> = setOf(PersonIdent("15")),
+    identer: Set<PersonIdent> = defaultIdenter,
     stønadstype: StønadType = StønadType.OVERGANGSSTØNAD,
     id: UUID = UUID.randomUUID(),
     eksternId: EksternFagsakId = EksternFagsakId(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -5,14 +5,16 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
-import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
+import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig.Companion.annenForelderFnr
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstandstype
@@ -37,19 +39,20 @@ internal class GrunnlagsdataServiceTest {
     private val pdlClient = PdlClientConfig().pdlClient()
     private val søknadService = mockk<SøknadService>()
     private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
-    private val infotrygdReplikaClient = InfotrygdReplikaMock().infotrygdReplikaClient()
-    private val infotrygdService = InfotrygdService(infotrygdReplikaClient, pdlClient)
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         pdlClient,
         personopplysningerIntegrasjonerClient,
-        infotrygdService
+        tidligereVedaksperioderService
     )
 
     private val søknad = SøknadsskjemaMapper.tilDomene(
         TestsøknadBuilder.Builder().setBarn(
             listOf(
-                TestsøknadBuilder.Builder().defaultBarn("Navn1 navnesen", fødselTermindato = LocalDate.now().plusMonths(4)),
-                TestsøknadBuilder.Builder().defaultBarn("Navn2 navnesen", fødselTermindato = LocalDate.now().plusMonths(6))
+                TestsøknadBuilder.Builder()
+                    .defaultBarn("Navn1 navnesen", fødselTermindato = LocalDate.now().plusMonths(4)),
+                TestsøknadBuilder.Builder()
+                    .defaultBarn("Navn2 navnesen", fødselTermindato = LocalDate.now().plusMonths(6))
             )
         ).build().søknadOvergangsstønad
     )
@@ -130,12 +133,19 @@ internal class GrunnlagsdataServiceTest {
 
     @Test
     internal fun `skal sjekke om personen har historikk i infotrygd`() {
-        val grunnlagsdata = service.hentGrunnlagsdataFraRegister("1", emptyList())
+        val personIdent = PdlClientConfig.søkerFnr
+        val defaultTidligereInnvilgetVedtak = TidligereInnvilgetVedtak(true, true, false)
 
-        assertThat(grunnlagsdata.tidligereVedtaksperioder!!.infotrygd.harTidligereOvergangsstønad).isTrue
-        assertThat(grunnlagsdata.tidligereVedtaksperioder!!.infotrygd.harTidligereBarnetilsyn).isTrue
-        assertThat(grunnlagsdata.tidligereVedtaksperioder!!.infotrygd.harTidligereSkolepenger).isFalse
+        every { tidligereVedaksperioderService.hentTidligereVedtaksperioder(personIdent) } returns
+            TidligereVedtaksperioder(defaultTidligereInnvilgetVedtak)
 
-        verify(exactly = 1) { infotrygdReplikaClient.hentPerioder(any()) }
+        val grunnlagsdata = service.hentGrunnlagsdataFraRegister(personIdent, emptyList())
+
+        val tidligereVedtaksperioder = grunnlagsdata.tidligereVedtaksperioder!!
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereOvergangsstønad).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereBarnetilsyn).isTrue
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereSkolepenger).isFalse
+
+        verify(exactly = 1) { tidligereVedaksperioderService.hentTidligereVedtaksperioder(personIdent) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -6,8 +6,6 @@ import io.mockk.verify
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
-import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
@@ -15,6 +13,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataServic
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.InnflyttingUtflyttingMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.PersonopplysningerMapper
@@ -39,6 +38,8 @@ internal class PersonopplysningerServiceTest {
     private lateinit var søknadService: SøknadService
     private lateinit var behandlingService: BehandlingService
 
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
+
     @BeforeEach
     internal fun setUp() {
         personopplysningerIntegrasjonerClient = mockk(relaxed = true)
@@ -48,11 +49,10 @@ internal class PersonopplysningerServiceTest {
         søknadService = mockk()
         val pdlClient = PdlClientConfig().pdlClient()
 
-        val infotrygdService = InfotrygdService(InfotrygdReplikaMock().infotrygdReplikaClient(), pdlClient)
         val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
             pdlClient,
             personopplysningerIntegrasjonerClient,
-            infotrygdService
+            tidligereVedaksperioderService
         )
 
         grunnlagsdataService = GrunnlagsdataService(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VilkårGrunnlagServiceTest.kt
@@ -5,14 +5,13 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
-import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRepository
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.tilSøknadsverdier
@@ -39,13 +38,13 @@ internal class VilkårGrunnlagServiceTest {
     private val søknadService = mockk<SøknadService>()
     private val featureToggleService = mockk<FeatureToggleService>()
     private val medlemskapMapper = MedlemskapMapper(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
-    private val infotrygdService = InfotrygdService(InfotrygdReplikaMock().infotrygdReplikaClient(), pdlClient)
     private val behandlingService = mockk<BehandlingService>()
+    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
 
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         pdlClient,
         personopplysningerIntegrasjonerClient,
-        infotrygdService
+        tidligereVedaksperioderService
     )
 
     private val fagsakService = mockk<FagsakService>()

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -2042,6 +2042,28 @@
           }
         },
         "nullable" : false
+      },
+      "sak" : {
+        "name" : "sak",
+        "type" : "Object",
+        "fields" : {
+          "harTidligereOvergangsstønad" : {
+            "name" : "harTidligereOvergangsstønad",
+            "type" : "Boolean",
+            "nullable" : false
+          },
+          "harTidligereBarnetilsyn" : {
+            "name" : "harTidligereBarnetilsyn",
+            "type" : "Boolean",
+            "nullable" : false
+          },
+          "harTidligereSkolepenger" : {
+            "name" : "harTidligereSkolepenger",
+            "type" : "Boolean",
+            "nullable" : false
+          }
+        },
+        "nullable" : true
       }
     },
     "nullable" : true


### PR DESCRIPTION
…til sjekk for andre foreldre senere.

Fikk ikke reåpne https://github.com/navikt/familie-ef-sak/pull/1640

Denne er for å støtte Eirik sin oppgave https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9001 og senere min oppgave https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9055

* Flytter ut metode fra GrunnlagsdataRegisterService->hentTidligereVedtaksperioder i til TidligereVedaksperioderService
* Legger til tidligereVedtaksperioder for sak

Splittet opp denne fra en litt større PR, då jeg avventer svar fra PDL. Dette kommer senere:
* Henter identer til annen forelder, for å kunne kalle Infotrygd med alle identene til en person
* Legge til tidligereVedtaksperioder for andre foreldre