### PR TITLE
Når man henter vedtaksperioder fra gitt dato så fylles hull med midle…

### DIFF
--- a/src/test/resources/json/simuleringsresultat_beriket.json
+++ b/src/test/resources/json/simuleringsresultat_beriket.json
@@ -415,8 +415,8 @@
       }
     ],
     "fomDatoNestePeriode": null,
-    "etterbetaling": 13890,
-    "feilutbetaling": 76118,
+    "etterbetaling": 0,
+    "feilutbetaling": 0,
     "fom": "2021-02-01",
     "tomDatoNestePeriode": null,
     "forfallsdatoNestePeriode": null,

--- a/src/test/resources/no/nav/familie/ef/sak/vedtak_fra_gitt_dato/behandling_med_hull.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/vedtak_fra_gitt_dato/behandling_med_hull.feature
@@ -1,0 +1,40 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: hentVedtakForOvergangsstønadFraDato
+
+  Scenario: Behandling med hull i historikk legger til midlertidelig opphør
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Aktivitet          | Vedtaksperiode |
+      | 1            | 02.2021         | 03.2021         | INNVILGE        | BARN_UNDER_ETT_ÅR  | HOVEDPERIODE   |
+      | 2            | 06.2021         | 07.2021         | INNVILGE        | FORSØRGER_I_ARBEID | UTVIDELSE      |
+
+    Og følgende inntekter
+      | BehandlingId | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 1            | 02.2021         | 10      | 20                 |
+      | 2            | 06.2021         | 20      | 10                 |
+
+    Når beregner ytelse
+
+    # henter perioder før tidligere dato
+    Så forvent følgende vedtaksperioder fra dato: 01.2021
+      | Fra og med dato | Til og med dato | Aktivitet            | Vedtaksperiode     |
+      | 02.2021         | 03.2021         | BARN_UNDER_ETT_ÅR    | HOVEDPERIODE       |
+      | 04.2021         | 05.2021         | IKKE_AKTIVITETSPLIKT | HOVEDPERIODE |
+      | 06.2021         | 07.2021         | FORSØRGER_I_ARBEID   | UTVIDELSE          |
+
+    # henter perioder fra første fom-dato
+    Så forvent følgende vedtaksperioder fra dato: 02.2021
+      | Fra og med dato | Til og med dato | Aktivitet            | Vedtaksperiode     |
+      | 02.2021         | 03.2021         | BARN_UNDER_ETT_ÅR    | HOVEDPERIODE       |
+      | 04.2021         | 05.2021         | IKKE_AKTIVITETSPLIKT | MIDLERTIDIG_OPPHØR |
+      | 06.2021         | 07.2021         | FORSØRGER_I_ARBEID   | UTVIDELSE          |
+
+    # henter perioder fra hull
+    Så forvent følgende vedtaksperioder fra dato: 04.2021
+      | Fra og med dato | Til og med dato | Aktivitet          | Vedtaksperiode |
+      | 06.2021         | 07.2021         | FORSØRGER_I_ARBEID | UTVIDELSE      |
+
+    # henter perioder etter tidligere perioder
+    Så forvent følgende vedtaksperioder fra dato: 08.2021
+      | Fra og med dato | Til og med dato | Aktivitet          | Vedtaksperiode |


### PR DESCRIPTION
…rtidelig opphør for å fylle hull for prefyll

Denne påvirker også g-omregning. Burde vi gjøre dette i frontend i stedet, eller er dette greit? 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7719