### PR TITLE
Barn matcher forenkling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMatcher.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMatcher.kt
@@ -14,8 +14,8 @@ object BarnMatcher {
     ): List<MatchetBehandlingBarn> {
         val grunnlagsbarnPåIdent = grunnlagsbarn.associateBy { it.personIdent }
         val behandlingBarnFnrMatchetTilPdlBarn = behandlingBarn.map {
-            val firstOrNull = grunnlagsbarnPåIdent.entries.firstOrNull { entry -> it.personIdent == entry.key }
-            MatchetBehandlingBarn(firstOrNull?.key, firstOrNull?.value, it)
+            val matchetBarnPåIdent = grunnlagsbarnPåIdent[it.personIdent]
+            MatchetBehandlingBarn(matchetBarnPåIdent?.personIdent, matchetBarnPåIdent, it)
         }
 
         val pdlBarnIkkeIBehandlingBarn =

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMatcher.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMatcher.kt
@@ -10,16 +10,16 @@ object BarnMatcher {
 
     fun kobleBehandlingBarnOgRegisterBarn(
         behandlingBarn: List<BehandlingBarn>,
-        barn: List<BarnMedIdent>
+        grunnlagsbarn: List<BarnMedIdent>
     ): List<MatchetBehandlingBarn> {
-        val barnMap = barn.associateBy { it.personIdent }
+        val grunnlagsbarnPåIdent = grunnlagsbarn.associateBy { it.personIdent }
         val behandlingBarnFnrMatchetTilPdlBarn = behandlingBarn.map {
-            val firstOrNull = barnMap.entries.firstOrNull { entry -> it.personIdent == entry.key }
+            val firstOrNull = grunnlagsbarnPåIdent.entries.firstOrNull { entry -> it.personIdent == entry.key }
             MatchetBehandlingBarn(firstOrNull?.key, firstOrNull?.value, it)
         }
 
         val pdlBarnIkkeIBehandlingBarn =
-            barnMap.filter { entry -> behandlingBarn.none { it.personIdent == entry.key } }.toMutableMap()
+            grunnlagsbarnPåIdent.filter { entry -> behandlingBarn.none { it.personIdent == entry.key } }.toMutableMap()
 
         return behandlingBarnFnrMatchetTilPdlBarn.map {
             if (it.barn != null) {


### PR DESCRIPTION
Ingen direkt endring på funksjonalitet, men liten forenkling og andre navn

```kotlin
barnMap.entries.firstOrNull { entry -> it.personIdent == entry.key }
```
blir til 
```kotlin
val matchetBarnPåFnr = grunnlagsbarnPåIdent[it.personIdent]
```