### PR TITLE
Kan ta av vent

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -58,7 +58,7 @@ class BehandlingController(
         return Ressurs.success(behandlingId)
     }
 
-    @GetMapping("{behandlingId}/aktiver")
+    @GetMapping("{behandlingId}/kan-ta-av-vent")
     fun kanTaAvVent(@PathVariable behandlingId: UUID): Ressurs<TaAvVentStatusDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -27,6 +27,7 @@ import java.util.UUID
 @Validated
 class BehandlingController(
     private val behandlingService: BehandlingService,
+    private val behandlingPåVentService: BehandlingPåVentService,
     private val fagsakService: FagsakService,
     private val henleggService: HenleggService,
     private val tilgangService: TilgangService,
@@ -53,7 +54,7 @@ class BehandlingController(
     fun settPåVent(@PathVariable behandlingId: UUID): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
-        behandlingService.settPåVent(behandlingId)
+        behandlingPåVentService.settPåVent(behandlingId)
         return Ressurs.success(behandlingId)
     }
 
@@ -61,14 +62,14 @@ class BehandlingController(
     fun kanTaAvVent(@PathVariable behandlingId: UUID): Ressurs<TaAvVentStatusDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(TaAvVentStatusDto(behandlingService.kanTaAvVent(behandlingId)))
+        return Ressurs.success(TaAvVentStatusDto(behandlingPåVentService.kanTaAvVent(behandlingId)))
     }
 
     @PostMapping("{behandlingId}/aktiver")
     fun taAvVent(@PathVariable behandlingId: UUID): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
-        behandlingService.taAvVent(behandlingId)
+        behandlingPåVentService.taAvVent(behandlingId)
         return Ressurs.success(behandlingId)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.behandling
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.behandling.dto.BehandlingDto
 import no.nav.familie.ef.sak.behandling.dto.HenlagtDto
+import no.nav.familie.ef.sak.behandling.dto.TaAvVentStatusDto
 import no.nav.familie.ef.sak.behandling.dto.tilDto
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
@@ -54,6 +55,13 @@ class BehandlingController(
         tilgangService.validerHarSaksbehandlerrolle()
         behandlingService.settPåVent(behandlingId)
         return Ressurs.success(behandlingId)
+    }
+
+    @GetMapping("{behandlingId}/aktiver")
+    fun kanTaAvVent(@PathVariable behandlingId: UUID): Ressurs<TaAvVentStatusDto> {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return Ressurs.success(TaAvVentStatusDto(behandlingService.kanTaAvVent(behandlingId)))
     }
 
     @PostMapping("{behandlingId}/aktiver")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -1,0 +1,65 @@
+package no.nav.familie.ef.sak.behandling
+
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.dto.TaAvVentStatus
+import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class BehandlingPåVentService(
+    private val behandlingService: BehandlingService,
+    private val taskService: TaskService
+) {
+    @Transactional
+    fun settPåVent(behandlingId: UUID) {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        brukerfeilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke sette behandling med status ${behandling.status} på vent"
+        }
+
+        behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.SATT_PÅ_VENT)
+        taskService.save(BehandlingsstatistikkTask.opprettVenterTask(behandlingId))
+    }
+
+    @Transactional
+    fun taAvVent(behandlingId: UUID) {
+        when (kanTaAvVent(behandlingId)) {
+            TaAvVentStatus.OK -> {}
+            TaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES ->
+                throw ApiFeil(
+                    "Annen behandling må ferdigstilles før denne kan aktiveres på nytt",
+                    HttpStatus.BAD_REQUEST
+                )
+            TaAvVentStatus.MÅ_OPPDATERES -> {
+                error("Har ikke støtte for dette ennå")
+            }
+        }
+        behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES)
+        taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId))
+    }
+
+    fun kanTaAvVent(behandlingId: UUID): TaAvVentStatus {
+        val behandling = behandlingService.hentBehandling(behandlingId)
+        brukerfeilHvis(behandling.status != BehandlingStatus.SATT_PÅ_VENT) {
+            "Kan ikke ta behandling med status ${behandling.status} av vent"
+        }
+
+        val behandlinger = behandlingService.hentBehandlinger(behandling.fagsakId)
+            .sortedByDescending { it.sporbar.endret.endretTid }
+        if (behandlinger.any { it.id != behandlingId && !it.erAvsluttet() }) {
+            return TaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES
+        }
+        val sisteIverksatte = behandlingService.finnSisteIverksatteBehandling(behandling.fagsakId)
+        return if (sisteIverksatte == null || sisteIverksatte.id == behandling.forrigeBehandlingId) {
+            TaAvVentStatus.OK
+        } else {
+            TaAvVentStatus.MÅ_OPPDATERES
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -36,7 +36,7 @@ class BehandlingPåVentService(
                     "Annen behandling må ferdigstilles før denne kan aktiveres på nytt",
                     HttpStatus.BAD_REQUEST
                 )
-            TaAvVentStatus.MÅ_OPPDATERES -> {
+            TaAvVentStatus.MÅ_NULSTILLE_VEDTAK -> {
                 error("Har ikke støtte for dette ennå")
             }
         }
@@ -59,7 +59,7 @@ class BehandlingPåVentService(
         return if (sisteIverksatte == null || sisteIverksatte.id == behandling.forrigeBehandlingId) {
             TaAvVentStatus.OK
         } else {
-            TaAvVentStatus.MÅ_OPPDATERES
+            TaAvVentStatus.MÅ_NULSTILLE_VEDTAK
         }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FERDIGSTILT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.domain.Behandlingsjournalpost
 import no.nav.familie.ef.sak.behandling.dto.HenlagtDto
+import no.nav.familie.ef.sak.behandling.dto.TaAvVentStatus
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType.BEHANDLING_FERDIGSTILT
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType.VILKÅR
@@ -277,5 +278,23 @@ class BehandlingService(
         }
         behandlingRepository.update(behandling.copy(status = BehandlingStatus.UTREDES))
         taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId))
+    }
+
+    fun kanTaAvVent(behandlingId: UUID): TaAvVentStatus {
+        val behandling = hentBehandling(behandlingId)
+        brukerfeilHvis(behandling.status != BehandlingStatus.SATT_PÅ_VENT) {
+            "Kan ikke ta behandling med status ${behandling.status} av vent"
+        }
+
+        val behandlinger = hentBehandlinger(behandling.fagsakId).sortedByDescending { it.sporbar.endret.endretTid }
+        if (behandlinger.any { it.id != behandlingId && it.erAvsluttet() }) {
+            return TaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES
+        }
+        val sisteIverksatte = finnSisteIverksatteBehandling(behandling.fagsakId)
+        return if (sisteIverksatte == null || sisteIverksatte.id == behandling.forrigeBehandlingId) {
+            TaAvVentStatus.OK
+        } else {
+            TaAvVentStatus.MÅ_OPPDATERES
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/TaAvVentStatusDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/TaAvVentStatusDto.kt
@@ -7,5 +7,5 @@ data class TaAvVentStatusDto(
 enum class TaAvVentStatus {
     OK,
     ANNEN_BEHANDLING_MÅ_FERDIGSTILLES,
-    MÅ_OPPDATERES
+    MÅ_NULSTILLE_VEDTAK
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/TaAvVentStatusDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/TaAvVentStatusDto.kt
@@ -1,0 +1,11 @@
+package no.nav.familie.ef.sak.behandling.dto
+
+data class TaAvVentStatusDto(
+    val status: TaAvVentStatus
+)
+
+enum class TaAvVentStatus {
+    OK,
+    ANNEN_BEHANDLING_MÅ_FERDIGSTILLES,
+    MÅ_OPPDATERES
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
@@ -1,0 +1,197 @@
+package no.nav.familie.ef.sak.behandling
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.dto.TaAvVentStatus
+import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.kontrakter.ef.iverksett.Hendelse
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+internal class BehandlingPåVentServiceTest {
+
+    private val behandlingService = mockk<BehandlingService>(relaxed = true)
+    private val taskService = mockk<TaskService>(relaxed = true)
+    private val behandlingPåVentService =
+        BehandlingPåVentService(
+            behandlingService,
+            taskService,
+        )
+    val fagsak = fagsak()
+    val tidligereIverksattBehandling = behandling(fagsak)
+    val behandling = behandling(fagsak)
+    val behandlingId = behandling.id
+
+    @BeforeEach
+    internal fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler(true) } returns "bob"
+        mockFinnSisteIverksatteBehandling(null)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Nested
+    inner class SettPåVent {
+
+        @Test
+        fun `skal sette behandling på vent hvis den kan redigeres og sende melding til DVH`() {
+            mockHentBehandling(BehandlingStatus.UTREDES)
+
+            behandlingPåVentService.settPåVent(behandlingId)
+
+            verify { behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.SATT_PÅ_VENT) }
+            verify {
+                taskService.save(
+                    coWithArg {
+                        assertThat(it.type).isEqualTo(BehandlingsstatistikkTask.TYPE)
+                        assertThat(it.payload).contains(Hendelse.VENTER.name)
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `skal ikke sette behandling på vent hvis den er sperret for redigering`() {
+            mockHentBehandling(BehandlingStatus.FATTER_VEDTAK)
+
+            val feil: ApiFeil = assertThrows { behandlingPåVentService.settPåVent(behandlingId) }
+
+            assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+    }
+
+    @Nested
+    inner class KanTaAvVent {
+
+        @BeforeEach
+        internal fun setUp() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT)
+        }
+
+        @Test
+        internal fun `kan ta av vent når det ikke finnes andre behandlinger`() {
+            every { behandlingService.hentBehandlinger(fagsak.id) } returns emptyList()
+
+            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId)).isEqualTo(TaAvVentStatus.OK)
+        }
+
+        @Test
+        internal fun `kaster feil når behandlingen ikke har status PÅ_VENT`() {
+            mockHentBehandling(BehandlingStatus.UTREDES)
+
+            val feil: ApiFeil = assertThrows { behandlingPåVentService.kanTaAvVent(behandlingId) }
+
+            assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+
+        @Test
+        internal fun `kan ta av vent hvis siste behandling på vent peker til siste iverksatte behandling`() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT, forrigeBehandlingId = tidligereIverksattBehandling.id)
+            mockFinnSisteIverksatteBehandling(tidligereIverksattBehandling)
+
+            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId)).isEqualTo(TaAvVentStatus.OK)
+        }
+
+        @Test
+        internal fun `må oppdatere behandling hvis siste iverksatte behandling er en annen enn behandling på vent peker til`() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT, forrigeBehandlingId = UUID.randomUUID())
+            mockFinnSisteIverksatteBehandling(tidligereIverksattBehandling)
+
+            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId)).isEqualTo(TaAvVentStatus.MÅ_OPPDATERES)
+        }
+
+        @Test
+        internal fun `annen behandling må ferdigstilles`() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT, forrigeBehandlingId = UUID.randomUUID())
+            mockHentBehandlinger(behandling(fagsak, status = BehandlingStatus.IVERKSETTER_VEDTAK))
+
+            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId))
+                .isEqualTo(TaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES)
+        }
+    }
+
+    @Nested
+    inner class TaAvVent {
+
+        @BeforeEach
+        internal fun setUp() {
+            mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT)
+        }
+
+        @Test
+        fun `skal ta behandling av vent og sende melding til DVH`() {
+            behandlingPåVentService.taAvVent(behandlingId)
+
+            verify { behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES) }
+            verify {
+                taskService.save(
+                    coWithArg {
+                        assertThat(it.type).isEqualTo(BehandlingsstatistikkTask.TYPE)
+                        assertThat(it.payload).contains(Hendelse.PÅBEGYNT.name)
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `skal feile hvis behandling ikke er på vent`() {
+            mockHentBehandling(BehandlingStatus.FATTER_VEDTAK)
+
+            val feil: ApiFeil = assertThrows { behandlingPåVentService.taAvVent(behandlingId) }
+
+            assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+
+        @Test
+        internal fun `skal feile hvis det finnes en annen behandling som må ferdigstilles`() {
+            mockHentBehandlinger(behandling(fagsak, status = BehandlingStatus.IVERKSETTER_VEDTAK))
+
+            val feil: ApiFeil = assertThrows { behandlingPåVentService.taAvVent(behandlingId) }
+
+            assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
+        }
+
+        @Test
+        internal fun `skal oppdateres hvis behandlingen ikke peker till forrige iverksatte behandling`() {
+            mockFinnSisteIverksatteBehandling(tidligereIverksattBehandling)
+
+            val feil: IllegalStateException = assertThrows { behandlingPåVentService.taAvVent(behandlingId) }
+
+            assertThat(feil).hasMessageContaining("Har ikke støtte for dette ennå")
+        }
+    }
+
+    private fun mockHentBehandling(status: BehandlingStatus, forrigeBehandlingId: UUID? = null) {
+        every {
+            behandlingService.hentBehandling(behandlingId)
+        } returns behandling.copy(status = status, forrigeBehandlingId = forrigeBehandlingId)
+    }
+
+    private fun mockHentBehandlinger(vararg behandlinger: Behandling) {
+        every { behandlingService.hentBehandlinger(fagsak.id) } returns behandlinger.toList()
+    }
+
+    private fun mockFinnSisteIverksatteBehandling(behandling: Behandling?) {
+        every { behandlingService.finnSisteIverksatteBehandling(fagsak.id) } returns behandling
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
@@ -117,7 +117,7 @@ internal class BehandlingPåVentServiceTest {
             mockHentBehandling(BehandlingStatus.SATT_PÅ_VENT, forrigeBehandlingId = UUID.randomUUID())
             mockFinnSisteIverksatteBehandling(tidligereIverksattBehandling)
 
-            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId)).isEqualTo(TaAvVentStatus.MÅ_OPPDATERES)
+            assertThat(behandlingPåVentService.kanTaAvVent(behandlingId)).isEqualTo(TaAvVentStatus.MÅ_NULSTILLE_VEDTAK)
         }
 
         @Test


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10514

All funksjonalitet er ikke klar, men et steg på veien

* Databasen tillater behandling PÅ_VENT og utredes samtidig (denne ble fjernet fra denne branch og blir egen PR)
* Hvis man må oppdatere forrigeBehandlingId så feiler det, dette håndteres i egen PR

Litt koblet til frontend-PR uten at vi ennå synket
* https://github.com/navikt/familie-ef-sak-frontend/pull/1951