### PR TITLE
Skal gi saksbehandler beskjed om å laste siden på nytt dersom valider…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
@@ -89,7 +89,7 @@ class BeslutteVedtakSteg(
             "Beggrunnelse er påkrevd ved underkjennelse av vedtak"
         }
         brukerfeilHvis(featureToggleService.isEnabled(Toggle.STRUKTURERTE_ÅRSAKER_UNDKJENT_TOTRINNSKONTROLL) && data.årsakerUnderkjent.isEmpty()) {
-            "Minst en årsak for underkjennelse av vedtak må velges"
+            "Minst en årsak for underkjennelse av vedtak må velges. Hvis du ikke ser valg for årsak til undkjerkjennelse må du laste siden på nytt (Shift + F5)."
         }
     }
 


### PR DESCRIPTION
…ing feiler.

I en overgangsperiiode vil noen saksbehandlere sitte med utdatert frontend, og dermed ikke få til å underkjenne vedtak. Derfor gir feilmelding instruks om å laste siden på nytt