### PR TITLE
Validering av avsenderMottaker må sjekke journalposttype og navn på a…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -104,15 +104,25 @@ class JournalføringService(
     fun fullførJournalpost(journalføringRequest: JournalføringRequest, journalpostId: String): Long {
         journalføringRequest.valider()
         val journalpost = hentJournalpost(journalpostId)
-        brukerfeilHvis(journalpost.avsenderMottaker == null) {
-            "Avsender mangler og må settes på journalposten i gosys. " +
-                "Når endringene er gjort, trykker du på \"Lagre utkast\" før du går tilbake til EF Sak og journalfører."
-        }
+        validerMottakerFinnes(journalpost)
 
         return if (journalføringRequest.skalJournalførePåEksisterendeBehandling()) {
             journalførSøknadTilEksisterendeBehandling(journalføringRequest, journalpost)
         } else {
             journalførSøknadTilNyBehandling(journalføringRequest, journalpost)
+        }
+    }
+
+    /**
+     * [Journalposttype.N] brukes for innskannede dokumentm, samme validering finnes i dokarkiv
+     */
+    private fun validerMottakerFinnes(journalpost: Journalpost) {
+        brukerfeilHvis(
+            journalpost.journalposttype != Journalposttype.N &&
+                !journalpost.avsenderMottaker?.navn.isNullOrBlank()
+        ) {
+            "Avsender mangler og må settes på journalposten i gosys. " +
+                "Når endringene er gjort, trykker du på \"Lagre utkast\" før du går tilbake til EF Sak og journalfører."
         }
     }
 


### PR DESCRIPTION
…vsenderMottaker, som også gjøres i dokarkiv

Koblet til feilene om at saksbehandler ikke får fullføre journalpost for skannende dokument som mangler avsender

https://github.com/navikt/dokarkiv/blob/master/journalpost/src/main/java/no/nav/dokarkiv/journalpost/v1/validators/FerdigstillJournalpostValidator.java#L124-L125