### PR TITLE
Skal fjerne toggle for strukturerte tilbakemeldinger fra beslutter da…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
@@ -86,7 +86,7 @@ class BeslutteVedtakSteg(
             "Beggrunnelse er påkrevd ved underkjennelse av vedtak"
         }
         brukerfeilHvis(data.årsakerUnderkjent.isEmpty()) {
-            "Minst en årsak for underkjennelse av vedtak må velges. Hvis du ikke ser valg for årsak til undkjerkjennelse må du laste siden på nytt (Shift + F5)."
+            "Minst en årsak for underkjennelse av vedtak må velges."
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
@@ -13,8 +13,6 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.iverksett.IverksettingDtoMapper
@@ -39,7 +37,6 @@ class BeslutteVedtakSteg(
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
     private val vedtaksbrevService: VedtaksbrevService,
-    private val featureToggleService: FeatureToggleService
 ) : BehandlingSteg<BeslutteVedtakDto> {
 
     override fun validerSteg(saksbehandling: Saksbehandling) {
@@ -88,7 +85,7 @@ class BeslutteVedtakSteg(
         brukerfeilHvis(data.begrunnelse.isNullOrBlank()) {
             "Beggrunnelse er påkrevd ved underkjennelse av vedtak"
         }
-        brukerfeilHvis(featureToggleService.isEnabled(Toggle.STRUKTURERTE_ÅRSAKER_UNDKJENT_TOTRINNSKONTROLL) && data.årsakerUnderkjent.isEmpty()) {
+        brukerfeilHvis(data.årsakerUnderkjent.isEmpty()) {
             "Minst en årsak for underkjennelse av vedtak må velges. Hvis du ikke ser valg for årsak til undkjerkjennelse må du laste siden på nytt (Shift + F5)."
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -24,7 +24,6 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
         Toggle.FRONTEND_SATSENDRING,
         Toggle.FØRSTEGANGSBEHANDLING,
         Toggle.AUTOMATISKE_VEDTAKSDATOER_BREV,
-        Toggle.STRUKTURERTE_ÅRSAKER_UNDKJENT_TOTRINNSKONTROLL,
         Toggle.BRUK_8_ÅR_HOVEDPERIODEVALIDERING
     )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -38,7 +38,6 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     FØRSTEGANGSBEHANDLING("familie.ef.sak.opprett-forstegangsbehandling"),
     AUTOMATISK_JOURNALFØR_REVURDERING("familie.ef.sak.automatisk-journalfor-revurdering"),
     AUTOMATISKE_VEDTAKSDATOER_BREV("familie.ef.sak.frontend.automatiskeVedtaksdatoer"),
-    STRUKTURERTE_ÅRSAKER_UNDKJENT_TOTRINNSKONTROLL("familie.ef.sak.totrinnskontroll.strukturerte-arsaker-underkjent"),
     BRUK_8_ÅR_HOVEDPERIODEVALIDERING("familie.ef.sak.frontend-bruk-validering-8ar-hovedperiode");
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
@@ -24,7 +24,6 @@ import no.nav.familie.ef.sak.felles.domain.Fil
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.iverksett.IverksettingDtoMapper
 import no.nav.familie.ef.sak.oppgave.Oppgave
@@ -66,7 +65,6 @@ internal class BeslutteVedtakStegTest {
     private val vedtakService = mockk<VedtakService>()
     private val vedtaksbrevService = mockk<VedtaksbrevService>()
     private val behandlingService = mockk<BehandlingService>()
-    private val featureToggleService = mockk<FeatureToggleService>()
 
     private val beslutteVedtakSteg = BeslutteVedtakSteg(
         taskService = taskService,
@@ -78,7 +76,6 @@ internal class BeslutteVedtakStegTest {
         behandlingService = behandlingService,
         vedtakService = vedtakService,
         vedtaksbrevService = vedtaksbrevService,
-        featureToggleService = featureToggleService
     )
 
     private val vedtakKreverBeslutter = VedtakErUtenBeslutter(false)
@@ -123,7 +120,6 @@ internal class BeslutteVedtakStegTest {
         every { behandlingService.oppdaterResultatPåBehandling(any(), any()) } answers {
             behandling(fagsak, id = behandlingId, resultat = secondArg())
         }
-        every { featureToggleService.isEnabled(any()) } returns true
         every { vedtaksbrevService.slettVedtaksbrev(any()) } just Runs
     }
 


### PR DESCRIPTION
… den er tatt i bruk i prod

Kan vente med å merge denne til https://github.com/navikt/familie-ef-sak-frontend/pull/1882 har vært ute noen dager.