### PR TITLE
Lagrer sanksjonsårsak i vedtaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/PatchSanksjonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/PatchSanksjonController.kt
@@ -1,0 +1,59 @@
+package no.nav.familie.ef.sak.vedtak
+
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
+import no.nav.familie.ef.sak.vedtak.dto.ResultatType
+import no.nav.security.token.support.core.api.Unprotected
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/api/sanksjon-patch"], produces = [MediaType.APPLICATION_JSON_VALUE])
+@Unprotected
+@Validated
+class PatchSanksjonController(
+    private val vedtakRepository: VedtakRepository
+
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    @PostMapping("{dryRun}")
+    fun oppdater(@PathVariable dryRun: Boolean) {
+        val sankjonsvedtak = vedtakRepository.findAllByResultatType(ResultatType.SANKSJONERE)
+
+        sankjonsvedtak.forEach { vedtak ->
+            feilHvis(vedtak.resultatType != ResultatType.SANKSJONERE) {
+                "Vedtak behandlingId=${vedtak.behandlingId} er av resultatType=${vedtak.resultatType}"
+            }
+            feilHvis(vedtak.sanksjonsårsak == null) {
+                "Vedtak behandlingId=${vedtak.behandlingId} mangler sanksjonsårsan"
+            }
+            val perioder = vedtak.perioder?.perioder ?: emptyList()
+            val vedtaksperiode = perioder.single()
+
+            feilHvis(vedtaksperiode.periodeType !== VedtaksperiodeType.SANKSJON) {
+                "Vedtak behandlingId=${vedtak.behandlingId} inneholder ikke sanksjon"
+            }
+            logger.info("Oppdaterer behandling=${vedtak.behandlingId} dryRun=$dryRun")
+
+            if (!dryRun) {
+                val antallOppdaterte = vedtakRepository.oppdaterPerioder(
+                    vedtak.behandlingId,
+                    PeriodeWrapper(listOf(vedtaksperiode.copy(sanksjonsårsak = vedtak.sanksjonsårsak)))
+                )
+                feilHvis(antallOppdaterte != 1) {
+                    "Vedtak behandlingId=${vedtak.behandlingId} oppdaterte $antallOppdaterte raderﬁ"
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakRepository.kt
@@ -2,9 +2,20 @@ package no.nav.familie.ef.sak.vedtak
 
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
+import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
+import no.nav.familie.ef.sak.vedtak.dto.ResultatType
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface VedtakRepository : RepositoryInterface<Vedtak, UUID>, InsertUpdateRepository<Vedtak>
+interface VedtakRepository : RepositoryInterface<Vedtak, UUID>, InsertUpdateRepository<Vedtak> {
+
+    fun findAllByResultatType(resultatType: ResultatType): List<Vedtak>
+
+    @Modifying
+    @Query("UPDATE vedtak SET perioder=:perioder WHERE behandling_id = :behandlingId")
+    fun oppdaterPerioder(behandlingId: UUID, perioder: PeriodeWrapper): Int
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/domain/Vedtak.kt
@@ -50,17 +50,25 @@ data class Vedtaksperiode(
     val datoFra: LocalDate,
     val datoTil: LocalDate,
     val aktivitet: AktivitetType,
-    val periodeType: VedtaksperiodeType
+    val periodeType: VedtaksperiodeType,
+    val sanksjonsårsak: Sanksjonsårsak? = null
 ) {
+
+    init {
+        // TODO validere at man ikke kan opprette sansjon uten årsak
+    }
+
     constructor(
         periode: Månedsperiode,
         aktivitet: AktivitetType,
-        periodeType: VedtaksperiodeType
+        periodeType: VedtaksperiodeType,
+        sanksjonsårsak: Sanksjonsårsak? = null
     ) : this(
         periode.fomDato,
         periode.tomDato,
         aktivitet,
-        periodeType
+        periodeType,
+        sanksjonsårsak
     )
 
     val periode get() = Månedsperiode(datoFra, datoTil)
@@ -72,19 +80,22 @@ data class Barnetilsynperiode(
     val datoTil: LocalDate,
     val utgifter: Int,
     val barn: List<UUID>,
-    val erMidlertidigOpphør: Boolean? = false
+    val erMidlertidigOpphør: Boolean? = false,
+    val sanksjonsårsak: Sanksjonsårsak? = null
 ) {
     constructor(
         periode: Månedsperiode,
         utgifter: Int,
         barn: List<UUID>,
-        erMidlertidigOpphør: Boolean? = false
+        erMidlertidigOpphør: Boolean? = false,
+        sanksjonsårsak: Sanksjonsårsak? = null
     ) : this(
         periode.fomDato,
         periode.tomDato,
         utgifter,
         barn,
-        erMidlertidigOpphør
+        erMidlertidigOpphør,
+        sanksjonsårsak
     )
 
     val periode get() = Månedsperiode(datoFra, datoTil)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
@@ -177,7 +177,8 @@ private fun Sanksjonert.sanksjonertTilVedtak(
             val vedtaksperiode = Vedtaksperiode(
                 periode.tilPeriode(),
                 AktivitetType.IKKE_AKTIVITETSPLIKT,
-                VedtaksperiodeType.SANKSJON
+                VedtaksperiodeType.SANKSJON,
+                this.sanksjonsårsak
             )
             Vedtak(
                 behandlingId = behandlingId,
@@ -192,7 +193,8 @@ private fun Sanksjonert.sanksjonertTilVedtak(
                 periode = periode.tilPeriode(),
                 utgifter = 0,
                 barn = emptyList(),
-                erMidlertidigOpphør = true
+                erMidlertidigOpphør = true,
+                this.sanksjonsårsak
             )
             Vedtak(
                 behandlingId = behandlingId,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/PatchSanksjonControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/PatchSanksjonControllerTest.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.ef.sak.vedtak
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
+import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
+import no.nav.familie.ef.sak.vedtak.domain.Vedtak
+import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
+import no.nav.familie.ef.sak.vedtak.dto.ResultatType
+import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
+import no.nav.familie.kontrakter.felles.Månedsperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.YearMonth
+
+internal class PatchSanksjonControllerTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var vedtakRepository: VedtakRepository
+
+    @Autowired
+    private lateinit var patchSanksjonController: PatchSanksjonController
+
+    @Test
+    internal fun `skal oppdatere sanksjoner`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val vedtaksperiode = Vedtaksperiode(
+            Månedsperiode(YearMonth.now()),
+            AktivitetType.IKKE_AKTIVITETSPLIKT,
+            VedtaksperiodeType.SANKSJON,
+            sanksjonsårsak = null
+        )
+        val sanksjonsårsak = Sanksjonsårsak.SAGT_OPP_STILLING
+
+        vedtakRepository.insert(
+            Vedtak(
+                behandlingId = behandling.id,
+                resultatType = ResultatType.SANKSJONERE,
+                sanksjonsårsak = sanksjonsårsak,
+                perioder = PeriodeWrapper(listOf(vedtaksperiode))
+            )
+        )
+
+        patchSanksjonController.oppdater(false)
+
+        val vedtak = vedtakRepository.findByIdOrThrow(behandling.id)
+        assertThat(vedtak.perioder?.perioder?.single()?.sanksjonsårsak).isEqualTo(sanksjonsårsak)
+    }
+}


### PR DESCRIPTION
Lagt til patch for tidligere vedtak

Dette er noen av stegene som må gjøres (oppdateres i favro)
- Legge inn sanksjonsårsak i vedtaksperiode
- Patche data i ef-sak
~- Oppdatere domenemodell i iverksett~
~- Patche data i iverksett (forsiktig med periode-datoer her)~
~- Oppdatere kontrakter mot iverksett~
- Ta i bruk sanksjonsårsak fra vedtaksperiode
- Fjerne sanksjonsårsak fra vedtak

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8055