### PR TITLE
Ska ta med barn over 18 når man oppretter en ny behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -4,12 +4,15 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
 import no.nav.familie.ef.sak.opplysninger.mapper.MatchetBehandlingBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
@@ -21,7 +24,8 @@ import java.util.UUID
 class BarnService(
     private val barnRepository: BarnRepository,
     private val søknadService: SøknadService,
-    private val behandlingService: BehandlingService
+    private val behandlingService: BehandlingService,
+    private val featureToggleService: FeatureToggleService
 ) {
 
     /**
@@ -42,14 +46,17 @@ class BarnService(
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT
     ) {
+        val barnOver18Toggle = featureToggleService.isEnabled(Toggle.BARN_OVER_18)
+        val grunnlagsdataBarnFiltrert = grunnlagsdataBarn
+            .filter { barnOver18Toggle || it.fødsel.gjeldende().erUnder18År() }
         val barnPåBehandlingen: List<BehandlingBarn> = when (stønadstype) {
-            StønadType.BARNETILSYN -> barnForBarnetilsyn(barnSomSkalFødes, behandlingId, grunnlagsdataBarn)
+            StønadType.BARNETILSYN -> barnForBarnetilsyn(barnSomSkalFødes, behandlingId, grunnlagsdataBarnFiltrert)
             StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER ->
                 kobleBarnForOvergangsstønadOgSkolepenger(
                     fagsakId,
                     behandlingId,
                     ustrukturertDokumentasjonType,
-                    grunnlagsdataBarn,
+                    grunnlagsdataBarnFiltrert,
                     barnSomSkalFødes,
                     vilkårsbehandleNyeBarn
                 )
@@ -246,7 +253,10 @@ class BarnService(
         kobledeBarn: List<BehandlingBarn>,
         grunnlagsdataBarn: List<BarnMedIdent>
     ) {
-        val grunnlagsdataBarnIdenter = grunnlagsdataBarn.map { it.personIdent }
+        val barnOver18Toggle = featureToggleService.isEnabled(Toggle.BARN_OVER_18)
+        val grunnlagsdataBarnIdenter = grunnlagsdataBarn
+            .filter { barnOver18Toggle || it.fødsel.gjeldende().erUnder18År()}
+            .map { it.personIdent }
         val kobledeBarnIdenter = kobledeBarn.mapNotNull { it.personIdent }
 
         feilHvisIkke(kobledeBarnIdenter.containsAll(grunnlagsdataBarnIdenter)) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -112,11 +112,14 @@ class BarnService(
                 vilkårsbehandleNyeBarn,
                 grunnlagsdataBarn
             )
-            UstrukturertDokumentasjonType.IKKE_VALGT -> kobleBehandlingBarnOgRegisterBarnTilBehandlingBarn(
-                finnSøknadsbarnOgMapTilBehandlingBarn(behandlingId = behandlingId),
-                grunnlagsdataBarn,
-                behandlingId
-            )
+            UstrukturertDokumentasjonType.IKKE_VALGT -> {
+                val kobledeBarn = kobleBehandlingBarnOgRegisterBarnTilBehandlingBarn(
+                    finnSøknadsbarnOgMapTilBehandlingBarn(behandlingId = behandlingId),
+                    grunnlagsdataBarn,
+                    behandlingId
+                )
+                kobledeBarnPlusRegisterbarn(behandlingId, grunnlagsdataBarn, kobledeBarn)
+            }
         }
     }
 
@@ -255,7 +258,7 @@ class BarnService(
     ) {
         val barnOver18Toggle = featureToggleService.isEnabled(Toggle.BARN_OVER_18)
         val grunnlagsdataBarnIdenter = grunnlagsdataBarn
-            .filter { barnOver18Toggle || it.fødsel.gjeldende().erUnder18År()}
+            .filter { barnOver18Toggle || it.fødsel.gjeldende().erUnder18År() }
             .map { it.personIdent }
         val kobledeBarnIdenter = kobledeBarn.mapNotNull { it.personIdent }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -10,7 +10,6 @@ import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
 import no.nav.familie.ef.sak.opplysninger.mapper.MatchetBehandlingBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
@@ -43,15 +42,14 @@ class BarnService(
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT
     ) {
-        val barnUnder18 = grunnlagsdataBarn.filter { it.fødsel.gjeldende().erUnder18År() }
         val barnPåBehandlingen: List<BehandlingBarn> = when (stønadstype) {
-            StønadType.BARNETILSYN -> barnForBarnetilsyn(barnSomSkalFødes, behandlingId, barnUnder18)
+            StønadType.BARNETILSYN -> barnForBarnetilsyn(barnSomSkalFødes, behandlingId, grunnlagsdataBarn)
             StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER ->
                 kobleBarnForOvergangsstønadOgSkolepenger(
                     fagsakId,
                     behandlingId,
                     ustrukturertDokumentasjonType,
-                    barnUnder18,
+                    grunnlagsdataBarn,
                     barnSomSkalFødes,
                     vilkårsbehandleNyeBarn
                 )
@@ -248,8 +246,7 @@ class BarnService(
         kobledeBarn: List<BehandlingBarn>,
         grunnlagsdataBarn: List<BarnMedIdent>
     ) {
-        val grunnlagsdataBarnIdenter =
-            grunnlagsdataBarn.filter { it.fødsel.gjeldende().erUnder18År() }.map { it.personIdent }
+        val grunnlagsdataBarnIdenter = grunnlagsdataBarn.map { it.personIdent }
         val kobledeBarnIdenter = kobledeBarn.mapNotNull { it.personIdent }
 
         feilHvisIkke(kobledeBarnIdenter.containsAll(grunnlagsdataBarnIdenter)) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -100,11 +100,10 @@ class NyeBarnService(
 
     private fun finnKobledeBarn(forrigeBehandlingId: UUID, personIdent: String): NyeBarnData {
         val alleBarnPåBehandlingen = barnService.finnBarnPåBehandling(forrigeBehandlingId)
-        val pdlBarnUnder18år = GrunnlagsdataMapper.mapBarn(personService.hentPersonMedBarn(personIdent).barn)
-            .filter { it.fødsel.gjeldende().erUnder18År() }
-        val kobledeBarn = BarnMatcher.kobleBehandlingBarnOgRegisterBarn(alleBarnPåBehandlingen, pdlBarnUnder18år)
+        val pdlBarn = GrunnlagsdataMapper.mapBarn(personService.hentPersonMedBarn(personIdent).barn)
+        val kobledeBarn = BarnMatcher.kobleBehandlingBarnOgRegisterBarn(alleBarnPåBehandlingen, pdlBarn)
 
-        return NyeBarnData(pdlBarnUnder18år, kobledeBarn)
+        return NyeBarnData(pdlBarn, kobledeBarn)
     }
 
     private fun finnForTidligtFødteBarn(kobledeBarn: NyeBarnData, stønadstype: StønadType): List<NyttBarn> {
@@ -128,12 +127,12 @@ class NyeBarnService(
     }
 
     private data class NyeBarnData(
-        val pdlBarnUnder18år: List<BarnMedIdent>,
+        val pdlBarn: List<BarnMedIdent>,
         val kobledeBarn: List<MatchetBehandlingBarn>
     )
 
     private fun filtrerNyeBarn(data: NyeBarnData) =
-        data.pdlBarnUnder18år
+        data.pdlBarn
             .filter { pdlBarn -> data.kobledeBarn.none { it.barn?.personIdent == pdlBarn.personIdent } }
             .map { barnMinimumDto(it) }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -28,6 +28,8 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
 
     BARNETILSYN_REVURDER_FRA("familie.ef.sak.barnetilsyn-revurder-fra"),
 
+    BARN_OVER_18("familie.ef.sak.barn-over-18"),
+
     REVURDERING_SANKSJON("familie.ef.sak.revurdering-sanksjon"),
 
     KLAGE_TILBAKEKREVING("familie.ef.sak.klage-tilbakekreving"),

--- a/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.felles.util.mockFeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
@@ -36,7 +37,7 @@ internal class BarnServiceTest {
     val barnRepository = mockk<BarnRepository>()
     val søknadService = mockk<SøknadService>()
     val behandlingService = mockk<BehandlingService>()
-    val barnService = BarnService(barnRepository, søknadService, behandlingService)
+    val barnService = BarnService(barnRepository, søknadService, behandlingService, mockFeatureToggleService())
     val søknadMock = mockk<Søknadsverdier>()
     val fagsakId: UUID = UUID.randomUUID()
     val behandlingId: UUID = UUID.randomUUID()

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -150,7 +150,7 @@ class NyeBarnServiceTest {
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med ett ekstra voksent barn i PDL, forvent ingen treff`() {
+    fun `finnNyeEllerTidligereFødteBarn med ett ekstra voksent barn i PDL skal returnere det voksne barnet som nytt barn`() {
         val pdlBarn = mapOf(
             fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
             fnrForVoksentBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoVoksentBarn))
@@ -159,7 +159,8 @@ class NyeBarnServiceTest {
         every { barnService.finnBarnPåBehandling(any()) } returns listOf(behandlingBarn(fnrForEksisterendeBarn))
 
         val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
-        assertThat(barn).hasSize(0)
+        assertThat(barn).hasSize(1)
+        assertThat(barn[0].personIdent).isEqualTo(fnrForVoksentBarn)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.barn.BehandlingBarn
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.felles.util.mockFeatureToggleService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
@@ -39,7 +40,7 @@ class NyeBarnServiceTest {
     val barnService = mockk<BarnService>()
     val pdlSøker = mockk<PdlSøker>(relaxed = true)
     val taskService = mockk<TaskService>(relaxed = true)
-    val nyeBarnService = NyeBarnService(behandlingService, fagsakService, personService, barnService, taskService)
+    val nyeBarnService = NyeBarnService(behandlingService, fagsakService, personService, barnService, taskService, mockFeatureToggleService())
 
     val grunnlagsdataMedMetadata = mockk<GrunnlagsdataMedMetadata>()
     val fagsak = fagsak()

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -98,7 +98,7 @@ class StepDefinitions {
     private val simuleringService = mockk<SimuleringService>(relaxed = true)
     private val tilbakekrevingService = mockk<TilbakekrevingService>(relaxed = true)
     private val barnRepository = mockk<BarnRepository>()
-    private val barnService = spyk(BarnService(barnRepository, mockk(), behandlingService))
+    private val barnService = spyk(BarnService(barnRepository, mockk(), behandlingService, mockFeatureToggleService()))
     private val fagsakService = mockFagsakService()
     private val validerOmregningService = mockk<ValiderOmregningService>(relaxed = true)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnServiceTest.kt
@@ -41,7 +41,6 @@ internal class ForberedOppgaverTerminbarnServiceTest {
         every { fagsakService.hentAktivIdent(any()) } returns ""
         every { personService.hentPersonMedBarn(any()).barn } returns mockk()
         every { terminbarnRepository.insert(any()) } returns mockk()
-        every { fødsel.erUnder18År() } returns true
         mockkObject(GrunnlagsdataMapper)
     }
 


### PR DESCRIPTION
Jeg tenkte først at det var tilstrekkelig å kun ta med registerbarnen i https://github.com/navikt/familie-ef-sak/compare/skal-ikke-filtrere-vekk-barn-over-18?expand=1
Tenkte det hadde gjort koden mye enklere. 

Men så fikk jeg då selvfølgelig ikke med terminbarnen, så måtte gå for å endre eksisterende kode. Mulig det går å gjøre noen forenklinger senere

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9733