### PR TITLE
fagsystemvedtak skal kunne vite om vedtakstypen er en sanksjon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>1.20221202080911_bcf8f33</felles.version>
         <prosessering.version>1.20221110194901_e9e0d90</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>2.0_20221213124351_7c53585</kontrakter.version>
+        <kontrakter.version>2.0_20221216093604_cfeaf82</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20221118130052_e2abd9f</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.9.0</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController
 @ProtectedWithClaims(issuer = "azuread")
 class EksternBehandlingController(
     private val tilgangService: TilgangService,
-    private val eksternBehandlingService: EksternBehandlingService,
+    private val eksternBehandlingService: EksternBehandlingService
 ) {
 
     /**

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternVedtakService.kt
@@ -6,8 +6,10 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingClient
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
+import no.nav.familie.kontrakter.felles.klage.VedtakType
 import org.springframework.stereotype.Service
 
 @Service
@@ -29,12 +31,22 @@ class EksternVedtakService(
             .map { tilFagsystemVedtak(it) }
     }
 
-    private fun tilFagsystemVedtak(behandling: Behandling) = FagsystemVedtak(
-        eksternBehandlingId = behandling.eksternId.id.toString(),
-        behandlingstype = behandling.type.visningsnavn,
-        resultat = behandling.resultat.displayName,
-        vedtakstidspunkt = behandling.vedtakstidspunkt
-            ?: error("Mangler vedtakstidspunkt for behandling=${behandling.id}"),
-        fagsystemType = FagsystemType.ORDNIÆR
-    )
+    private fun tilFagsystemVedtak(behandling: Behandling): FagsystemVedtak {
+        val (resultat, vedtakType) = utledReultatOgVedtakType(behandling)
+
+        return FagsystemVedtak(
+            eksternBehandlingId = behandling.eksternId.id.toString(),
+            behandlingstype = behandling.type.visningsnavn,
+            resultat = resultat,
+            vedtakstidspunkt = behandling.vedtakstidspunkt
+                ?: error("Mangler vedtakstidspunkt for behandling=${behandling.id}"),
+            fagsystemType = FagsystemType.ORDNIÆR,
+            vedtakType = vedtakType
+        )
+    }
+
+    private fun utledReultatOgVedtakType(behandling: Behandling): Pair<String, VedtakType> = when (behandling.årsak) {
+        BehandlingÅrsak.SANKSJON_1_MND -> Pair("Sanksjon 1 måned", VedtakType.SANKSJON_1_MND)
+        else -> Pair(behandling.resultat.displayName, VedtakType.ORDINÆR)
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternVedtakServiceTest.kt
@@ -13,8 +13,10 @@ import no.nav.familie.ef.sak.fagsak.domain.EksternFagsakId
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingClient
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
+import no.nav.familie.kontrakter.felles.klage.VedtakType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -72,6 +74,21 @@ internal class EksternVedtakServiceTest {
     }
 
     @Test
+    internal fun `dersom behandlingstypen er sanksjon skal dette mappes til vedtakType`() {
+        val vedtakstidspunkt = LocalDateTime.now()
+        val behandling = ferdigstiltBehandling(vedtakstidspunkt).copy(årsak = BehandlingÅrsak.SANKSJON_1_MND)
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns listOf(behandling)
+
+        val vedtak = service.hentVedtak(eksternFagsakId)
+        assertThat(vedtak.map { it.fagsystemType }).containsExactly(FagsystemType.ORDNIÆR)
+        assertThat(vedtak.map { it.vedtakType }).containsExactly(VedtakType.SANKSJON_1_MND)
+        assertThat(vedtak).hasSize(1)
+        assertThat(vedtak.first().resultat).isEqualTo("Sanksjon 1 måned")
+
+        verify(exactly = 1) { behandlingService.hentBehandlinger(fagsak.id) }
+    }
+
+    @Test
     internal fun `skal ikke returnere henlagte behandlinger`() {
         val henlagtBehandling = behandling(
             fagsak = fagsak,
@@ -110,6 +127,7 @@ internal class EksternVedtakServiceTest {
         behandlingstype = "Tilbakekreving",
         resultat = "Delvis tilbakebetaling",
         vedtakstidspunkt = LocalDateTime.now(),
-        fagsystemType = FagsystemType.TILBAKEKREVING
+        fagsystemType = FagsystemType.TILBAKEKREVING,
+        vedtakType = VedtakType.TILBAKEKREVING
     )
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/TilbakekrevingClientTestConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/TilbakekrevingClientTestConfig.kt
@@ -7,6 +7,7 @@ import io.mockk.runs
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingClient
 import no.nav.familie.kontrakter.felles.klage.FagsystemType
 import no.nav.familie.kontrakter.felles.klage.FagsystemVedtak
+import no.nav.familie.kontrakter.felles.klage.VedtakType
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingsstatus
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandlingstype
@@ -51,7 +52,8 @@ class TilbakekrevingClientTestConfig {
                 behandlingstype = "Tilbakekreving",
                 resultat = "Delvis tilbakebetaling",
                 vedtakstidspunkt = LocalDateTime.now(),
-                fagsystemType = FagsystemType.TILBAKEKREVING
+                fagsystemType = FagsystemType.TILBAKEKREVING,
+                vedtakType = VedtakType.TILBAKEKREVING
             )
         )
 


### PR DESCRIPTION
En start på [denne oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10592)

Tar i bruk `VedtakType` fra kontrakter, som kan være `SANKSJON_1_MND`

Har også tatt i bruk kontrakter i `familie-tilbake` og `familie-klage`:
* https://github.com/navikt/familie-tilbake/pull/959
* https://github.com/navikt/familie-klage/pull/218