### PR TITLE
Fjern toggle-8år-validering. Skrudd på i både dev og prod. Ikke lenge…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -23,7 +23,6 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
         Toggle.FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR,
         Toggle.FRONTEND_SATSENDRING,
         Toggle.FØRSTEGANGSBEHANDLING,
-        Toggle.BRUK_8_ÅR_HOVEDPERIODEVALIDERING,
         Toggle.VIS_SETT_PÅ_VENT_KNAPP,
         Toggle.PERSONOPPLYSNINGER_ENDRINGER,
         Toggle.AUTOMATISKE_HJEMLER_BREV,

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -43,7 +43,6 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     FRONTEND_SATSENDRING("familie.ef.sak.frontend-vis-satsendring"),
     FØRSTEGANGSBEHANDLING("familie.ef.sak.opprett-forstegangsbehandling"),
     AUTOMATISK_JOURNALFØR_REVURDERING("familie.ef.sak.automatisk-journalfor-revurdering"),
-    BRUK_8_ÅR_HOVEDPERIODEVALIDERING("familie.ef.sak.frontend-bruk-validering-8ar-hovedperiode"),
     VIS_SETT_PÅ_VENT_KNAPP("familie.ef.sak.frontend.vis-sett-pa-vent-knapp"),
     HISTORISK_PENSJON("familie.ef.sak.historisk-pensjon"),
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),


### PR DESCRIPTION
…r i bruk.

Merges når endringer i [familie-ef-sak-frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2016) 
er merget.