### PR TITLE
Oppdater feilmelding dersom godkjenne vedtak oppgave ikke finnes

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/AngreSendTilBeslutterService.kt
@@ -85,7 +85,7 @@ class AngreSendTilBeslutterService(
             oppgavetype = Oppgavetype.GodkjenneVedtak,
             saksbehandling = saksbehandling
         )
-            ?: throw ApiFeil(feil = "Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda. Denne må opprettes før man kan angre send til beslutter. Prøv igjen om litt.", httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
+            ?: throw ApiFeil(feil = "Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda. Prøv igjen om litt.", httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
 
         val tilordnetRessurs = oppgaveService.hentOppgave(efOppgave.gsakOppgaveId).tilordnetRessurs
         val oppgaveErTilordnetEnAnnenSaksbehandler =

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/AngreSendTilBeslutterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/AngreSendTilBeslutterService.kt
@@ -7,11 +7,13 @@ import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillOppgaveTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveTask
 import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.StegUtfall
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -83,7 +85,7 @@ class AngreSendTilBeslutterService(
             oppgavetype = Oppgavetype.GodkjenneVedtak,
             saksbehandling = saksbehandling
         )
-            ?: error("Fant ingen godkjenne vedtak oppgave")
+            ?: throw ApiFeil(feil = "Systemet har ikke rukket å opprette godkjenne vedtak oppgaven enda. Denne må opprettes før man kan angre send til beslutter. Prøv igjen om litt.", httpStatus = HttpStatus.INTERNAL_SERVER_ERROR)
 
         val tilordnetRessurs = oppgaveService.hentOppgave(efOppgave.gsakOppgaveId).tilordnetRessurs
         val oppgaveErTilordnetEnAnnenSaksbehandler =

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/TotrinnskontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/TotrinnskontrollService.kt
@@ -81,15 +81,10 @@ class TotrinnskontrollService(
     }
 
     fun hentSaksbehandlerSomSendteTilBeslutter(behandlingId: UUID): String {
-        val sisteBehandlingshistorikk = behandlingshistorikkService.finnSisteBehandlingshistorikk(behandlingId)
-        if (sisteBehandlingshistorikk.steg != StegType.SEND_TIL_BESLUTTER) {
-            throw Feil(
-                message = "Kan ikke utlede hvem som sendte til beslutter. Siste innslag i behandlingshistorikken har feil steg=${sisteBehandlingshistorikk.steg}",
-                frontendFeilmelding = "Behandlingen er i feil steg, last siden på nytt",
-                httpStatus = HttpStatus.BAD_REQUEST
-            )
-        }
-        return sisteBehandlingshistorikk.opprettetAv
+        val sisteBehandlingshistorikk =
+            behandlingshistorikkService.finnSisteBehandlingshistorikk(behandlingId, StegType.SEND_TIL_BESLUTTER)
+
+        return sisteBehandlingshistorikk?.opprettetAv ?: throw Feil("Fant ikke saksbehandler som sendte til beslutter")
     }
 
     fun hentBeslutter(behandlingId: UUID): String? {

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/TotrinnskontrollServiceTest.kt
@@ -62,7 +62,7 @@ internal class TotrinnskontrollServiceTest {
     @Test
     internal fun `skal utlede saksbehandler som sendte behandling til besluttning`() {
         val opprettetAv = "Behandler"
-        every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any()) } returns
+        every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any(), StegType.SEND_TIL_BESLUTTER) } returns
             behandlingshistorikk(StegType.SEND_TIL_BESLUTTER, opprettetAv = opprettetAv)
         val response = totrinnskontrollService
             .hentSaksbehandlerSomSendteTilBeslutter(UUID.randomUUID())


### PR DESCRIPTION
Hvis man trykker på "angre send til beslutter" for fort etter at man har sendt behandlingen har ikke oppgaven blitt laget enda (typ hvis man trykker etter 2 sek). Derfor returneres det en litt mer spesifikk feilmelding til saksbehandler. 