### PR TITLE
Kode for nære boforhold

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -234,6 +234,14 @@ data class Vegadresse(
     val koordinater: Koordinater?,
     val matrikkelId: Long?
 ) {
+
+    /**
+     * Norge er delt i tre UTM-soner (32, 33 og 35) - men PDL returnerer ikke hvilken sone et koordinat tilhører
+     * Pga dette vil det være vanskelig å sammenligne x-verdi på tvers av soner. Grensen mellom 32 og 33 ligger på ca 7 200 000
+     * og alt sør for dette kan avstandsberegnes med både x- og y-koordinater. Nord for dette gjør vi ren avstandsberegning på
+     * y-koordinater inntil vi evt får riktig UTM-sone i datagrunnlaget.
+     */
+    val UTM_GRENSE = 7_200_000
     fun fjerneBoforhold(annenVegadresse: Vegadresse?): Boolean {
         if (this.koordinater == null || annenVegadresse?.koordinater == null) {
             return false
@@ -246,7 +254,7 @@ data class Vegadresse(
             return false
         }
 
-        if (koordinater1.y > 7_200_000 || koordinater2.y > 7_200_000) {
+        if (koordinater1.y > UTM_GRENSE || koordinater2.y > UTM_GRENSE) {
             return abs(koordinater2.y - koordinater1.y) > 1000
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.lang.Math.abs
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.math.sqrt
 
 data class PdlResponse<T>(
     val data: T,
@@ -231,7 +233,35 @@ data class Vegadresse(
     val postnummer: String?,
     val koordinater: Koordinater?,
     val matrikkelId: Long?
-)
+) {
+    fun fjerneBoforhold(annenVegadresse: Vegadresse?): Boolean {
+        if (this.koordinater == null || annenVegadresse?.koordinater == null) {
+            return false
+        }
+
+        val koordinater1 = this.koordinater
+        val koordinater2 = annenVegadresse.koordinater
+
+        if (koordinater1.x == null || koordinater1.y == null || koordinater2.x == null || koordinater2.y == null) {
+            return false
+        }
+
+        if (koordinater1.y > 7_200_000 || koordinater2.y > 7_200_000) {
+            return abs(koordinater2.y - koordinater1.y) > 1000
+        }
+
+        return beregnAvstandIMeter(koordinater1.x, koordinater1.y, koordinater2.x, koordinater2.y) > 1000
+    }
+
+    private fun beregnAvstandIMeter(xKoordinat1: Float, yKoordinat1: Float, xKoordinat2: Float, yKoordinat2: Float): Float {
+        return abs(
+            sqrt(
+                (xKoordinat1 - xKoordinat2) * (xKoordinat1 - xKoordinat2) +
+                    (yKoordinat1 - yKoordinat2) * (yKoordinat1 - yKoordinat2)
+            )
+        )
+    }
+}
 
 data class UkjentBosted(val bostedskommune: String?)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -262,11 +262,9 @@ data class Vegadresse(
     }
 
     private fun beregnAvstandIMeter(xKoordinat1: Float, yKoordinat1: Float, xKoordinat2: Float, yKoordinat2: Float): Float {
-        return abs(
-            sqrt(
-                (xKoordinat1 - xKoordinat2) * (xKoordinat1 - xKoordinat2) +
-                    (yKoordinat1 - yKoordinat2) * (yKoordinat1 - yKoordinat2)
-            )
+        return sqrt(
+            (xKoordinat1 - xKoordinat2) * (xKoordinat1 - xKoordinat2) +
+                (yKoordinat1 - yKoordinat2) * (yKoordinat1 - yKoordinat2)
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -242,6 +242,7 @@ data class Vegadresse(
      * y-koordinater inntil vi evt får riktig UTM-sone i datagrunnlaget.
      */
     val UTM_GRENSE = 7_200_000
+    val MINIMUM_AVSTAND_FOR_AUTOMATISK_BEREGNING_I_METER = 1000
     fun fjerneBoforhold(annenVegadresse: Vegadresse?): Boolean {
         if (this.koordinater == null || annenVegadresse?.koordinater == null) {
             return false
@@ -254,11 +255,12 @@ data class Vegadresse(
             return false
         }
 
+
         if (koordinater1.y > UTM_GRENSE || koordinater2.y > UTM_GRENSE) {
-            return abs(koordinater2.y - koordinater1.y) > 1000
+            return abs(koordinater2.y - koordinater1.y) > MINIMUM_AVSTAND_FOR_AUTOMATISK_BEREGNING_I_METER
         }
 
-        return beregnAvstandIMeter(koordinater1.x, koordinater1.y, koordinater2.x, koordinater2.y) > 1000
+        return beregnAvstandIMeter(koordinater1.x, koordinater1.y, koordinater2.x, koordinater2.y) > MINIMUM_AVSTAND_FOR_AUTOMATISK_BEREGNING_I_METER
     }
 
     private fun beregnAvstandIMeter(xKoordinat1: Float, yKoordinat1: Float, xKoordinat2: Float, yKoordinat2: Float): Float {

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -255,7 +255,6 @@ data class Vegadresse(
             return false
         }
 
-
         if (koordinater1.y > UTM_GRENSE || koordinater2.y > UTM_GRENSE) {
             return abs(koordinater2.y - koordinater1.y) > MINIMUM_AVSTAND_FOR_AUTOMATISK_BEREGNING_I_METER
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -47,7 +47,8 @@ data class AnnenForelderDto(
     val bosattINorge: Boolean?,
     val land: String?,
     val dødsfall: LocalDate? = null,
-    val tidligereVedtaksperioder: TidligereVedtaksperioderDto? = null
+    val tidligereVedtaksperioder: TidligereVedtaksperioderDto? = null,
+    val langAvstandTilSøker: LangAvstandTilSøker?
 )
 
 data class BarnepassDto(
@@ -64,3 +65,8 @@ data class BarnepassordningDto(
     val til: LocalDate,
     val beløp: Int
 )
+
+enum class LangAvstandTilSøker {
+    JA,
+    UKJENT
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.InnflyttingTilN
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.KjønnType
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Kontaktadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.KontaktadresseType
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Koordinater
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.MotpartsRolle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Navn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Opphold
@@ -232,7 +233,7 @@ class PdlClientConfig {
         private fun annenForelder(): PdlAnnenForelder =
             PdlAnnenForelder(
                 adressebeskyttelse = emptyList(),
-                bostedsadresse = bostedsadresse(),
+                bostedsadresse = bostedsadresse(Koordinater(x = 598845f, y = 6643333f, z = null, kvalitet = null)),
                 dødsfall = listOf(Dødsfall(LocalDate.of(2021, 9, 22))),
                 fødsel = listOf(fødsel(1994, 11, 1)),
                 navn = listOf(Navn("Bob", "", "Burger", metadataGjeldende)),
@@ -323,8 +324,8 @@ class PdlClientConfig {
                     omraader = listOf()
                 )
             )
-
-        private fun bostedsadresse(): List<Bostedsadresse> =
+        val defaultKoordinater = Koordinater(x = 601372f, y = 6629367f, z = null, kvalitet = null)
+        private fun bostedsadresse(koordinater: Koordinater = defaultKoordinater): List<Bostedsadresse> =
             listOf(
                 Bostedsadresse(
                     angittFlyttedato = startdato.plusDays(1),
@@ -332,14 +333,14 @@ class PdlClientConfig {
                     gyldigTilOgMed = LocalDate.of(2199, 1, 1),
                     utenlandskAdresse = null,
                     coAdressenavn = "CONAVN",
-                    vegadresse = vegadresse(),
+                    vegadresse = vegadresse(koordinater),
                     ukjentBosted = null,
                     matrikkeladresse = null,
                     metadata = metadataGjeldende
                 )
             )
 
-        private fun vegadresse(): Vegadresse =
+        private fun vegadresse(koordinater: Koordinater = defaultKoordinater): Vegadresse =
             Vegadresse(
                 husnummer = "13",
                 husbokstav = "b",
@@ -348,7 +349,7 @@ class PdlClientConfig {
                 postnummer = "0575",
                 bruksenhetsnummer = "",
                 tilleggsnavn = null,
-                koordinater = null,
+                koordinater = koordinater,
                 matrikkelId = 0
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/klage/KlageServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/klage/KlageServiceTest.kt
@@ -232,7 +232,5 @@ internal class KlageServiceTest {
 
             assertThat(feil.feil).isEqualTo("Finner ikke behandlende enhet for personen")
         }
-
-
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -7,7 +7,7 @@ object PdlTestdata {
 
     private val metadataGjeldende = Metadata(false)
 
-    private val vegadresse = Vegadresse(
+    val vegadresse = Vegadresse(
         "",
         "",
         "",

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/VegadresseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/VegadresseTest.kt
@@ -1,0 +1,73 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class VegadresseTest {
+
+    @Test
+    fun avstandTilAnnenAdresse() {
+        val avstandTilAnnenAdresse =
+            PdlTestdata.vegadresse.fjerneBoforhold(
+                PdlTestdata.vegadresse.copy(
+                    koordinater = Koordinater(
+                        4f,
+                        5f,
+                        null,
+                        null
+                    )
+                )
+            )
+
+        assertThat(avstandTilAnnenAdresse).isFalse()
+    }
+
+    @Test
+    fun avstandTilAnnenAdresse2() {
+        val motzfeldtsgate = PdlTestdata.vegadresse.copy(
+            koordinater = Koordinater(
+                598845f,
+                6643333f,
+                null,
+                null
+            )
+        )
+        val sofiemyr = PdlTestdata.vegadresse.copy(
+            koordinater = Koordinater(
+                601372f,
+                6629367f,
+                null,
+                null
+            )
+        )
+        val avstandTilAnnenAdresse =
+            motzfeldtsgate.fjerneBoforhold(sofiemyr)
+
+        assertThat(avstandTilAnnenAdresse).isTrue()
+    }
+
+    @Test
+    fun avstandTilAnnenAdresse3() {
+        val kirkenes = PdlTestdata.vegadresse.copy(
+            koordinater = Koordinater(
+                615386.4f,
+                7734094.9f,
+                null,
+                null
+            )
+        )
+
+        val sofiemyr = PdlTestdata.vegadresse.copy(
+            koordinater = Koordinater(
+                601372f,
+                6629367f,
+                null,
+                null
+            )
+        )
+        val avstandTilAnnenAdresse =
+            kirkenes.fjerneBoforhold(sofiemyr)
+
+        assertThat(avstandTilAnnenAdresse).isTrue()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/VegadresseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/VegadresseTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 internal class VegadresseTest {
 
     @Test
-    fun avstandTilAnnenAdresse() {
+    fun `returner false når avstand til annen adresse er mindre enn minimumsavstand for automatisk behandling`() {
         val avstandTilAnnenAdresse =
             PdlTestdata.vegadresse.fjerneBoforhold(
                 PdlTestdata.vegadresse.copy(
@@ -19,11 +19,11 @@ internal class VegadresseTest {
                 )
             )
 
-        assertThat(avstandTilAnnenAdresse).isFalse()
+        assertThat(avstandTilAnnenAdresse).isFalse
     }
 
     @Test
-    fun avstandTilAnnenAdresse2() {
+    fun `returner true når avstand til annen adresse er lenger enn minimumsavstand for automatisk behandling, sjekk Motzfeldts Gate og Sofiemyr`() {
         val motzfeldtsgate = PdlTestdata.vegadresse.copy(
             koordinater = Koordinater(
                 598845f,
@@ -43,11 +43,11 @@ internal class VegadresseTest {
         val avstandTilAnnenAdresse =
             motzfeldtsgate.fjerneBoforhold(sofiemyr)
 
-        assertThat(avstandTilAnnenAdresse).isTrue()
+        assertThat(avstandTilAnnenAdresse).isTrue
     }
 
     @Test
-    fun avstandTilAnnenAdresse3() {
+    fun `returner true når avstand til annen adresse er lenger enn minimumsavstand for automatisk behandling, sjekk Sofiemyr og Kirkenes`() {
         val kirkenes = PdlTestdata.vegadresse.copy(
             koordinater = Koordinater(
                 615386.4f,


### PR DESCRIPTION
Kan kalkulere alt i UTM-sone 32 med riktige verdier. Nord for dette krever vi avstand i nord-retningen på 1000 meter for at det skal bli ☑️