### PR TITLE
Vil slette mellomlagret brev nulstilling av vedtak.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.vedtak
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
+import no.nav.familie.ef.sak.brev.MellomlagringBrevService
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingService
@@ -18,7 +19,8 @@ class NullstillVedtakService(
     private val behandlingService: BehandlingService,
     private val simuleringService: SimuleringService,
     private val tilkjentYtelseService: TilkjentYtelseService,
-    private val tilbakekrevingService: TilbakekrevingService
+    private val tilbakekrevingService: TilbakekrevingService,
+    private val mellomlagringBrevService: MellomlagringBrevService
 ) {
 
     @Transactional
@@ -29,6 +31,7 @@ class NullstillVedtakService(
             "Behandling er låst og vedtak kan ikke slettes"
         }
 
+        mellomlagringBrevService.slettMellomlagringHvisFinnes(behandlingId)
         simuleringService.slettSimuleringForBehandling(saksbehandling)
         tilkjentYtelseService.slettTilkjentYtelseForBehandling(behandlingId)
         tilbakekrevingService.slettTilbakekreving(behandlingId)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
+import no.nav.familie.ef.sak.brev.MellomlagringBrevService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.repository.saksbehandling
 import no.nav.familie.ef.sak.simulering.SimuleringService
@@ -32,6 +33,7 @@ class NullstillVedtakServiceTest {
     private val simuleringService = mockk<SimuleringService>(relaxed = true)
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>(relaxed = true)
     private val tilbakekrevingService = mockk<TilbakekrevingService>(relaxed = true)
+    private val mellomlagringBrevService = mockk<MellomlagringBrevService>(relaxed = true)
 
     private val nullstillVedtakService = NullstillVedtakService(
         vedtakRepository,
@@ -39,7 +41,8 @@ class NullstillVedtakServiceTest {
         behandlingService,
         simuleringService,
         tilkjentYtelseService,
-        tilbakekrevingService
+        tilbakekrevingService,
+        mellomlagringBrevService
     )
     private val behandlingId = UUID.randomUUID()
 
@@ -53,6 +56,7 @@ class NullstillVedtakServiceTest {
         nullstillVedtakService.nullstillVedtak(behandlingId)
 
         verifyAll {
+            mellomlagringBrevService.slettMellomlagringHvisFinnes(behandlingId)
             simuleringService.slettSimuleringForBehandling(capture(saksbehandling))
             tilkjentYtelseService.slettTilkjentYtelseForBehandling(behandlingId)
             tilbakekrevingService.slettTilbakekreving(behandlingId)


### PR DESCRIPTION
Etter at man har nullstilt vedtak A og deretter lagret et nytt vedtak B kommer brevet som ble startet på i vedtak A opp på brevsiden. Dett er ikke ønskelig og vi sletter derfor mellomlagring ved nullstilling av vedtak.