### PR TITLE
Bedre feilmelding til saksbehandler når behandlingsvalidering feiler 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
@@ -78,7 +78,7 @@ enum class BehandlingStatus {
     SATT_PÅ_VENT
     ;
 
-    fun visningsNavn(): String {
+    fun visningsnavn(): String {
         return this.name.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
@@ -78,6 +78,10 @@ enum class BehandlingStatus {
     SATT_PÅ_VENT
     ;
 
+    fun visningsNavn(): String {
+        return this.name.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
+    }
+
     fun behandlingErLåstForVidereRedigering(): Boolean =
         setOf(FATTER_VEDTAK, IVERKSETTER_VEDTAK, FERDIGSTILT).contains(this)
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakSteg.kt
@@ -40,6 +40,9 @@ class BeslutteVedtakSteg(
 ) : BehandlingSteg<BeslutteVedtakDto> {
 
     override fun validerSteg(saksbehandling: Saksbehandling) {
+        brukerfeilHvis (saksbehandling.steg.kommerEtter(stegType())) {
+            "Behandlingen er allerede besluttet. Status på behandling er '${saksbehandling.status.visningsnavn()}'"
+        }
         if (saksbehandling.steg != stegType()) {
             throw Feil("Behandling er i feil steg=${saksbehandling.steg}")
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -189,9 +189,7 @@ class StegService(
         behandlingSteg: BehandlingSteg<T>
     ) {
         validerHarTilgang(saksbehandling, stegType, saksbehandlerIdent)
-
         validerGyldigTilstand(saksbehandling, stegType, saksbehandlerIdent)
-
         utførBehandlingsvalidering(behandlingSteg, saksbehandling)
     }
 
@@ -253,7 +251,6 @@ class StegService(
         saksbehandlerIdent: String
     ) {
         val rolleForSteg: BehandlerRolle = utledRolleForSteg(stegType, saksbehandling)
-
         val harTilgangTilSteg = SikkerhetContext.harTilgangTilGittRolle(rolleConfig, rolleForSteg)
 
         logger.info("Starter håndtering av $stegType på behandling ${saksbehandling.id}")
@@ -261,6 +258,10 @@ class StegService(
             "Starter håndtering av $stegType på behandling " +
                 "${saksbehandling.id} med saksbehandler=[$saksbehandlerIdent]"
         )
+
+        feilHvis(rolleForSteg == BehandlerRolle.SYSTEM && !harTilgangTilSteg) {
+            "$saksbehandlerIdent kan ikke utføre steg '${stegType.displayName()}' - behandlingen har status: ${saksbehandling.status.visningsNavn()}"
+        }
 
         feilHvis(!harTilgangTilSteg) {
             "$saksbehandlerIdent kan ikke utføre steg '${stegType.displayName()}' pga manglende rolle."

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -188,9 +188,9 @@ class StegService(
         saksbehandlerIdent: String,
         behandlingSteg: BehandlingSteg<T>
     ) {
+        utførBehandlingsvalidering(behandlingSteg, saksbehandling)
         validerHarTilgang(saksbehandling, stegType, saksbehandlerIdent)
         validerGyldigTilstand(saksbehandling, stegType, saksbehandlerIdent)
-        utførBehandlingsvalidering(behandlingSteg, saksbehandling)
     }
 
     private fun oppdaterMetrikk(stegType: StegType, metrikk: Map<StegType, Counter>) {
@@ -218,8 +218,8 @@ class StegService(
         behandlingSteg: BehandlingSteg<T>,
         saksbehandling: Saksbehandling
     ) {
-        if (!behandlingSteg.stegType().erGyldigIKombinasjonMedStatus(saksbehandling.status)) {
-            error("Kan ikke utføre ${behandlingSteg.stegType()} når behandlingstatus er ${saksbehandling.status}")
+        feilHvis (!behandlingSteg.stegType().erGyldigIKombinasjonMedStatus(saksbehandling.status)) {
+           "Kan ikke utføre '${behandlingSteg.stegType().displayName()}' når behandlingstatus er ${saksbehandling.status.visningsNavn()}"
         }
         behandlingSteg.validerSteg(saksbehandling)
     }
@@ -258,10 +258,6 @@ class StegService(
             "Starter håndtering av $stegType på behandling " +
                 "${saksbehandling.id} med saksbehandler=[$saksbehandlerIdent]"
         )
-
-        feilHvis(rolleForSteg == BehandlerRolle.SYSTEM && !harTilgangTilSteg) {
-            "$saksbehandlerIdent kan ikke utføre steg '${stegType.displayName()}' - behandlingen har status: ${saksbehandling.status.visningsNavn()}"
-        }
 
         feilHvis(!harTilgangTilSteg) {
             "$saksbehandlerIdent kan ikke utføre steg '${stegType.displayName()}' pga manglende rolle."

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -218,10 +218,10 @@ class StegService(
         behandlingSteg: BehandlingSteg<T>,
         saksbehandling: Saksbehandling
     ) {
+        behandlingSteg.validerSteg(saksbehandling)
         feilHvis (!behandlingSteg.stegType().erGyldigIKombinasjonMedStatus(saksbehandling.status)) {
            "Kan ikke utføre '${behandlingSteg.stegType().displayName()}' når behandlingstatus er ${saksbehandling.status.visningsnavn()}"
         }
-        behandlingSteg.validerSteg(saksbehandling)
     }
 
     private fun validerGyldigTilstand(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -219,7 +219,7 @@ class StegService(
         saksbehandling: Saksbehandling
     ) {
         feilHvis (!behandlingSteg.stegType().erGyldigIKombinasjonMedStatus(saksbehandling.status)) {
-           "Kan ikke utføre '${behandlingSteg.stegType().displayName()}' når behandlingstatus er ${saksbehandling.status.visningsNavn()}"
+           "Kan ikke utføre '${behandlingSteg.stegType().displayName()}' når behandlingstatus er ${saksbehandling.status.visningsnavn()}"
         }
         behandlingSteg.validerSteg(saksbehandling)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
@@ -198,6 +198,14 @@ internal class BeslutteVedtakStegTest {
         assertThrows<ApiFeil> { utførTotrinnskontroll(godkjent = false, begrunnelse = "bergrunnelse", årsakerUnderkjent = emptyList()) }
     }
 
+    @Test
+    internal fun `Skal kaste feil når behandling allerede er iverksatt `() {
+        val behandling = behandling(fagsak, BehandlingStatus.IVERKSETTER_VEDTAK, StegType.VENTE_PÅ_STATUS_FRA_IVERKSETT)
+        val apiFeil =
+            assertThrows<ApiFeil> { beslutteVedtakSteg.validerSteg(saksbehandling(behandling = behandling)) }
+        assertThat(apiFeil.message).isEqualTo("Behandlingen er allerede besluttet. Status på behandling er 'Iverksetter vedtak'")
+    }
+
     private fun utførTotrinnskontroll(
         godkjent: Boolean,
         saksbehandling: Saksbehandling = opprettSaksbehandling(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
@@ -55,7 +55,6 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
     @AfterEach
     internal fun tearDown() {
         BrukerContextUtil.clearBrukerContext()
-        MDC.remove(MDCConstants.MDC_CALL_ID)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
@@ -177,10 +177,11 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         vedtakService.lagreVedtak(InnvilgelseOvergangsstønad("", ""), behandling.id, fagsak.stønadstype)
         BrukerContextUtil.mockBrukerContext("navIdent")
         val beslutteVedtakDto = BeslutteVedtakDto(true, "")
-        val assertThrows = assertThrows<Feil> {
+        val feil = assertThrows<Feil> {
             stegService.håndterBeslutteVedtak(saksbehandling(fagsak, behandling), beslutteVedtakDto)
         }
-        assertThat(assertThrows.message).isEqualTo("navIdent kan ikke utføre steg 'Beslutte vedtak' - behandlingen har status: Iverksetter vedtak")
+        assertThat(feil.message).isEqualTo("Kan ikke utføre 'Beslutte vedtak' når behandlingstatus er Iverksetter vedtak")
+
     }
 
     private fun behandlingSomIverksettes(fagsak: Fagsak): Behandling {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ef.sak.beregning.Inntekt
 import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
-import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
@@ -176,10 +176,10 @@ internal class StegServiceTest : OppslagSpringRunnerTest() {
         vedtakService.lagreVedtak(InnvilgelseOvergangsstønad("", ""), behandling.id, fagsak.stønadstype)
         BrukerContextUtil.mockBrukerContext("navIdent")
         val beslutteVedtakDto = BeslutteVedtakDto(true, "")
-        val feil = assertThrows<Feil> {
+        val feil = assertThrows<ApiFeil> {
             stegService.håndterBeslutteVedtak(saksbehandling(fagsak, behandling), beslutteVedtakDto)
         }
-        assertThat(feil.message).isEqualTo("Kan ikke utføre 'Beslutte vedtak' når behandlingstatus er Iverksetter vedtak")
+        assertThat(feil.message).isEqualTo("Behandlingen er allerede besluttet. Status på behandling er 'Iverksetter vedtak'")
 
     }
 


### PR DESCRIPTION
Når status på behandlingen ikke samsvarer med aksjon får vi feil. 

f.eks: 
saksbehandler vil beslutte et vedtak som allerede er sendt til iverksett 
saksbehandler får feilmelding at hen "mangler rolle for å..." - som er helt riktig (skulle hatt systemrolle for å gjøre mer med denne) 

Nå ønsker vi gjøre sjekk av behandlingsstatus mot stegtype før rolle-sjekk for å få litt bedre feilmeldinger. 

![image](https://user-images.githubusercontent.com/53942238/211014367-5f4308d8-1955-43da-9720-87a7890cfc34.png)

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10757
