### PR TITLE
Fjerner telefonnummer fra grunnlagsdata og fra data vi henter fra pdl

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Navn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Opphold
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Oppholdsadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Telefonnummer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.TilrettelagtKommunikasjon
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergemaalEllerFremtidsfullmakt
@@ -90,7 +89,6 @@ data class Søker(
     val oppholdsadresse: List<Oppholdsadresse>,
     val sivilstand: List<SivilstandMedNavn>,
     val statsborgerskap: List<Statsborgerskap>,
-    val telefonnummer: List<Telefonnummer>,
     val tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon>,
     val innflyttingTilNorge: List<InnflyttingTilNorge>,
     val utflyttingFraNorge: List<UtflyttingFraNorge>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -19,7 +19,6 @@ data class PersonopplysningerDto(
     val folkeregisterpersonstatus: Folkeregisterpersonstatus?,
     val fødselsdato: LocalDate?,
     val dødsdato: LocalDate?,
-    val telefonnummer: TelefonnummerDto?,
     val statsborgerskap: List<StatsborgerskapDto>,
     val sivilstand: List<SivilstandDto>,
     val adresse: List<AdresseDto>,
@@ -53,11 +52,6 @@ data class AnnenForelderMinimumDto(
     val personIdent: String,
     val navn: String,
     val dødsdato: LocalDate?
-)
-
-data class TelefonnummerDto(
-    val landskode: String,
-    val nummer: String
 )
 
 data class SivilstandDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -71,7 +71,6 @@ object GrunnlagsdataMapper {
         opphold = pdlSøker.opphold,
         oppholdsadresse = pdlSøker.oppholdsadresse,
         statsborgerskap = pdlSøker.statsborgerskap,
-        telefonnummer = pdlSøker.telefonnummer,
         tilrettelagtKommunikasjon = pdlSøker.tilrettelagtKommunikasjon,
         utflyttingFraNorge = pdlSøker.utflyttingFraNorge,
         vergemaalEllerFremtidsfullmakt = mapVergemålEllerFremtidsfullmakt(pdlSøker, andrePersoner),

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.SivilstandDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.TelefonnummerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.VergemålDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Bostedsadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Familierelasjonsrolle
@@ -53,8 +52,6 @@ class PersonopplysningerMapper(
             navn = NavnDto.fraNavn(søker.navn),
             kjønn = KjønnMapper.tilKjønn(søker.kjønn),
             personIdent = gjeldendePersonIdent,
-            telefonnummer = søker.telefonnummer.find { it.prioritet == 1 }
-                ?.let { TelefonnummerDto(it.landskode, it.nummer) },
             statsborgerskap = statsborgerskapMapper.map(søker.statsborgerskap),
             sivilstand = søker.sivilstand.map {
                 SivilstandDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -109,7 +109,6 @@ data class PdlSøker(
     val oppholdsadresse: List<Oppholdsadresse>,
     val sivilstand: List<Sivilstand>,
     val statsborgerskap: List<Statsborgerskap>,
-    val telefonnummer: List<Telefonnummer>,
     val tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon>,
     val innflyttingTilNorge: List<InnflyttingTilNorge>,
     val utflyttingFraNorge: List<UtflyttingFraNorge>,
@@ -370,12 +369,6 @@ data class Personnavn(
     val etternavn: String,
     val fornavn: String,
     val mellomnavn: String?
-)
-
-data class Telefonnummer(
-    val landskode: String,
-    val nummer: String,
-    val prioritet: Int
 )
 
 data class TilrettelagtKommunikasjon(

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -220,11 +220,6 @@ query($ident: ID!){
             gyldigFraOgMed
             gyldigTilOgMed
         }
-        telefonnummer {
-            landskode
-            nummer
-            prioritet
-        }
         tilrettelagtKommunikasjon {
             talespraaktolk {
                 spraak

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
@@ -34,7 +34,6 @@ fun opprettGrunnlagsdata(
         oppholdsadresse = emptyList(),
         sivilstand = emptyList(),
         statsborgerskap = emptyList(),
-        telefonnummer = emptyList(),
         tilrettelagtKommunikasjon = emptyList(),
         innflyttingTilNorge = innflyttingTilNorge,
         utflyttingFraNorge = utflyttingFraNorge,

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -40,7 +40,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PersonSøkTreff
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Telefonnummer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Vegadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergeEllerFullmektig
@@ -195,7 +194,6 @@ class PdlClientConfig {
                 oppholdsadresse = listOf(),
                 sivilstand = sivilstand(),
                 statsborgerskap = statsborgerskap(),
-                telefonnummer = listOf(Telefonnummer(landskode = "+47", nummer = "98999923", prioritet = 1)),
                 tilrettelagtKommunikasjon = listOf(),
                 innflyttingTilNorge = listOf(InnflyttingTilNorge("SWE", "Stockholm", folkeregistermetadata)),
                 utflyttingFraNorge = listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -440,7 +440,6 @@ internal class UtledEndringerUtilTest {
         folkeregisterpersonstatus = status,
         fødselsdato = fødselsdato,
         dødsdato = dødsdato,
-        telefonnummer = null,
         statsborgerskap = statsborgerskap,
         sivilstand = sivilstand,
         adresse = adresse,

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -141,7 +141,6 @@ object PdlTestdata {
                     )
                 ),
                 statsborgerskap,
-                listOf(Telefonnummer("", "", 1)),
                 listOf(TilrettelagtKommunikasjon(Tolk(""), Tolk(""))),
                 innflyttingTilNorge,
                 utflyttingFraNorge,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -477,6 +477,5 @@ fun søker(sivilstand: List<SivilstandMedNavn> = emptyList()): Søker =
         listOf(),
         listOf(),
         listOf(),
-        listOf(),
         listOf()
     )

--- a/src/test/kotlin/testutil/PdlTestdataHelper.kt
+++ b/src/test/kotlin/testutil/PdlTestdataHelper.kt
@@ -22,7 +22,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonForeld
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Telefonnummer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.TilrettelagtKommunikasjon
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UkjentBosted
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
@@ -65,7 +64,6 @@ object PdlTestdataHelper {
         oppholdsadresse: List<Oppholdsadresse> = emptyList(),
         sivilstand: List<Sivilstand> = emptyList(),
         statsborgerskap: List<Statsborgerskap> = emptyList(),
-        telefonnummer: List<Telefonnummer> = emptyList(),
         tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon> = emptyList(),
         innflyttingTilNorge: List<InnflyttingTilNorge> = emptyList(),
         utflyttingFraNorge: List<UtflyttingFraNorge> = emptyList(),
@@ -88,7 +86,6 @@ object PdlTestdataHelper {
             oppholdsadresse,
             sivilstand,
             statsborgerskap,
-            telefonnummer,
             tilrettelagtKommunikasjon,
             innflyttingTilNorge,
             utflyttingFraNorge,

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -891,28 +891,6 @@
         },
         "nullable" : false
       },
-      "telefonnummer" : {
-        "name" : "telefonnummer",
-        "type" : "Collection",
-        "fields" : {
-          "landskode" : {
-            "name" : "landskode",
-            "type" : "String",
-            "nullable" : false
-          },
-          "nummer" : {
-            "name" : "nummer",
-            "type" : "String",
-            "nullable" : false
-          },
-          "prioritet" : {
-            "name" : "prioritet",
-            "type" : "Int",
-            "nullable" : false
-          }
-        },
-        "nullable" : false
-      },
       "tilrettelagtKommunikasjon" : {
         "name" : "tilrettelagtKommunikasjon",
         "type" : "Collection",

--- a/src/test/resources/json/personopplysningerDto.json
+++ b/src/test/resources/json/personopplysningerDto.json
@@ -11,10 +11,6 @@
   "folkeregisterpersonstatus" : "BOSATT",
   "fødselsdato" : "2018-01-01",
   "dødsdato" : null,
-  "telefonnummer" : {
-    "landskode" : "+47",
-    "nummer" : "98999923"
-  },
   "statsborgerskap" : [ {
     "land" : "Norge",
     "gyldigFraOgMedDato" : "2020-01-01",

--- a/src/test/resources/json/søker.json
+++ b/src/test/resources/json/søker.json
@@ -146,7 +146,6 @@
           "gyldigTilOgMed": null
         }
       ],
-      "telefonnummer": [],
       "tilrettelagtKommunikasjon": [],
       "innflyttingTilNorge": [
         {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10864

* https://github.com/navikt/familie-ef-sak-frontend/pull/2060

Hvis vi skal fjerne telefonnummer fra databasen så kan man kjøre
```sql
update grunnlagsdata set data = (data::jsonb #- '{søker, telefonnummer}');
```