### PR TITLE
Definerer eksplisitt dei query-params som faktisk blir sendt inn for finnMappeRequest

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -99,7 +99,8 @@ class OppgaveClient(
     fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
         val uri = UriComponentsBuilder.fromUri(oppgaveUri)
             .pathSegment("mappe", "sok")
-            .queryParams(finnMappeRequest.toQueryParams())
+            .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
+            .queryParam("limit", finnMappeRequest.limit)
             .build()
             .toUri()
         val respons = getForEntity<Ressurs<FinnMappeResponseDto>>(uri)

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -9,7 +9,6 @@ import no.nav.familie.ef.sak.infrastruktur.http.AbstractPingableRestWebClient
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.getDataOrThrow
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
@@ -96,11 +95,11 @@ class OppgaveClient(
         return response.getDataOrThrow().oppgaveId
     }
 
-    fun finnMapper(finnMappeRequest: FinnMappeRequest): FinnMappeResponseDto {
+    fun finnMapper(enhetsnummer: String, limit: Int): FinnMappeResponseDto {
         val uri = UriComponentsBuilder.fromUri(oppgaveUri)
             .pathSegment("mappe", "sok")
-            .queryParam("enhetsnr", finnMappeRequest.enhetsnr)
-            .queryParam("limit", finnMappeRequest.limit)
+            .queryParam("enhetsnr", enhetsnummer)
+            .queryParam("limit", limit)
             .build()
             .toUri()
         val respons = getForEntity<Ressurs<FinnMappeResponseDto>>(uri)

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -10,7 +10,6 @@ import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.ef.StønadType
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
@@ -138,13 +137,7 @@ class OppgaveService(
     }
 
     fun finnHendelseMappeId(enhetsnummer: String): Long? {
-        val finnMappeRequest = FinnMappeRequest(
-            listOf(),
-            enhetsnummer,
-            null,
-            1000
-        )
-        val mapperResponse = oppgaveClient.finnMapper(finnMappeRequest)
+        val mapperResponse = oppgaveClient.finnMapper(enhetsnummer, 1000)
         val mappe = mapperResponse.mapper.find {
             it.navn.contains("62 Hendelser") && !it.navn.contains("EF Sak")
         }
@@ -282,12 +275,8 @@ class OppgaveService(
         return cacheManager.getValue("oppgave-mappe", enhet) {
             logger.info("Henter mapper på nytt")
             val mappeRespons = oppgaveClient.finnMapper(
-                FinnMappeRequest(
-                    tema = listOf(),
-                    enhetsnr = enhet,
-                    opprettetFom = null,
+                    enhetsnummer = enhet,
                     limit = 1000
-                )
             )
             if (mappeRespons.antallTreffTotalt > mappeRespons.mapper.size) {
                 logger.error(

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
@@ -5,7 +5,6 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.oppgave.OppgaveClient
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
-import no.nav.familie.kontrakter.felles.oppgave.FinnMappeRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnMappeResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
@@ -52,9 +51,9 @@ class OppgaveClientMock {
             oppgaver[oppgaveId] ?: error("Finner ikke oppgave med oppgaveId=$oppgaveId")
         }
 
-        every { oppgaveClient.finnMapper(any()) } answers {
-            val mappeRequest: FinnMappeRequest = firstArg()
-            if (mappeRequest.enhetsnr == "4489") {
+        every { oppgaveClient.finnMapper(any(), any()) } answers {
+            val enhetsnr = firstArg<String>()
+            if (enhetsnr == "4489") {
                 FinnMappeResponseDto(
                     antallTreffTotalt = 2,
                     mapper = listOf(
@@ -85,7 +84,7 @@ class OppgaveClientMock {
                         )
                     )
                 )
-            } else if (mappeRequest.enhetsnr == "4483") {
+            } else if (enhetsnr == "4483") {
                 FinnMappeResponseDto(
                     antallTreffTotalt = 2,
                     mapper = listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -268,9 +268,9 @@ internal class OppgaveServiceTest {
         oppgaveService.finnMapper("4489")
         oppgaveService.finnMapper("4489")
 
-        verify(exactly = 1) { oppgaveClient.finnMapper(any()) }
+        verify(exactly = 1) { oppgaveClient.finnMapper(any(), any()) }
         oppgaveService.finnMapper("4483")
-        verify(exactly = 2) { oppgaveClient.finnMapper(any()) }
+        verify(exactly = 2) { oppgaveClient.finnMapper(any(), any()) }
     }
 
     @Test
@@ -281,7 +281,7 @@ internal class OppgaveServiceTest {
         oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
         oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
 
-        verify(exactly = 1) { oppgaveClient.finnMapper(any()) }
+        verify(exactly = 1) { oppgaveClient.finnMapper(any(), any()) }
     }
 
     @Test

--- a/src/test/resources/json/simuleringsresultat_beriket.json
+++ b/src/test/resources/json/simuleringsresultat_beriket.json
@@ -415,7 +415,7 @@
       }
     ],
     "fomDatoNestePeriode": null,
-    "etterbetaling": 10,
+    "etterbetaling": 0,
     "feilutbetaling": 0,
     "fom": "2021-02-01",
     "tomDatoNestePeriode": null,


### PR DESCRIPTION
Tilretteleggjing for å fjerne toQueryParams-metoden, som fører med seg mykje unødig kompleksitet

Legg til rette for https://github.com/navikt/familie-kontrakter/pull/684