### PR TITLE
Dependabot oppdateringer 20220822-084839

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                     <dependency>
                         <groupId>com.pinterest</groupId>
                         <artifactId>ktlint</artifactId>
-                        <version>0.47.0</version>
+                        <version>0.45.2</version>
                     </dependency>
                     <!-- additional 3rd party ruleset(s) can be specified here -->
                 </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
         <java.version>17</java.version>
         <kotlin.version>1.6.21</kotlin.version>
         <kotlin-coroutines.version>1.6.4</kotlin-coroutines.version>
-        <springdoc.version>1.6.10</springdoc.version>
+        <springdoc.version>1.6.11</springdoc.version>
         <mockk.version>1.12.5</mockk.version>
         <felles.version>1.20220811104902_c1860ff</felles.version>
         <prosessering.version>1.20220624132237_7f5ba9c</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20220819134825_6678be2</kontrakter.version>
+        <kontrakter.version>2.0_20220822080904_cd90e50</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20220613122416_43a5f72</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.6.0</cucumber.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>1.20220811104902_c1860ff</felles.version>
         <prosessering.version>1.20220624132237_7f5ba9c</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20220822080904_cd90e50</kontrakter.version>
+        <kontrakter.version>2.0_20220811151836_90bc956</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20220613122416_43a5f72</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.6.0</cucumber.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
                     <dependency>
                         <groupId>com.pinterest</groupId>
                         <artifactId>ktlint</artifactId>
-                        <version>0.45.2</version>
+                        <version>0.47.0</version>
                     </dependency>
                     <!-- additional 3rd party ruleset(s) can be specified here -->
                 </dependencies>


### PR DESCRIPTION
Erstatter:
 - https://github.com/navikt/familie-ef-sak/pull/1714
 - https://github.com/navikt/familie-ef-sak/pull/1713
 - ~https://github.com/navikt/familie-ef-sak/pull/1704~
 - ~https://github.com/navikt/familie-ef-sak/pull/1703~
 - ~https://github.com/navikt/familie-ef-sak/pull/1701~
 - ~https://github.com/navikt/familie-ef-sak/pull/1690~

Flere av disse var allerede tatt inn, men der pr ikke var lukket