### PR TITLE
Finn siste behandlingen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -133,7 +133,7 @@ class BarnService(
         behandlingId: UUID,
         grunnlagsdataBarn: List<BarnMedIdent>
     ): List<BehandlingBarn> {
-        val forrigeBehandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsakId)
+        val forrigeBehandling = behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(fagsakId)
         feilHvis(forrigeBehandling == null) {
             "Kan ikke behandle ettersending når det ikke finnes en tidligere behandling"
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.behandling
 
 import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.dto.EksternId
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
@@ -115,13 +116,13 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         FROM behandling b
         JOIN behandling_ekstern be ON b.id = be.behandling_id
         WHERE b.fagsak_id = :fagsakId
-         AND b.resultat IN ('OPPHØRT', 'INNVILGET')
+         AND b.resultat IN (:behandlingResultater)
          AND b.status = 'FERDIGSTILT'
         ORDER BY b.opprettet_tid DESC
         LIMIT 1
     """
     )
-    fun finnSisteIverksatteBehandling(fagsakId: UUID): Behandling?
+    fun finnSisteFerdigstilteBehandlingen(fagsakId: UUID, behandlingResultater: Set<BehandlingResultat>): Behandling?
 
     @Query(
         """

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -87,7 +87,7 @@ class NyeBarnService(
         fagsakId: UUID,
         forventerAtBehandlingFinnes: Boolean = true
     ): NyeBarnData {
-        val behandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsakId)
+        val behandling = behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(fagsakId)
         if (behandling == null) {
             feilHvis(forventerAtBehandlingFinnes) {
                 "Fant ikke iverksatt eller avslått behandling for fagsak=$fagsakId"

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.behandling
 
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
-import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
@@ -91,10 +90,7 @@ class RevurderingService(
      * Skal håndtere en førstegangsbehandling som er avslått, då vi trenger en behandlingId for å kopiere data fra søknaden
      */
     private fun forrigeBehandling(revurdering: Behandling): UUID {
-        val sisteBehandling = behandlingService.hentBehandlinger(revurdering.fagsakId)
-            .filter { it.id != revurdering.id }
-            .filter { it.resultat != BehandlingResultat.HENLAGT }
-            .maxByOrNull { it.sporbar.opprettetTid }
+        val sisteBehandling = behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(revurdering.fagsakId)
         return revurdering.forrigeBehandlingId
             ?: sisteBehandling?.id
             ?: error("Revurdering må ha eksisterende iverksatt behandling")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTask.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.behandlingsflyt.task
 
-import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
@@ -23,7 +23,7 @@ class StartBehandlingTask(
     private val iverksettClient: IverksettClient,
     private val pdlClient: PdlClient,
     private val fagsakService: FagsakService,
-    private val behandlingRepository: BehandlingRepository
+    private val behandlingService: BehandlingService
 ) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
@@ -38,7 +38,7 @@ class StartBehandlingTask(
     }
 
     private fun finnesEnIverksattBehandlingFor(fagsak: Fagsak) =
-        behandlingRepository.finnSisteIverksatteBehandling(fagsak.id) != null
+        behandlingService.finnSisteIverksatteBehandling(fagsak.id) != null
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynService.kt
@@ -51,8 +51,7 @@ class BisysBarnetilsynService(
     ): EfPerioder? {
         val personIdenter = personService.hentPersonIdenter(personIdent).identer()
         val fagsak: Fagsak = fagsakService.finnFagsak(personIdenter, StønadType.BARNETILSYN) ?: return null
-        val sisteGjeldendeBehandling =
-            behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id) ?: return null
+        val sisteGjeldendeBehandling = behandlingService.finnSisteIverksatteBehandling(fagsak.id) ?: return null
         val startdato = tilkjentYtelseService.hentForBehandling(sisteGjeldendeBehandling.id).startdato
 
         val historikk = andelsHistorikkService.hentHistorikk(fagsak.id, null)

--- a/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
@@ -443,7 +443,7 @@ internal class BarnServiceTest {
 
         @BeforeEach
         internal fun setUp() {
-            every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsakId) } returns tidligereBehandling
+            every { behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(fagsakId) } returns tidligereBehandling
             every { barnRepository.findByBehandlingId(tidligereBehandling.id) } returns emptyList()
         }
 
@@ -483,7 +483,7 @@ internal class BarnServiceTest {
             assertThat(barnPåForrigeBehandling.map { it.søknadBarnId }).doesNotContainNull()
             assertThat(barnSlot.captured[0].søknadBarnId).isNull()
 
-            verify(exactly = 1) { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsakId) }
+            verify(exactly = 1) { behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(fagsakId) }
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -55,7 +55,7 @@ class NyeBarnServiceTest {
 
     @BeforeEach
     fun init() {
-        every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns behandling
+        every { behandlingService.finnSisteIverksatteEllerAvslåtteBehandling(any()) } returns behandling
         every { fagsakService.finnFagsaker(any()) } returns listOf(fagsak)
         every { grunnlagsdataMedMetadata.grunnlagsdata } returns grunnlagsdataDomene
         every { personService.hentPersonIdenter(any()) } returns PdlIdenter(listOf(PdlIdent("fnr til søker", false)))

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/StartBehandlingTaskTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.BehandlingOppsettUtil
 import no.nav.familie.ef.sak.iverksett.IverksettClient
@@ -30,6 +31,9 @@ class StartBehandlingTaskTest : OppslagSpringRunnerTest() {
     private lateinit var behandlingRepository: BehandlingRepository
 
     @Autowired
+    private lateinit var behandlingService: BehandlingService
+
+    @Autowired
     private lateinit var fagsakService: FagsakService
 
     private val iverksettClient = mockk<IverksettClient>()
@@ -48,7 +52,7 @@ class StartBehandlingTaskTest : OppslagSpringRunnerTest() {
         every { pdlClient.hentPersonidenter(personIdent, true) } returns PdlIdenter(listOf(PdlIdent(personIdent, false)))
         justRun { iverksettClient.startBehandling(capture(opprettStartBehandlingHendelseDtoSlot)) }
 
-        startBehandlingTask = StartBehandlingTask(iverksettClient, pdlClient, fagsakService, behandlingRepository)
+        startBehandlingTask = StartBehandlingTask(iverksettClient, pdlClient, fagsakService, behandlingService)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
@@ -70,7 +70,7 @@ internal class BisysBarnetilsynServiceTest {
     fun setup() {
         every { personService.hentPersonIdenter(any()) } returns PdlIdenter(listOf(PdlIdent(personident, false)))
         every { fagsakService.finnFagsak(any(), any()) } returns fagsak
-        every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns lagBehandlingerForSisteIverksatte().first()
+        every { behandlingService.finnSisteIverksatteBehandling(any()) } returns lagBehandlingerForSisteIverksatte().first()
         every { barnService.hentBehandlingBarnForBarnIder(any()) } returns behandlingBarn
         every {
             infotrygdService.hentSammenslåtteBarnetilsynPerioderFraReplika(any())

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.HENLAGT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.IKKE_SATT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.INNVILGET
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.OPPHØRT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FATTER_VEDTAK
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FERDIGSTILT
@@ -166,7 +167,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `finnSisteIverksatteBehandling - skal ikke returnere noe hvis behandlingen ikke er ferdigstilt`() {
+    fun `finnSisteFerdigstilteBehandlingen - skal ikke returnere noe hvis behandlingen ikke er ferdigstilt`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(identer = setOf(PersonIdent(ident))))
         behandlingRepository.insert(
             behandling(
@@ -175,11 +176,12 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
                 opprettetTid = LocalDateTime.now().minusDays(2)
             )
         )
-        assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)).isNull()
+        val behandlingResultater = BehandlingResultat.values().toSet()
+        assertThat(behandlingRepository.finnSisteFerdigstilteBehandlingen(fagsak.id, behandlingResultater)).isNull()
     }
 
     @Test
-    fun `finnSisteIverksatteBehandling skal finne id til siste ferdigstilte behandling`() {
+    fun `finnSisteFerdigstilteBehandlingen skal finne id til siste ferdigstilte behandling`() {
         val førstegangsbehandling = BehandlingOppsettUtil.iverksattFørstegangsbehandling
         val fagsak =
             testoppsettService.lagreFagsak(fagsak(setOf(PersonIdent("1"))).copy(id = førstegangsbehandling.fagsakId))
@@ -187,7 +189,8 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         val behandlinger = BehandlingOppsettUtil.lagBehandlingerForSisteIverksatte()
         behandlingRepository.insertAll(behandlinger)
 
-        assertThat(behandlingRepository.finnSisteIverksatteBehandling(fagsak.id)?.id)
+        val iverksattBehandlinger = setOf(INNVILGET, OPPHØRT)
+        assertThat(behandlingRepository.finnSisteFerdigstilteBehandlingen(fagsak.id, iverksattBehandlinger)?.id)
             .isEqualTo(førstegangsbehandling.id)
     }
 


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9506

Vi har 2 ulike måter for hvordan “forrige” behandling hentes
RevurderingService
```kotlin
private fun forrigeBehandling(revurdering: Behandling): UUID {
    val sisteBehandling = behandlingService.hentBehandlinger(revurdering.fagsakId)
        .filter { it.id != revurdering.id }
        .filter { it.resultat != BehandlingResultat.HENLAGT }
        .maxByOrNull { it.sporbar.opprettetTid }
```
BehandlingService (brukes for å sjekke nye barn)
```kotlin
fun finnSisteIverksatteBehandlingMedEventuellAvslått(fagsakId: UUID): Behandling? =
    behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
        ?: hentBehandlinger(fagsakId).lastOrNull {
            it.status == FERDIGSTILT && it.resultat != HENLAGT
        }
```

Her tenker jeg att det burde vare en og samme metode for disse.

I tillegg så endret jeg til å kun ha 1 spørring for denne uthenting av liknende data
```kotlin
fun finnSisteIverksatteBehandling(fagsakId: UUID) =
        behandlingRepository.finnSisteFerdigstilteBehandlingen(fagsakId, setOf(INNVILGET, OPPHØRT))

fun finnSisteIverksatteEllerAvslåtteBehandling(fagsakId: UUID): Behandling? =
        behandlingRepository.finnSisteFerdigstilteBehandlingen(fagsakId, setOf(INNVILGET, OPPHØRT, AVSLÅTT))
```

Disse testes i BehandlingServiceTest

Siste delen som ble endret er at [Bisys burde bruke den siste iverksatte behandlingen for å hente perioder for barnetilsyn](https://github.com/navikt/familie-ef-sak/commit/3dde40dc8396eb1aba96cc6452b23bcbdae3fb1c)