### PR TITLE
Oppfølgingsoppgaver for behandlinger med andeler med 0-beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepository.kt
@@ -25,8 +25,7 @@ interface GjeldendeBarnRepository :
             JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
             WHERE ty.id = aty.tilkjent_ytelse 
             AND ty.behandling_id = b.id
-          AND aty.stonad_tom >= :dato
-          AND aty.belop > 0)
+          AND aty.stonad_tom >= :dato)
         """
     )
     fun finnBarnAvGjeldendeIverksatteBehandlinger(stønadstype: StønadType, dato: LocalDate): List<BarnTilUtplukkForOppgave>
@@ -44,8 +43,7 @@ interface GjeldendeBarnRepository :
                      JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
                     WHERE ty.id = aty.tilkjent_ytelse
                      AND ty.behandling_id = b.id
-                     AND aty.stonad_tom >= :dato
-                     AND aty.belop > 0)
+                     AND aty.stonad_tom >= :dato)
          AND b.migrert = TRUE
     """
     )

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/GjeldendeBarnRepositoryTest.kt
@@ -73,7 +73,7 @@ class GjeldendeBarnRepositoryTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    internal fun `finnBarnAvGjeldendeIverksatteBehandlinger med fremtidig andel med null i inntekt, forvent ingen treff `() {
+    internal fun `finnBarnAvGjeldendeIverksatteBehandlinger med fremtidig andel med null i inntekt, forvent treff `() {
         val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf("12345678910"))))
 
         val behandlingMedFremtidigAndel = lagreInnvilgetBehandling(fagsak)
@@ -83,7 +83,7 @@ class GjeldendeBarnRepositoryTest : OppslagSpringRunnerTest() {
         barnRepository.insertAll(listOf(barn(behandlingId = behandlingMedFremtidigAndel.id)))
 
         val barnForUtplukk = finnBarnAvGjeldendeIverksatteBehandlinger()
-        assertThat(barnForUtplukk.size).isEqualTo(0)
+        assertThat(barnForUtplukk.size).isEqualTo(1)
     }
 
     @Test


### PR DESCRIPTION
Det har blitt etterlyst noen oppgaver som skulle vært opprettet på barn som har fylt 6 mnd og 1 år. Det viste seg at det ikke har blitt opprettet oppgaver dersom noen har kun andeler med 0-beløp. Ifølge Mirja var det interessant å få oppgaver selv om alle andeler har beløp 0.