### PR TITLE
Inbound outbound klage lokal

### DIFF
--- a/.deploy/azure-ad-app-lokal.yaml
+++ b/.deploy/azure-ad-app-lokal.yaml
@@ -21,6 +21,9 @@ spec:
     - application: familie-prosessering-lokal
       cluster: dev-gcp
       namespace: teamfamilie
+    - application: familie-klage-lokal
+      cluster: dev-gcp
+      namespace: teamfamilie
   tenant: trygdeetaten.no
   secretName: azuread-familie-ef-sak-lokal
   claims:

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -57,7 +57,6 @@ spec:
         - application: familie-ef-sak-frontend-lokal
         - application: familie-ef-mottak
         - application: familie-klage
-        - application: familie-klage-lokal
         - application: familie-ef-proxy
           namespace: teamfamilie
           cluster: dev-fss
@@ -72,7 +71,6 @@ spec:
       rules:
         - application: familie-tilbake
         - application: familie-klage
-        - application: familie-klage-lokal
         - application: familie-brev
         - application: familie-ef-blankett
         - application: familie-ef-iverksett

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -56,6 +56,8 @@ spec:
         - application: familie-prosessering-lokal
         - application: familie-ef-sak-frontend-lokal
         - application: familie-ef-mottak
+        - application: familie-klage
+        - application: familie-klage-lokal
         - application: familie-ef-proxy
           namespace: teamfamilie
           cluster: dev-fss
@@ -70,6 +72,7 @@ spec:
       rules:
         - application: familie-tilbake
         - application: familie-klage
+        - application: familie-klage-lokal
         - application: familie-brev
         - application: familie-ef-blankett
         - application: familie-ef-iverksett

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -53,6 +53,7 @@ spec:
       rules:
         - application: familie-ef-sak-frontend
         - application: familie-prosessering
+        - application: familie-klage
         - application: familie-ef-personhendelse
         - application: familie-ef-mottak
         - application: familie-ef-proxy

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -31,7 +31,7 @@ fun main(args: Array<String>) {
             "mock-brev",
             "mock-dokument",
             "mock-tilbakekreving",
-            "mock-klage"
+            // "mock-klage"
         )
         .properties(properties)
         .run(*args)

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -31,7 +31,7 @@ fun main(args: Array<String>) {
             "mock-brev",
             "mock-dokument",
             "mock-tilbakekreving",
-            // "mock-klage"
+            "mock-klage"
         )
         .properties(properties)
         .run(*args)

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -26,6 +26,7 @@ FAMILIE_BLANKETT_API_URL: http://localhost:8033
 FAMILIE_EF_IVERKSETT_URL: http://localhost:8094
 FAMILIE_EF_PROXY_URL: http://localhost:8002
 FAMILIE_DOKUMENT_URL: http://localhost:8082
+FAMILIE_KLAGE_URL: http://localhost:8094
 
 AZURE_APP_TENANT_ID: navq.onmicrosoft.com
 

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -23,7 +23,7 @@ FAMILIE_INTEGRASJONER_URL: http://localhost:8385
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087
 FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BLANKETT_API_URL: http://localhost:8033
-FAMILIE_EF_IVERKSETT_URL: http://localhost:8094
+#FAMILIE_EF_IVERKSETT_URL: http://localhost:8094
 FAMILIE_EF_PROXY_URL: http://localhost:8002
 FAMILIE_DOKUMENT_URL: http://localhost:8082
 FAMILIE_KLAGE_URL: http://localhost:8094

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -23,7 +23,7 @@ FAMILIE_INTEGRASJONER_URL: http://localhost:8385
 FAMILIE_OPPDRAG_API_URL: http://localhost:8087
 FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BLANKETT_API_URL: http://localhost:8033
-#FAMILIE_EF_IVERKSETT_URL: http://localhost:8094
+#FAMILIE_EF_IVERKSETT_URL: http://localhost:8094 # Fordi iverksett og klage er på samme url/port lokalt så må vi kommentere ut den av de vi ikke vil kjøre opp mot lokalt
 FAMILIE_EF_PROXY_URL: http://localhost:8002
 FAMILIE_DOKUMENT_URL: http://localhost:8082
 FAMILIE_KLAGE_URL: http://localhost:8094


### PR DESCRIPTION
Fungerer kun å kjøre lokalt dersom #FAMILIE_EF_IVERKSETT_URL: http://localhost:8094 er kommentert ut. 

Vi får vurdere å bytte port på en av appene dersom vi har behov for begge. Akkurat nå tenker jeg vi kan åpne for å kjøre klage?  