### PR TITLE
Splittet opp periode fra sanksjon skal peke til behandlingen som den o…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
@@ -29,9 +29,15 @@ object AndelHistorikkBeregner {
         var kontrollert: UUID
     )
 
+    /**
+     * @param kontrollertId peker til tilkjent ytelse som man prosesserer, for å kunne markere riktige perioder som fjernet
+     * @param tilkjentYtelse er TY(tilkjente ytelsen) som prosesseres, eller TY koblet til andelen sin [kildeBehandlingId]
+     * @param vedtaksdata liknende som [tilkjentYtelse]
+     */
     private data class TilkjentYtelseMedVedtakstidspunkt(
+        val kontrollertId: UUID,
         val tilkjentYtelse: TilkjentYtelse,
-        val vedtakstidspunkt: LocalDateTime
+        val vedtaksdata: Vedtaksdata
     )
 
     fun lagHistorikk(
@@ -142,11 +148,12 @@ object AndelHistorikkBeregner {
 
         val vedtaksdataPerBehandling = lagVedtaksperioderPerBehandling(behandlingHistorikkData, konfigurasjon)
 
-        tilkjentYtelser.forEach { tilkjentYtelse ->
-            val vedtaksdata = vedtaksdataPerBehandling.getValue(tilkjentYtelse.behandlingId)
+        tilkjentYtelser.map {
+            TilkjentYtelseMedVedtakstidspunkt(it.id, it, vedtaksdataPerBehandling.getValue(it.behandlingId))
+        }.forEach { tilkjentYtelseMedVedtakstidspunkt ->
+            val tilkjentYtelse = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse
+            val vedtaksdata = tilkjentYtelseMedVedtakstidspunkt.vedtaksdata
             val vedtaksperioder = vedtaksdata.perioder
-            val tilkjentYtelseMedVedtakstidspunkt =
-                TilkjentYtelseMedVedtakstidspunkt(tilkjentYtelse, vedtaksdata.vedtakstidspunkt)
 
             val andelerFraSanksjonOgOpphør = lagAndelerFraSanksjonerOgOpphør(vedtaksperioder, tilkjentYtelse)
             (tilkjentYtelse.andelerTilkjentYtelse + andelerFraSanksjonOgOpphør).sortedBy { it.stønadFom }.forEach { andel ->
@@ -157,21 +164,46 @@ object AndelHistorikkBeregner {
                 val andelFraHistorikk = finnTilsvarendeAndelIHistorikk(historikk, andel)
                 val index = finnIndeksForNyAndel(historikk, andel)
                 if (andelFraHistorikk == null) {
-                    historikk.add(index, lagNyAndel(tilkjentYtelseMedVedtakstidspunkt, andel, vedtaksperiode))
+                    val kildeTilkjentYtelse = tilkjentYtelseForKildeBehandlingId(andel,
+                        vedtaksdataPerBehandling,
+                        tilkjentYtelser,
+                        tilkjentYtelseMedVedtakstidspunkt)
+                    historikk.add(index, lagNyAndel(kildeTilkjentYtelse, andel, vedtaksperiode))
                 } else {
                     markerTidligereMedEndringOgReturnerNyAndel(
                         tilkjentYtelseMedVedtakstidspunkt,
                         andel,
                         andelFraHistorikk,
                         vedtaksperiode
-                    )
-                        ?.let { historikk.add(index, it) }
+                    )?.let { historikk.add(index, it) }
                 }
             }
 
             markerAndelerSomErFjernet(tilkjentYtelseMedVedtakstidspunkt, historikk)
         }
         return historikk
+    }
+
+    /**
+     * Hvis man har en andel jan-mars, og får en sakjson i februar, så splittes det i 2 andeler, jan og mars.
+     * Marsperioden beholder kildeBehandlingId til den behandling den ble opprinnelig opprettet fra
+     * Hvis då kildebehandlingId er annet enn det som tilkjent ytelse peker til, så skal man bruke dataen til den opprinnelige tilkjente ytelsen og vedtaksdata
+     * Men man skal beholde [kontrollertId] til TilkjentYtelse som man looper over for å ikke markere mars-andelen som fjernet
+     */
+    private fun tilkjentYtelseForKildeBehandlingId(
+        andel: AndelTilkjentYtelse,
+        vedtaksdataPerBehandling: Map<UUID, Vedtaksdata>,
+        tilkjentYtelser: List<TilkjentYtelse>,
+        tilkjentYtelseMedVedtakstidspunkt: TilkjentYtelseMedVedtakstidspunkt,
+    ): TilkjentYtelseMedVedtakstidspunkt {
+        return if (andel.kildeBehandlingId != tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.behandlingId) {
+            tilkjentYtelseMedVedtakstidspunkt.copy(
+                tilkjentYtelse = tilkjentYtelser.single { it.behandlingId == andel.kildeBehandlingId },
+                vedtaksdata = vedtaksdataPerBehandling.getValue(andel.kildeBehandlingId)
+            )
+        } else {
+            tilkjentYtelseMedVedtakstidspunkt
+        }
     }
 
     /**
@@ -260,12 +292,12 @@ object AndelHistorikkBeregner {
     ) =
         AndelHistorikkHolder(
             behandlingId = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.behandlingId,
-            vedtakstidspunkt = tilkjentYtelseMedVedtakstidspunkt.vedtakstidspunkt,
+            vedtakstidspunkt = tilkjentYtelseMedVedtakstidspunkt.vedtaksdata.vedtakstidspunkt,
             saksbehandler = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.sporbar.opprettetAv,
             andel = andel,
             endring = null,
             vedtaksperiode = vedtaksperiode,
-            kontrollert = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.id
+            kontrollert = tilkjentYtelseMedVedtakstidspunkt.kontrollertId
         )
 
     private fun AndelHistorikkHolder.finnEndringstype(
@@ -337,7 +369,7 @@ object AndelHistorikkBeregner {
         HistorikkEndring(
             type = type,
             behandlingId = tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.behandlingId,
-            vedtakstidspunkt = tilkjentYtelseMedVedtakstidspunkt.vedtakstidspunkt
+            vedtakstidspunkt = tilkjentYtelseMedVedtakstidspunkt.vedtaksdata.vedtakstidspunkt
         )
 
     /**

--- a/src/test/resources/no/nav/familie/ef/sak/barnetilsyn/sanksjon.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/barnetilsyn/sanksjon.feature
@@ -25,5 +25,5 @@ Egenskap: Andelhistorikk: Sanksjon av barnetilsyn
       | 1            | SPLITTET     | 01.2021         | 01.2021         | ORDINÆR        | 2                     | 10            | 15             | 1           | 200      | 107   | I_ARBEID  |                       |
       | 1            | FJERNET      | 02.2021         | 03.2021         | ORDINÆR        | 2                     | 10            | 15             | 1           | 200      | 107   | I_ARBEID  |                       |
       | 2            |              | 02.2021         | 02.2021         | SANKSJON_1_MND |                       | 0             | 0              | 0           | 0        | 0     |           | NEKTET_TILBUDT_ARBEID |
-      | 2            |              | 03.2021         | 03.2021         | ORDINÆR        |                       | 10            | 15             | 1           | 200      | 107   | I_ARBEID  |                       |
+      | 1            |              | 03.2021         | 03.2021         | ORDINÆR        |                       | 10            | 15             | 1           | 200      | 107   | I_ARBEID  |                       |
 

--- a/src/test/resources/no/nav/familie/ef/sak/barnetilsyn/sanksjon_revurdering.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/barnetilsyn/sanksjon_revurdering.feature
@@ -136,7 +136,7 @@ Egenskap: Andelhistorikk: Revurdere sanksjon for barnetilsyn
       | 3            | 01.2021         | 03.2021         |              |                       |                | 01.03.2021  |
       | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
       | 2            | 02.2021         | 02.2021         | FJERNET      | 3                     | SANKSJON_1_MND | 01.02.2021  |
-      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+      | 1            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.01.2021  |
 
   Scenario: Revurder før sanksjon med periode før og etter, beholde sanksjon
 
@@ -162,7 +162,7 @@ Egenskap: Andelhistorikk: Revurdere sanksjon for barnetilsyn
       | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
       | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
       | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON_1_MND | 01.02.2021  |
-      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+      | 1            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.01.2021  |
       | 3            | 03.2021         | 03.2021         |              |                       |                | 01.03.2021  |
 
   Scenario: 2 sanksjoner revurderer før begge og begge fjernes

--- a/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/sanksjon.feature
@@ -136,7 +136,7 @@ Egenskap: Andelhistorikk: Sanksjon
       | 3            | 01.2021         | 03.2021         |              |                       |                | 01.03.2021  |
       | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
       | 2            | 02.2021         | 02.2021         | FJERNET      | 3                     | SANKSJON       | 01.02.2021  |
-      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+      | 1            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.01.2021  |
 
   Scenario: Revurder før sanksjon med periode før og etter, beholde sanksjon
 
@@ -162,7 +162,7 @@ Egenskap: Andelhistorikk: Sanksjon
       | 3            | 01.2021         | 01.2021         |              |                       |                | 01.03.2021  |
       | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
       | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.02.2021  |
-      | 2            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.02.2021  |
+      | 1            | 03.2021         | 03.2021         | FJERNET      | 3                     |                | 01.01.2021  |
       | 3            | 03.2021         | 03.2021         |              |                       |                | 01.03.2021  |
 
   Scenario: 2 sanksjoner revurderer før begge og begge fjernes
@@ -265,3 +265,50 @@ Egenskap: Andelhistorikk: Sanksjon
       | 2            | 02.2021         | 02.2021         | ERSTATTET    | 4                     | SANKSJON       | 01.02.2021  |
       | 4            | 02.2021         | 02.2021         |              |                       |                | 01.04.2021  |
       | 3            | 03.2021         | 03.2021         |              |                       | SANKSJON       | 01.03.2021  |
+
+  Scenario: Sanksjon skal ikke endre vedtaksdatoet på splittet periode
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.04.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 01.2021         | 03.2021         | INNVILGE        |                |                   |
+      | 2            | 02.2021         | 02.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 01.2021         | 01.2021         | SPLITTET     | 2                     |                | 01.01.2021  |
+      | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |                | 01.01.2021  |
+      | 2            | 02.2021         | 02.2021         |              |                       | SANKSJON       | 01.04.2021  |
+      | 1            | 03.2021         | 03.2021         |              |                       |                | 01.01.2021  |
+
+  Scenario: Sanksjon skal ikke endre vedtaksdatoet på splittet periode, flere sanksjoner
+
+    Gitt følgende behandlinger for Overgangsstønad
+      | BehandlingId | Behandlingstype       | Vedtaksdato |
+      | 1            | FØRSTEGANGSBEHANDLING | 01.01.2021  |
+      | 2            | REVURDERING           | 01.04.2021  |
+      | 3            | REVURDERING           | 01.06.2021  |
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Vedtaksperiode | Sanksjonsårsak    |
+      | 1            | 10.2020         | 04.2021         | INNVILGE        |                |                   |
+      | 2            | 11.2020         | 11.2020         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+      | 3            | 01.2021         | 01.2021         | SANKSJONERE     | SANKSJON       | SAGT_OPP_STILLING |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId | Vedtaksperiode | Vedtaksdato |
+      | 1            | 10.2020         | 10.2020         | SPLITTET     | 2                     |                | 01.01.2021  |
+      | 1            | 11.2020         | 04.2021         | FJERNET      | 2                     |                | 01.01.2021  |
+      | 2            | 11.2020         | 11.2020         |              |                       | SANKSJON       | 01.04.2021  |
+      | 1            | 12.2020         | 12.2020         | SPLITTET     | 3                     |                | 01.01.2021  |
+      | 1            | 01.2021         | 04.2021         | FJERNET      | 3                     |                | 01.01.2021  |
+      | 3            | 01.2021         | 01.2021         |              |                       | SANKSJON       | 01.06.2021  |
+      | 1            | 02.2021         | 04.2021         |              |                       |                | 01.01.2021  |


### PR DESCRIPTION
…pprinnelig ble opprettet fra
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10969

Endring:
* Viser riktig vedtakstidspunkt på perioden som har blitt oppsplittet (se etterbilde)
* Viser riktig behandling som perioden ble opprettet i (se etterbilde)

Før:
<img width="1780" alt="image" src="https://user-images.githubusercontent.com/937168/219414263-7960624c-b0dc-420b-bf3f-1c0f433a16cc.png">


Etter:
<img width="1786" alt="image" src="https://user-images.githubusercontent.com/937168/219414022-b8ff05e8-cc26-456a-8708-8d62fb814055.png">