### PR TITLE
BehandlingRepository - Fjerner queries som ikke er i bruk.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -23,11 +23,9 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
-import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
@@ -43,16 +41,12 @@ class BehandlingService(
     private val behandlingRepository: BehandlingRepository,
     private val behandlingshistorikkService: BehandlingshistorikkService,
     private val taskService: TaskService,
-    private val søknadService: SøknadService,
     private val featureToggleService: FeatureToggleService
 ) {
 
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun hentAktivIdent(behandlingId: UUID): String = behandlingRepository.finnAktivIdent(behandlingId)
-
-    fun hentAktiveIdenter(behandlingIds: Collection<UUID>): Map<UUID, String> =
-        behandlingRepository.finnAktiveIdenter(behandlingIds).toMap()
 
     fun hentEksterneIder(behandlingIder: Set<UUID>) = behandlingIder.takeIf { it.isNotEmpty() }
         ?.let { behandlingRepository.finnEksterneIder(it) } ?: emptySet()
@@ -68,9 +62,6 @@ class BehandlingService(
             ?: hentBehandlinger(fagsakId).lastOrNull {
                 it.status == FERDIGSTILT && it.resultat != HENLAGT
             }
-
-    fun finnGjeldendeIverksatteBehandlinger(stonadstype: StønadType) =
-        behandlingRepository.finnSisteIverksatteBehandlinger(stonadstype)
 
     fun hentBehandlingsjournalposter(behandlingId: UUID): List<Behandlingsjournalpost> {
         return behandlingsjournalpostRepository.findAllByBehandlingId(behandlingId)
@@ -170,14 +161,8 @@ class BehandlingService(
         return behandlingRepository.update(behandling.copy(steg = steg))
     }
 
-    fun harFørstegangsbehandlingEllerRevurderingFraFør(fagsakId: UUID) =
-        behandlingRepository.existsByFagsakIdAndTypeIn(
-            fagsakId,
-            setOf(
-                BehandlingType.FØRSTEGANGSBEHANDLING,
-                BehandlingType.REVURDERING
-            )
-        )
+    fun finnesBehandlingForFagsak(fagsakId: UUID) =
+        behandlingRepository.existsByFagsakId(fagsakId)
 
     fun hentBehandlinger(fagsakId: UUID): List<Behandling> {
         return behandlingRepository.findByFagsakId(fagsakId).sortedBy { it.sporbar.opprettetTid }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.ekstern
 
-import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
@@ -12,7 +12,7 @@ import java.util.UUID
 @Service
 class EksternBehandlingService(
     val tilkjentYtelseService: TilkjentYtelseService,
-    val behandlingRepository: BehandlingRepository,
+    val behandlingService: BehandlingService,
     val fagsakService: FagsakService
 ) {
 
@@ -37,12 +37,13 @@ class EksternBehandlingService(
         stønadstype: StønadType,
         personidenter: Set<String>
     ): Boolean {
-        return behandlingRepository.finnSisteBehandling(stønadstype, personidenter) != null
+        val fagsak = fagsakService.finnFagsak(personidenter, stønadstype) ?: return false
+        return behandlingService.finnesBehandlingForFagsak(fagsak.id)
     }
 
     private fun hentAlleBehandlingIDer(personidenter: Set<String>): Set<UUID> {
         return StønadType.values().mapNotNull { fagsakService.finnFagsak(personidenter, it) }
-            .mapNotNull { behandlingRepository.finnSisteIverksatteBehandling(it.id) }
+            .mapNotNull { behandlingService.finnSisteIverksatteBehandling(it.id) }
             .map { it.id }
             .toSet()
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -216,7 +216,7 @@ class JournalføringService(
     }
 
     private fun validerStateIInfotrygdHvisManIkkeHarBehandlingFraFør(fagsak: Fagsak) {
-        if (!behandlingService.harFørstegangsbehandlingEllerRevurderingFraFør(fagsak.id)) {
+        if (!behandlingService.finnesBehandlingForFagsak(fagsak.id)) {
             when (fagsak.stønadstype) {
                 StønadType.OVERGANGSSTØNAD ->
                     infotrygdPeriodeValideringService.validerKanJournalføreUtenÅMigrereOvergangsstønad(

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider
@@ -54,6 +55,9 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 internal class OmregningServiceTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    lateinit var fagsakService: FagsakService
 
     @Autowired
     lateinit var omregningService: OmregningService
@@ -235,20 +239,17 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
         vedtakstidspunkt: LocalDateTime
     ): IverksettOvergangsstønadDto {
 
-        val nyBehandling =
-            behandlingRepository.finnSisteBehandling(
-                StønadType.OVERGANGSSTØNAD,
-                fagsak.personIdenter.map {
-                    it.ident
-                }.toSet()
-            ) ?: error("Impossibru! :p")
+        val personidenter = fagsak.personIdenter.map { it.ident }.toSet()
+        val forrigeBehandling = fagsakService.finnFagsak(personidenter, StønadType.OVERGANGSSTØNAD)?.let {
+            behandlingRepository.findByFagsakId(it.id).maxByOrNull { it.sporbar.opprettetTid }
+        } ?: error("Finner ikke tidligere iverksatt behandling")
 
         val expectedIverksettDto: IverksettOvergangsstønadDto =
             ObjectMapperProvider.objectMapper.readValue(readFile("expectedIverksettDto.json"))
 
         val andelerTilkjentYtelse = expectedIverksettDto.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.map {
             if (it.fraOgMed >= nyesteGrunnbeløpGyldigFraOgMed) {
-                it.copy(kildeBehandlingId = nyBehandling.id)
+                it.copy(kildeBehandlingId = forrigeBehandling.id)
             } else {
                 it.copy(kildeBehandlingId = behandling.id)
             }
@@ -256,8 +257,8 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
         val tilkjentYtelseDto = expectedIverksettDto.vedtak.tilkjentYtelse?.copy(andelerTilkjentYtelse = andelerTilkjentYtelse)
         val vedtak = expectedIverksettDto.vedtak.copy(tilkjentYtelse = tilkjentYtelseDto, vedtakstidspunkt = vedtakstidspunkt)
         val behandlingsdetaljerDto = expectedIverksettDto.behandling.copy(
-            behandlingId = nyBehandling.id,
-            eksternId = nyBehandling.eksternId.id
+            behandlingId = forrigeBehandling.id,
+            eksternId = forrigeBehandling.eksternId.id
         )
         return expectedIverksettDto.copy(
             vedtak = vedtak,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
@@ -51,7 +51,6 @@ internal class BehandlingServiceTest {
             behandlingRepository,
             behandlingshistorikkService,
             taskService,
-            mockk(),
             mockFeatureToggleService()
         )
     private val behandlingSlot = slot<Behandling>()

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/JournalføringServiceTest.kt
@@ -154,7 +154,7 @@ internal class JournalføringServiceTest {
                 )
             )
 
-        every { behandlingService.harFørstegangsbehandlingEllerRevurderingFraFør(any()) } returns true
+        every { behandlingService.finnesBehandlingForFagsak(any()) } returns true
 
         every {
             fagsakService.hentFagsak(any())
@@ -324,7 +324,7 @@ internal class JournalføringServiceTest {
             journalpostClient.hentOvergangsstønadSøknad(any(), any())
         } returns Testsøknad.søknadOvergangsstønad
 
-        every { behandlingService.harFørstegangsbehandlingEllerRevurderingFraFør(any()) } returns false
+        every { behandlingService.finnesBehandlingForFagsak(any()) } returns false
         every { infotrygdPeriodeValideringService.validerKanJournalføreUtenÅMigrereOvergangsstønad(any(), any()) } throws ApiFeil(
             "feil",
             BAD_REQUEST


### PR DESCRIPTION
Fjerner finnSisteBehandling og erstatter med existsByFagsak for å ta ned antall komplekse queries

Det begynte som en opprydding av `harFørstegangsbehandlingEllerRevurderingFraFør` etter fjerning av blankett