### PR TITLE
PDL kan returnere null for sokPerson vid feil. Får då ikke parset res…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonSøk.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonSøk.kt
@@ -17,4 +17,4 @@ data class PdlPersonFraSøk(
 
 data class Folkeregisteridentifikator(val identifikasjonsnummer: String)
 
-data class PersonSøk(val sokPerson: PersonSøkResultat)
+data class PersonSøk(val sokPerson: PersonSøkResultat?)


### PR DESCRIPTION
…ponet og logget feilmelding som ligger i errors

https://nav-it.slack.com/archives/C84H68ESC/p1657187306881579?thread_ts=1657187072.785879&cid=C84H68ESC