### PR TITLE
Ikke fjern sanksjon i historikk om sanksjon fortsatt er gjeldende

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
@@ -164,6 +164,7 @@ object AndelHistorikkBeregner {
         val tilkjentYtelse = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse
         if (vedtaksperiode !is Sanksjonsperiode && vedtaksperiode !is Opphørsperiode && andel.kildeBehandlingId == tilkjentYtelse.behandlingId) {
             historikk.filter { it.andel.stønadFom > andel.stønadFom }
+                .filterNot { it.vedtaksperiode is Sanksjonsperiode }
                 .filter { it.endring == null || it.endring!!.type != EndringType.FJERNET }
                 .forEach { it.endring = lagEndring(EndringType.FJERNET, tilkjentYtelseMedVedtakstidspunkt) }
         }

--- a/src/test/resources/no/nav/familie/ef/sak/revurder_innvilg_med_sanksjon.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/revurder_innvilg_med_sanksjon.feature
@@ -22,8 +22,7 @@ Egenskap: Andelhistorikk: Sanksjon
       | BehandlingId | Endringstype | Endret i behandlingId | Inntekt | Vedtaksperiode | Aktivitet            | Fra og med dato | Til og med dato |
       | 1            | ERSTATTET    | 3                     | 0       | HOVEDPERIODE   | BARN_UNDER_ETT_ÅR    | 01.2022         | 02.2022         |
       | 3            |              |                       | 0       | HOVEDPERIODE   | FORSØRGER_I_ARBEID   | 01.2022         | 02.2022         |
-      | 2            | FJERNET      | 3                     | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
-      | 3            |              |                       | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
+      | 2            |              |                       | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
 
   Scenario: Revurderer en periode som inneholder sanksjon, med innvilget periode etterpå
 
@@ -46,6 +45,5 @@ Egenskap: Andelhistorikk: Sanksjon
       | BehandlingId | Endringstype | Endret i behandlingId | Inntekt | Vedtaksperiode | Aktivitet            | Fra og med dato | Til og med dato |
       | 1            | ERSTATTET    | 3                     | 0       | HOVEDPERIODE   | BARN_UNDER_ETT_ÅR    | 01.2022         | 02.2022         |
       | 3            |              |                       | 0       | HOVEDPERIODE   | FORSØRGER_I_ARBEID   | 01.2022         | 02.2022         |
-      | 2            | FJERNET      | 3                     | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
-      | 3            |              |                       | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
+      | 2            |              |                       | 0       | SANKSJON       | IKKE_AKTIVITETSPLIKT | 03.2022         | 03.2022         |
       | 3            |              |                       | 0       | HOVEDPERIODE   | FORSØRGER_I_ARBEID   | 04.2022         | 04.2022         |

--- a/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
@@ -164,3 +164,104 @@ Egenskap: Andelhistorikk: Sanksjon
       | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.02.2021  |
       | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
       | 3            | 03.2021         | 03.2021         |              |                       |                | 01.03.2021  |
+
+  Scenario: 2 sanksjoner revurderer før begge og begge fjernes
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+      | 4            | REVURDERING           | 01.04.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 03.2021         | 03.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 4            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | FJERNET      | 4                     |                | 01.01.2021  |
+      | 4            | 01.2021         | 01.2021         |              |                       |                | 01.04.2021  |
+      | 2            | 02.2021         | 02.2021         | FJERNET      | 4                     | SANKSJON       | 01.02.2021  |
+      | 3            | 03.2021         | 03.2021         | FJERNET      | 4                     | SANKSJON       | 01.03.2021  |
+
+  Scenario: 2 sanksjoner der siste blir revurder og fjernet
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+      | 4            | REVURDERING           | 01.04.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 03.2021         | 03.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 4            | 03.2021         | 03.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         |              |                       |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.02.2021  |
+      | 3            | 03.2021         | 03.2021         | ERSTATTET    | 4                     | SANKSJON       | 01.03.2021  |
+      | 4            | 03.2021         | 03.2021         |              |                       |                | 01.04.2021  |
+
+  Scenario: 2 sanksjoner, revurderer fra datot på første sanksjonen og begge fjernes
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+      | 4            | REVURDERING           | 01.04.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 03.2021         | 03.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 4            | 02.2021         | 02.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         |              |                       |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         | ERSTATTET    | 4                     | SANKSJON       | 01.02.2021  |
+      | 4            | 02.2021         | 02.2021         |              |                       |                | 01.04.2021  |
+      | 3            | 03.2021         | 03.2021         | FJERNET      | 4                     | SANKSJON       | 01.03.2021  |
+
+  Scenario: 2 sanksjoner med revurdering fra første der andre beholdes
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+      | 4            | REVURDERING           | 01.04.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 03.2021         | 03.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 4            | 02.2021         | 02.2021         | INNVILGE        |                |                   |
+      | 4            | 03.2021         | 03.2021         | INNVILGE        | SANKSJON       | SAGT_OPP_STILLING |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         |              |                       |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         | ERSTATTET    | 4                     | SANKSJON       | 01.02.2021  |
+      | 4            | 02.2021         | 02.2021         |              |                       |                | 01.04.2021  |
+      | 3            | 03.2021         | 03.2021         |              |                       | SANKSJON       | 01.03.2021  |

--- a/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
@@ -23,3 +23,144 @@ Egenskap: Andelhistorikk: Sanksjon
       | 3            | 04.2021         | 04.2021         | FJERNET      | 4                     |                |
       | 4            | 04.2021         | 04.2021         |              |                       | SANKSJON       |
 
+  Scenario: Revurder før sanksjon, beholder sanksjon
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 3            | 02.2021         | 02.2021         | INNVILGE        | SANKSJON       | SAGT_OPP_STILLING |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | FJERNET      | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
+      | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.02.2021  |
+
+  Scenario: Revurder før sanksjon og fjerner sanksjonen
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | FJERNET      | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
+      | 2            | 02.2021         | 02.2021         | FJERNET      | 3                     | SANKSJON       | 01.02.2021  |
+
+  Scenario: Revurder fra sanksjon og fjerner sanksjonen med ny periode i stedet for sanksjonen
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 02.2021         | 02.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         |              |                       |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         | ERSTATTET    | 3                     | SANKSJON       | 01.02.2021  |
+      | 3            | 02.2021         | 02.2021         |              |                       |                | 01.03.2021  |
+
+  Scenario: Revurder før sanksjon og fjerner sanksjonen med ny periode i stedet for sanksjonen
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 3            | 02.2021         | 02.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | FJERNET      | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
+      | 2            | 02.2021         | 02.2021         | ERSTATTET    | 3                     | SANKSJON       | 01.02.2021  |
+      | 3            | 02.2021         | 02.2021         |              |                       |                | 01.03.2021  |
+
+  Scenario: Revurder før sanksjon med periode før og etter, fjerner sanksjon
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 03.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 03.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | ERSTATTET    | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 03.2021         |              |                       |                | 01.03.2021  |
+      | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         | FJERNET      | 3                     | SANKSJON       | 01.02.2021  |
+      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+
+  Scenario: Revurder før sanksjon med periode før og etter, beholde sanksjon
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.02.2021  |
+      | 3            | REVURDERING           | 01.03.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 03.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 01.2021         | INNVILGE        |                |                   |
+      | 3            | 02.2021         | 02.2021         | INNVILGE        | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 03.2021         | 03.2021         | INNVILGE        |                |                   |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | FJERNET      | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
+      | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.02.2021  |
+      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+      | 3            | 03.2021         | 03.2021         |              |                       |                | 01.03.2021  |


### PR DESCRIPTION
Oppgave [Tea-10708](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10708)

Tidligere ble revurderte sanksjonsperioder overskrevet og markert som fjernet. I historikken ble sanksjonen opprettet på nytt og fikk vedtaksdatoen til revurderingen. 