### PR TITLE
Gammel sats som ikke-vedtatt for testing i preprod (er togglet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,6 @@ Testbrukeren som opprettes i IDA må ha minst en av følgende roller:
 
 ## Testdata
 - Registering av arbeidssøker - https://arbeidssokerregistrering.dev.nav.no/
-  
+
+## Manuell vedlikehold
+[Satsendring barnetilsyn](doc/BarnetilsynSatsendring_README.md)

--- a/doc/BarnetilsynSatsendring_README.md
+++ b/doc/BarnetilsynSatsendring_README.md
@@ -1,0 +1,45 @@
+#Satsendringsrutine - barnetilsyn
+
+## Finn mulige fagsaker som er berørt av nye maks-satser
+SQL: 
+```sql
+SELECT  gib.fagsak_id, v.*, gib.id behandling_id, v.behandling_id behandling_id_for_vedtak, v.barnetilsyn
+FROM gjeldende_iverksatte_behandlinger gib
+JOIN tilkjent_ytelse ty ON ty.behandling_id = gib.id
+JOIN andel_tilkjent_ytelse aty ON ty.id = aty.tilkjent_ytelse
+JOIN vedtak v ON v.behandling_id = aty.kilde_behandling_id
+WHERE aty.stonad_tom >= '<år som satsendres>-01-01' 
+AND gib.stonadstype = 'BARNETILSYN' 
+AND aty.belop IN (<gammel sats for 1 barn>, <gammel sats for 2 barn>, <gammel sats for 3 eller flere barn>);
+```
+Det er verdt å merke seg at spørringen finner bare alle andeler med likt beløp som makssatser, og tar ikke hensyn til antall barn. 
+Dermed er det en sjanse for at det f.eks. gis match på en som treffer makssats for 1 barn, selv om det er en behandling med to barn.
+Spørringen egner seg derfor ikke til automatisering, og må forbedres dersom før den eventuelt brukes i en automatisert rutine.
+
+Det er laget en scheduler `BarnetilsynSatsendringScheduler` som oppretter task av type `barnetilsynSatsendring` hvis den ikke finnes fra før. 
+Scheduleren er ikke skrudd på nå, kommenter inn @Scheduled-annotasjonen i `BarnetilsynSatsendringScheduler`
+Når tasken kjører så kaller den på en service som logger fagsakIds som skal satsendres. Tasken kan rekjøres fra prosessering ved behov.
+(Potensiell forbedring: Legg til knapp i prosessering som kaller endepunkt i ef-sak som logger satsendringskandidatene.)
+
+## Ikke-vedtatte satser
+Det ble testet med egne ikke-vedtatte satser i preprod og lokalt.
+
+## Gjennomføringsrutine
+Ta ut rapport med de som må satsjusteres. Det er brukere som treffer maks-sats på barnetilsyn i perioden med ny sats.
+Deploy versjon med nye og gjeldende satser slik at alle behandlinger som gjøres fra nå, blir riktig i perioder med nye satser. Best at det skjer rett etter pkt 1.
+Før vi deployer ny sats sjekker vi behandlinger som er i pipeline (ikke ennå besluttet) - dersom det er noen av disse som burde beregnes på nytt, må man følge opp disse sakene. Se SQL under.
+Det kan potensielt bli feil dersom det lagres andre beløp på vedtak enn det saksbehandler har sett ved beregning. Feil i brev?
+
+Gjennomfør manuell revurdering type satsendring før utbetaling i januar, sammen med saksbehandlere.
+
+
+```sql
+SELECT b.id, v.barnetilsyn, aty.* FROM fagsak f
+JOIN behandling b ON f.id=b.fagsak_id
+JOIN tilkjent_ytelse ty ON b.id = ty.behandling_id
+JOIN andel_tilkjent_ytelse aty ON aty.tilkjent_ytelse=ty.id
+JOIN vedtak v ON v.behandling_id = b.id
+WHERE stonadstype='BARNETILSYN' AND status != 'FERDIGSTILT';
+```
+
+PS: Sjekk antall som treffer max-sats for januar neste år i oktober, slik at man eventuelt har tid til å implementere en automatisk revurdering med satsendring som årsak.

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -40,11 +40,11 @@ object BeregningBarnetilsynUtil {
             )
         ) + eldreBarnetilsynsatser
 
