### PR TITLE
Behandling skal være låst hvis status er satt på vent

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/domain/Behandling.kt
@@ -83,5 +83,5 @@ enum class BehandlingStatus {
     }
 
     fun behandlingErLåstForVidereRedigering(): Boolean =
-        setOf(FATTER_VEDTAK, IVERKSETTER_VEDTAK, FERDIGSTILT).contains(this)
+        setOf(FATTER_VEDTAK, IVERKSETTER_VEDTAK, FERDIGSTILT, SATT_PÅ_VENT).contains(this)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/domain/BehandlingStatusTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/domain/BehandlingStatusTest.kt
@@ -1,0 +1,28 @@
+package no.nav.familie.ef.sak.behandling.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+internal class BehandlingStatusTest {
+
+    @EnumSource(
+        value = BehandlingStatus::class,
+        names = ["UTREDES", "OPPRETTET"],
+        mode = EnumSource.Mode.EXCLUDE
+    )
+    @ParameterizedTest
+    internal fun `behandling skal være låst`(status: BehandlingStatus) {
+        assertThat(status.behandlingErLåstForVidereRedigering()).isTrue
+    }
+
+    @EnumSource(
+        value = BehandlingStatus::class,
+        names = ["FATTER_VEDTAK", "IVERKSETTER_VEDTAK", "FERDIGSTILT", "SATT_PÅ_VENT"],
+        mode = EnumSource.Mode.EXCLUDE
+    )
+    @ParameterizedTest
+    internal fun `behandling skal være låst hvis en behandling utredes eller opprettes`(status: BehandlingStatus) {
+        assertThat(status.behandlingErLåstForVidereRedigering()).isFalse
+    }
+}


### PR DESCRIPTION
Del 1 for å kunne ha flere behandlinger åpne samtidig er å kunne sette en behandling på vent, og at denne ses som en låst behandling
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10514