### PR TITLE
Sjekk behandling har nyere vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -64,6 +64,13 @@ class BehandlingController(
         return Ressurs.success(behandlingId)
     }
 
+    @GetMapping("{behandlingId}/har-nyere-vedtak")
+    fun harNyereVedtak(@PathVariable behandlingId: UUID): Ressurs<Boolean> {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return Ressurs.success(behandlingService.harNyereVedtak(behandlingId))
+    }
+
     @PostMapping("{behandlingId}/henlegg")
     fun henleggBehandling(@PathVariable behandlingId: UUID, @RequestBody henlagt: HenlagtDto): Ressurs<BehandlingDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -278,4 +278,11 @@ class BehandlingService(
         behandlingRepository.update(behandling.copy(status = BehandlingStatus.UTREDES))
         taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId))
     }
+
+    fun harNyereVedtak(behandlingId: UUID): Boolean {
+        val saksbehandling = behandlingRepository.finnSaksbehandling(behandlingId)
+        val behandlinger = hentBehandlinger(saksbehandling.fagsakId)
+
+        return behandlinger.any { return it.vedtakstidspunkt != null && it.vedtakstidspunkt > saksbehandling.opprettetTid }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -283,6 +283,6 @@ class BehandlingService(
         val saksbehandling = behandlingRepository.finnSaksbehandling(behandlingId)
         val behandlinger = hentBehandlinger(saksbehandling.fagsakId)
 
-        return behandlinger.any { return it.vedtakstidspunkt != null && it.vedtakstidspunkt > saksbehandling.opprettetTid }
+        return behandlinger.any { it.vedtakstidspunkt != null && it.vedtakstidspunkt > saksbehandling.opprettetTid }
     }
 }


### PR DESCRIPTION
Tilhører oppgave [Tea-10972](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10872)

### Hva er gjort? ✨
- Lagd nytt endepunkt for å sjekke om det finnes nyere vedtak på samme fagsak. 

### Hvorfor? 🤔
Trengs for å sjekke om verdier må nullstilles for at en behandling kan tas av vent. Se [PR 1951](https://github.com/navikt/familie-ef-sak-frontend/pull/1951) i familie-ef-sak-frontend 