-    val ikkeVedtatteSatserForBarnetilsyn: List<MaxbeløpBarnetilsynSats> =
+    val ikkeGjeldendeSatserForBarnetilsyn: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
-                Datoperiode(LocalDate.of(2023, 1, 1), LocalDate.MAX),
-                maxbeløp = mapOf(1 to 4369, 2 to 5700, 3 to 6460)
+                Datoperiode(LocalDate.of(2022, 1, 1), LocalDate.MAX),
+                maxbeløp = mapOf(1 to 4250, 2 to 5700, 3 to 6460)
             )
         ) + eldreBarnetilsynsatser
 
@@ -94,7 +94,7 @@ object BeregningBarnetilsynUtil {
             kalkulerUtbetalingsbeløpFørFratrekkOgSatsjustering(periodeutgift, kontantstøtteBeløp)
 
         val maxSatsBeløp = when (brukIkkeVedtatteSatser) {
-            true -> ikkeVedtatteSatserForBarnetilsyn.hentSatsFor(antallBarn, årMåned).toBigDecimal()
+            true -> ikkeGjeldendeSatserForBarnetilsyn.hentSatsFor(antallBarn, årMåned).toBigDecimal()
             false -> satserForBarnetilsyn.hentSatsFor(antallBarn, årMåned).toBigDecimal()
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -44,7 +44,7 @@ object BeregningBarnetilsynUtil {
         listOf(
             MaxbeløpBarnetilsynSats(
                 Datoperiode(LocalDate.of(2022, 1, 1), LocalDate.MAX),
-                maxbeløp = mapOf(1 to 4250, 2 to 5700, 3 to 6460)
+                maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
             )
         ) + eldreBarnetilsynsatser
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -46,7 +46,7 @@ object BeregningBarnetilsynUtil {
                 Datoperiode(LocalDate.of(2022, 1, 1), LocalDate.MAX),
                 maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284)
             )
-        ) + eldreBarnetilsynsatser
+        ) + eldreBarnetilsynsatser.filter { !it.periode.inneholder(LocalDate.of(2022, 1, 1)) }
 
     fun lagBeløpsPeriodeBarnetilsyn(
         utgiftsperiode: UtgiftsMåned,

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.beregning.barnetilsyn.satsendring
 
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
-import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import kotlin.random.Random
 
@@ -12,9 +11,8 @@ class BarnetilsynSatsendringScheduler(val barnetilsynSatsendringService: Barneti
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) // TODO Slettes
+    // @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) //Kjører ved oppstart av app
     fun opprettTask() {
-        logger.info("Oppretter satsendring-task")
         Thread.sleep(Random.nextLong(5_000)) // YOLO unngå feil med att 2 noder
         barnetilsynSatsendringService.opprettTask()
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
@@ -98,6 +98,7 @@ class BarnetilsynSatsendringService(
     fun opprettTask() {
         val finnesTask = taskService.finnTaskMedPayloadOgType("barnetilsynSatsendring", BarnetilsynSatsendringTask.TYPE)
         if (finnesTask == null) {
+            logger.info("Oppretter satsendring-task, da den ikke finnes fra før")
             val task = BarnetilsynSatsendringTask.opprettTask()
             taskService.save(task)
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlSjekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlSjekkController.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakService.kt
@@ -44,7 +44,7 @@ class KopierVedtakService(
     }
 
     fun mapTilBarnetilsynVedtak(fagsakId: UUID, behandlingBarn: List<BehandlingBarn>, forrigeBehandlingId: UUID): VedtakDto {
-        val fraDato = BeregningBarnetilsynUtil.ikkeGjeldendeSatserForBarnetilsyn.maxOf { it.periode.fom }
+        val fraDato = BeregningBarnetilsynUtil.satserForBarnetilsyn.maxOf { it.periode.fom }
         val historikk = vedtakHistorikkService.hentAktivHistorikk(fagsakId).fraDato(YearMonth.from(fraDato))
 
         return InnvilgelseBarnetilsyn(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakService.kt
@@ -44,7 +44,7 @@ class KopierVedtakService(
     }
 
     fun mapTilBarnetilsynVedtak(fagsakId: UUID, behandlingBarn: List<BehandlingBarn>, forrigeBehandlingId: UUID): VedtakDto {
-        val fraDato = BeregningBarnetilsynUtil.ikkeVedtatteSatserForBarnetilsyn.maxOf { it.periode.fom }
+        val fraDato = BeregningBarnetilsynUtil.ikkeGjeldendeSatserForBarnetilsyn.maxOf { it.periode.fom }
         val historikk = vedtakHistorikkService.hentAktivHistorikk(fagsakId).fraDato(YearMonth.from(fraDato))
 
         return InnvilgelseBarnetilsyn(

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningBarnetilsynUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningBarnetilsynUtilKtTest.kt
@@ -11,14 +11,13 @@ internal class BeregningBarnetilsynUtilKtTest {
     @Test
     fun `hente riktig sats for 0, 1,2,3,4 barn for år 20, 22 og 23`() {
         // 2023 = mapOf(1 to 4369, 2 to 5700, 3 to 6460)
-        /*
         val år2023 = YearMonth.of(2023, 1)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 4, årMåned = år2023)).isEqualTo(6460)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 3, årMåned = år2023)).isEqualTo(6460)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 2, årMåned = år2023)).isEqualTo(5700)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 1, årMåned = år2023)).isEqualTo(4369)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 0, årMåned = år2023)).isEqualTo(0)
-        */
+
         // 2022 = mapOf(1 to 4250, 2 to 5545, 3 to 6284)),
         val år2022 = YearMonth.of(2022, 1)
         assertThat(satserForBarnetilsyn.hentSatsFor(antallBarn = 4, årMåned = år2022)).isEqualTo(6284)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakServiceTest.kt
@@ -67,7 +67,7 @@ internal class KopierVedtakServiceTest {
         fødselTermindato = LocalDate.now()
     )
 
-    val forventetFomYearMonth = YearMonth.from(BeregningBarnetilsynUtil.ikkeVedtatteSatserForBarnetilsyn.maxOf { it.periode.fom })
+    val forventetFomYearMonth = YearMonth.from(BeregningBarnetilsynUtil.ikkeGjeldendeSatserForBarnetilsyn.maxOf { it.periode.fom })
     val førsteAndelFraOgMedDato = forventetFomYearMonth.minusMonths(2)
     val førsteAndelTilOgMedDato = forventetFomYearMonth.plusMonths(6)
     val andreAndelFraOgMed = førsteAndelTilOgMedDato.plusMonths(1)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/KopierVedtakServiceTest.kt
@@ -67,7 +67,7 @@ internal class KopierVedtakServiceTest {
         fødselTermindato = LocalDate.now()
     )
 
-    val forventetFomYearMonth = YearMonth.from(BeregningBarnetilsynUtil.ikkeGjeldendeSatserForBarnetilsyn.maxOf { it.periode.fom })
+    val forventetFomYearMonth = YearMonth.from(BeregningBarnetilsynUtil.satserForBarnetilsyn.maxOf { it.periode.fom })
     val førsteAndelFraOgMedDato = forventetFomYearMonth.minusMonths(2)
     val førsteAndelTilOgMedDato = forventetFomYearMonth.plusMonths(6)
     val andreAndelFraOgMed = førsteAndelTilOgMedDato.plusMonths(1)


### PR DESCRIPTION
Før det skal kjøres manuelle satsendringer i prod må det testes litt, og lages test caser som er virkelighetsnære med gamle satser. Denne PR'n gjør at det kan featuretoggles mellom gamle og nye satser i preprod for at det skal bli lett å teste.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7888