### PR TITLE
Oppgaver versjonshåndtering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -75,6 +75,8 @@ class OppgaveClient(
                     "Oppgaven med id=$oppgaveId er allerede ferdigstilt. Prøv å hente oppgaver på nytt.",
                     HttpStatus.BAD_REQUEST
                 )
+            } else if (e.httpStatus == HttpStatus.CONFLICT) {
+                throw ApiFeil("Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du hente oppgaver på nytt.", HttpStatus.CONFLICT)
             }
             throw e
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -75,7 +75,7 @@ class OppgaveClient(
                     "Oppgaven med id=$oppgaveId er allerede ferdigstilt. Prøv å hente oppgaver på nytt.",
                     HttpStatus.BAD_REQUEST
                 )
-            } else if (e.httpStatus == HttpStatus.CONFLICT) {
+            } else if (e.ressurs.melding.contains("Versjonskonflikt")) {
                 throw ApiFeil("Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du hente oppgaver på nytt.", HttpStatus.CONFLICT)
             }
             throw e

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -54,12 +54,16 @@ class OppgaveClient(
         return pakkUtRespons(respons, uri, "hentOppgaver")
     }
 
-    fun fordelOppgave(oppgaveId: Long, saksbehandler: String?): Long {
+    fun fordelOppgave(oppgaveId: Long, saksbehandler: String?, versjon: Int? = null): Long {
         val baseUri = URI.create("$oppgaveUri/$oppgaveId/fordel")
-        val uri = if (saksbehandler == null) {
-            baseUri
-        } else {
-            UriComponentsBuilder.fromUri(baseUri).queryParam("saksbehandler", saksbehandler).build().toUri()
+        var uri = baseUri
+
+        if (saksbehandler != null) {
+            uri = UriComponentsBuilder.fromUri(uri).queryParam("saksbehandler", saksbehandler).build().toUri()
+        }
+
+        if (versjon != null) {
+            uri = UriComponentsBuilder.fromUri(uri).queryParam("versjon", versjon).build().toUri()
         }
 
         try {

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -35,7 +35,8 @@ class OppgaveClient(
     fun opprettOppgave(opprettOppgave: OpprettOppgaveRequest): Long {
         val uri = URI.create("$oppgaveUri/opprett")
 
-        val respons = postForEntity<Ressurs<OppgaveResponse>>(uri, opprettOppgave, HttpHeaders().medContentTypeJsonUTF8())
+        val respons =
+            postForEntity<Ressurs<OppgaveResponse>>(uri, opprettOppgave, HttpHeaders().medContentTypeJsonUTF8())
         return pakkUtRespons(respons, uri, "opprettOppgave").oppgaveId
     }
 
@@ -50,21 +51,19 @@ class OppgaveClient(
         val uri = URI.create("$oppgaveUri/v4")
 
         val respons =
-            postForEntity<Ressurs<FinnOppgaveResponseDto>>(uri, finnOppgaveRequest, HttpHeaders().medContentTypeJsonUTF8())
+            postForEntity<Ressurs<FinnOppgaveResponseDto>>(
+                uri,
+                finnOppgaveRequest,
+                HttpHeaders().medContentTypeJsonUTF8()
+            )
         return pakkUtRespons(respons, uri, "hentOppgaver")
     }
 
     fun fordelOppgave(oppgaveId: Long, saksbehandler: String?, versjon: Int? = null): Long {
         val baseUri = URI.create("$oppgaveUri/$oppgaveId/fordel")
-        var uri = baseUri
-
-        if (saksbehandler != null) {
-            uri = UriComponentsBuilder.fromUri(uri).queryParam("saksbehandler", saksbehandler).build().toUri()
-        }
-
-        if (versjon != null) {
-            uri = UriComponentsBuilder.fromUri(uri).queryParam("versjon", versjon).build().toUri()
-        }
+        val uri = UriComponentsBuilder.fromUri(baseUri)
+            .queryParam("saksbehandler", saksbehandler)
+            .queryParam("versjon", versjon).build().toUri()
 
         try {
             val respons = postForEntity<Ressurs<OppgaveResponse>>(uri, HttpHeaders().medContentTypeJsonUTF8())
@@ -76,7 +75,10 @@ class OppgaveClient(
                     HttpStatus.BAD_REQUEST
                 )
             } else if (e.ressurs.melding.contains("Versjonskonflikt")) {
-                throw ApiFeil("Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du hente oppgaver på nytt.", HttpStatus.CONFLICT)
+                throw ApiFeil(
+                    "Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du hente oppgaver på nytt.",
+                    HttpStatus.CONFLICT
+                )
             }
             throw e
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -62,13 +62,14 @@ class OppgaveController(
     @PostMapping(path = ["/{gsakOppgaveId}/fordel"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun fordelOppgave(
         @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
-        @RequestParam("saksbehandler") saksbehandler: String
+        @RequestParam("saksbehandler") saksbehandler: String,
+        @RequestParam("versjon") versjon: Int?
     ): Ressurs<Long> {
         tilgangService.validerHarSaksbehandlerrolle()
         if (!tilgangService.validerSaksbehandler(saksbehandler)) {
             throw ApiFeil("Kunne ikke validere saksbehandler : $saksbehandler", HttpStatus.BAD_REQUEST)
         }
-        return Ressurs.success(oppgaveService.fordelOppgave(gsakOppgaveId, saksbehandler))
+        return Ressurs.success(oppgaveService.fordelOppgave(gsakOppgaveId, saksbehandler, versjon))
     }
 
     @PostMapping(path = ["/{gsakOppgaveId}/tilbakestill"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -72,9 +72,12 @@ class OppgaveController(
     }
 
     @PostMapping(path = ["/{gsakOppgaveId}/tilbakestill"], produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun tilbakestillFordelingPåOppgave(@PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long): Ressurs<Long> {
+    fun tilbakestillFordelingPåOppgave(
+        @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
+        @RequestParam(name = "versjon") versjon: Int?
+    ): Ressurs<Long> {
         tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(oppgaveService.tilbakestillFordelingPåOppgave(gsakOppgaveId))
+        return Ressurs.success(oppgaveService.tilbakestillFordelingPåOppgave(gsakOppgaveId, versjon))
     }
 
     @GetMapping(path = ["/{gsakOppgaveId}"], produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.ENHET_NR_NAY
-import no.nav.familie.ef.sak.oppgave.OppgaveUtil.sekunderSidenEndret
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
@@ -152,17 +151,12 @@ class OppgaveService(
         return mappe.id.toLong()
     }
 
-    fun fordelOppgave(gsakOppgaveId: Long, saksbehandler: String): Long {
-        val gsakOppgave = hentOppgave(gsakOppgaveId)
-        val tidligereSaksbehandler = gsakOppgave.tilordnetRessurs
-        if (tidligereSaksbehandler != saksbehandler && tidligereSaksbehandler != null) {
-            logger.info(
-                "(Eier av behandling/oppgave) Fordeler oppgave=$gsakOppgaveId " +
-                    "fra=$tidligereSaksbehandler til=$saksbehandler " +
-                    "sekunderSidenEndret=${sekunderSidenEndret(gsakOppgave)}"
-            )
-        }
-        return oppgaveClient.fordelOppgave(gsakOppgaveId, saksbehandler)
+    fun fordelOppgave(gsakOppgaveId: Long, saksbehandler: String, versjon: Int? = null): Long {
+        return oppgaveClient.fordelOppgave(
+            gsakOppgaveId,
+            saksbehandler,
+            versjon
+        )
     }
 
     fun tilbakestillFordelingPåOppgave(gsakOppgaveId: Long, versjon: Int? = null): Long {

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -165,8 +165,8 @@ class OppgaveService(
         return oppgaveClient.fordelOppgave(gsakOppgaveId, saksbehandler)
     }
 
-    fun tilbakestillFordelingPåOppgave(gsakOppgaveId: Long): Long {
-        return oppgaveClient.fordelOppgave(gsakOppgaveId, null)
+    fun tilbakestillFordelingPåOppgave(gsakOppgaveId: Long, versjon: Int? = null): Long {
+        return oppgaveClient.fordelOppgave(gsakOppgaveId, null, versjon = versjon)
     }
 
     fun hentOppgaveSomIkkeErFerdigstilt(oppgavetype: Oppgavetype, saksbehandling: Saksbehandling): EfOppgave? {

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerTest.kt
@@ -58,6 +58,25 @@ internal class OppgaveControllerTest {
     }
 
     @Test
+    internal fun `skal sende med versjon i request `() {
+        val versjonSlot = slot<Int>()
+        val oppgaveIdSlot = slot<Long>()
+        tilgangOgRolleJustRuns()
+        every { oppgaveService.fordelOppgave(capture(oppgaveIdSlot), any(), capture(versjonSlot)) } returns 123
+        oppgaveController.fordelOppgave(123, "saksbehandler", 1)
+        assertThat(versjonSlot.captured).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `skal ikke feile hvis versjon er null `() {
+        val versjonSlot = slot<Int>()
+        val oppgaveIdSlot = slot<Long>()
+        tilgangOgRolleJustRuns()
+        every { oppgaveService.fordelOppgave(capture(oppgaveIdSlot), any()) } returns 123
+        oppgaveController.fordelOppgave(123, "saksbehandler", versjon = null)
+    }
+
+    @Test
     internal fun `skal ikke feile hvis ident er tom`() {
         val finnOppgaveRequestSlot = slot<FinnOppgaveRequest>()
         tilgangOgRolleJustRuns()
@@ -88,7 +107,7 @@ internal class OppgaveControllerTest {
         } throws ManglerTilgang("Bruker mangler tilgang", "Mangler tilgang")
 
         assertThrows<ManglerTilgang> {
-            oppgaveController.fordelOppgave(123, "dummy saksbehandler")
+            oppgaveController.fordelOppgave(123, "dummy saksbehandler", null)
         }
     }
 
@@ -154,5 +173,9 @@ internal class OppgaveControllerTest {
         every {
             tilgangService.validerHarSaksbehandlerrolle()
         } just Runs
+
+        every {
+            tilgangService.validerSaksbehandler(any())
+        } returns true
     }
 }


### PR DESCRIPTION
Oppgave [TEA-11403](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11403)

### Hvorfor er dette nødvendig?
Unngå at feil oppstår fordi SB ikke har den nyeste versjonen av en oppgave. 
Henger sammen med [PR-2089](https://github.com/navikt/familie-ef-sak-frontend/pull/2089) i ef-sak-frontend og [PR-788](https://github.com/navikt/familie-integrasjoner/pull/788) i familie-integrasjoner. 

### Hva er gjort

- Gjør det mulig å sende inn versjon til endepunkter for fordeling og tilbakestilling
- Sender egen feilmelding dersom kall feiler pga. versjon 
- Fjernet logging av bytte av saksbehandler på oppgave. Denne informasjonen skal senere legges inn i beskrivelse (egen oppgave)