### PR TITLE
Vil oppdatere max-satser for barnetilsyn for 2023 som nå er vedtatt.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -31,7 +31,11 @@ object BeregningBarnetilsynUtil {
     val satserForBarnetilsyn: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
-                Datoperiode(LocalDate.of(2022, 1, 1), LocalDate.MAX),
+                Datoperiode(LocalDate.of(2023, 1, 1), LocalDate.MAX),
+                maxbeløp = mapOf(1 to 4369, 2 to 5700, 3 to 6460)
+            ),
+            MaxbeløpBarnetilsynSats(
+                Datoperiode(YearMonth.of(2022, 1), YearMonth.of(2022, 12)),
                 maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
             )
         ) + eldreBarnetilsynsatser

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -19,6 +19,10 @@ object BeregningBarnetilsynUtil {
     private val eldreBarnetilsynsatser: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
+                Datoperiode(YearMonth.of(2022, 1), YearMonth.of(2022, 12)),
+                maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
+            ),
+            MaxbeløpBarnetilsynSats(
                 Datoperiode(YearMonth.of(2021, 1), YearMonth.of(2021, 12)),
                 maxbeløp = mapOf(1 to 4195, 2 to 5474, 3 to 6203)
             ),
@@ -33,10 +37,6 @@ object BeregningBarnetilsynUtil {
             MaxbeløpBarnetilsynSats(
                 Datoperiode(LocalDate.of(2023, 1, 1), LocalDate.MAX),
                 maxbeløp = mapOf(1 to 4369, 2 to 5700, 3 to 6460)
-            ),
-            MaxbeløpBarnetilsynSats(
-                Datoperiode(YearMonth.of(2022, 1), YearMonth.of(2022, 12)),
-                maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
             )
         ) + eldreBarnetilsynsatser
 
@@ -45,10 +45,6 @@ object BeregningBarnetilsynUtil {
             MaxbeløpBarnetilsynSats(
                 Datoperiode(LocalDate.of(2023, 1, 1), LocalDate.MAX),
                 maxbeløp = mapOf(1 to 4369, 2 to 5700, 3 to 6460)
-            ),
-            MaxbeløpBarnetilsynSats(
-                Datoperiode(YearMonth.of(2022, 1), YearMonth.of(2022, 12)),
-                maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
             )
         ) + eldreBarnetilsynsatser
 


### PR DESCRIPTION
Vil ta i bruk nye max-satser for barnetilsyn. Nye maxsatser vil da bli brukt for alle nye vedtak med perioder i 2023 -> 

Skal ikke merges før vi har tatt ut rapport på gamle saker med innvilget barnetilsyn som treffer maxsats i januar 2023. Disse sakene må satsreguleres før januar. 

Nye max-satser står i Favro-oppgaven: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7888