### PR TITLE
Tar i bruk postgres v14 i tester

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # SQL database
   postgres:
-    image: "postgres:11.5"
+    image: "postgres:14.6"
     volumes:
       - "familie-ef-sak-data:/var/lib/postgresql/data"
     ports:

--- a/src/test/kotlin/no/nav/familie/ef/sak/database/DbContainerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/database/DbContainerInitializer.kt
@@ -20,7 +20,7 @@ class DbContainerInitializer : ApplicationContextInitializer<ConfigurableApplica
 
         // Lazy because we only want it to be initialized when accessed
         private val postgres: KPostgreSQLContainer by lazy {
-            KPostgreSQLContainer("postgres:11.1")
+            KPostgreSQLContainer("postgres:14.6")
                 .withDatabaseName("ef-sak")
                 .withUsername("postgres")
                 .withPassword("test")


### PR DESCRIPTION
```bash
# gammel versjon av postgres kjørendes
docker-compose exec postgres pg_dumpall -U postgres > dump.sql
docker-compose down
docker volume rm familie-ef-sak_familie-ef-sak-data
# ny versjon av postgres
docker-compose-up
# det blir noe krøll med passordet her pga hvordan 11 og 14 håndterer passord
echo "alter user postgres with password 'test';" >> dump.sql
docker-compose exec -T postgres psql -U postgres -d familie-ef-sak < dump.sql
```