### PR TITLE
Fjerner toggles som ikke lengre skal være i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -23,9 +23,7 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
         Toggle.FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR,
         Toggle.FRONTEND_SATSENDRING,
         Toggle.FØRSTEGANGSBEHANDLING,
-        Toggle.VIS_SETT_PÅ_VENT_KNAPP,
         Toggle.PERSONOPPLYSNINGER_ENDRINGER,
-        Toggle.AUTOMATISKE_HJEMLER_BREV,
         Toggle.ANGRE_SEND_TIL_BESLUTTER
     )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -40,10 +40,8 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     FRONTEND_SATSENDRING("familie.ef.sak.frontend-vis-satsendring"),
     FØRSTEGANGSBEHANDLING("familie.ef.sak.opprett-forstegangsbehandling"),
     AUTOMATISK_JOURNALFØR_REVURDERING("familie.ef.sak.automatisk-journalfor-revurdering"),
-    VIS_SETT_PÅ_VENT_KNAPP("familie.ef.sak.frontend.vis-sett-pa-vent-knapp"),
     HISTORISK_PENSJON("familie.ef.sak.historisk-pensjon"),
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),
-    AUTOMATISKE_HJEMLER_BREV("familie.ef.sak.frontend.automatiske-hjemler-brev"),
     ANGRE_SEND_TIL_BESLUTTER("familie.ef.sak.frontend-angre-send-til-beslutter");
 
     companion object {


### PR DESCRIPTION
Kan merges etter https://github.com/navikt/familie-ef-sak-frontend/pull/2025 og https://github.com/navikt/familie-ef-sak-frontend/pull/2026 har vært ute en stund