### PR TITLE
Nytt barn samme partner automatisk vurdering

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -10,9 +10,7 @@ import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.StegUtfall
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
-import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.vedtak.NullstillVedtakService
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseHjelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseHjelper.kt
@@ -47,4 +47,3 @@ object AdresseHjelper {
             (gjeldende.sluttdatoForKontrakt == null || gjeldende.sluttdatoForKontrakt.isEqualOrAfter(nå))
     }
 }
-

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -130,7 +130,7 @@ class VurderingService(
             barn = barn,
             søktOmBarnetilsyn = søktOmBarnetilsyn,
             langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() },
-            terminbarnISøknad = barn.any { it.fødselTermindato != null }
+            terminbarnISøknad = barn.any { it.fødselTermindato != null && it.personIdent == null }
         )
         return Pair(grunnlag, metadata)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -123,12 +123,14 @@ class VurderingService(
         val grunnlag = vilkårGrunnlagService.hentGrunnlag(behandlingId, søknad, personIdent, barn)
         val søktOmBarnetilsyn =
             grunnlag.barnMedSamvær.filter { it.barnepass?.skalHaBarnepass == true }.map { it.barnId }
+
         val metadata = HovedregelMetadata(
             sivilstandstype = grunnlag.sivilstand.registergrunnlag.type,
             sivilstandSøknad = søknad?.sivilstand,
             barn = barn,
             søktOmBarnetilsyn = søktOmBarnetilsyn,
-            langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() }
+            langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() },
+            terminbarnISøknad = søknad?.barn?.any { it.fødselTermindato != null } ?: false
         )
         return Pair(grunnlag, metadata)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -130,7 +130,7 @@ class VurderingService(
             barn = barn,
             søktOmBarnetilsyn = søktOmBarnetilsyn,
             langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() },
-            terminbarnISøknad = søknad?.barn?.any { it.fødselTermindato != null } ?: false
+            terminbarnISøknad = barn.any { it.fødselTermindato != null }
         )
         return Pair(grunnlag, metadata)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -21,7 +21,8 @@ data class HovedregelMetadata(
     val erMigrering: Boolean = false,
     val barn: List<BehandlingBarn>,
     val søktOmBarnetilsyn: List<UUID>,
-    val langAvstandTilSøker: List<BarnForelderLangAvstandTilSøker> = listOf()
+    val langAvstandTilSøker: List<BarnForelderLangAvstandTilSøker> = listOf(),
+    val terminbarnISøknad: Boolean = false
 )
 
 data class BarnForelderLangAvstandTilSøker(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -1,18 +1,66 @@
 package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.Vurdering
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.RegelSteg
 import no.nav.familie.ef.sak.vilkår.regler.SluttSvarRegel
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
+import org.slf4j.LoggerFactory
+import java.util.*
 
 class NyttBarnSammePartnerRegel : Vilkårsregel(
     vilkårType = VilkårType.NYTT_BARN_SAMME_PARTNER,
     regler = setOf(HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER),
     hovedregler = regelIder(HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER)
 ) {
+
+    @JsonIgnore
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @JsonIgnore
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    override fun initiereDelvilkårsvurdering(
+        metadata: HovedregelMetadata,
+        resultat: Vilkårsresultat,
+        barnId: UUID?
+    ): List<Delvilkårsvurdering> {
+        logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId - terminbarn: ${metadata.terminbarnISøknad}")
+        if (metadata.barn.size == 1 && !metadata.terminbarnISøknad) { // Og sjekk på at det ikke er meldt om terminbarn
+            return listOf(
+                Delvilkårsvurdering(
+                    resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,
+                    listOf(
+                        Vurdering(
+                            regelId = RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER,
+                            svar = SvarId.NEI,
+                            begrunnelse = "Automatisk vurdert: Ut ifra at søker har kun ett barn og at det ikke er oppgitt noen terminbarn i søknad, vurderes vilkåret til oppfylt"
+                        )
+                    )
+                )
+            )
+        }
+        return listOf(
+            Delvilkårsvurdering(
+                resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                vurderinger = listOf(
+                    Vurdering(
+                        regelId = RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER,
+                        svar = null,
+                        begrunnelse = null
+                    )
+                )
+            )
+        )
+    }
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -34,7 +34,7 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
         barnId: UUID?
     ): List<Delvilkårsvurdering> {
         logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId - terminbarn: ${metadata.terminbarnISøknad}")
-        if (metadata.barn.size == 1 && !metadata.terminbarnISøknad) { // Og sjekk på at det ikke er meldt om terminbarn
+        if (metadata.barn.size == 1 && !metadata.terminbarnISøknad) {
             return listOf(
                 Delvilkårsvurdering(
                     resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -213,7 +213,8 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
                     sivilstandstype = Sivilstandstype.UGIFT,
                     erMigrering = false,
                     barn = listOf(barn),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    terminbarnISøknad = true
                 )
             )
             Vilkårsvurdering(

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -219,8 +219,8 @@ class PdlClientConfig {
                     bostedsadresse = bostedsadresse(),
                     deltBosted = listOf(
                         DeltBosted(
-                            LocalDate.of(2023,1,1),
-                            LocalDate.of(2053,1,1),
+                            LocalDate.of(2023, 1, 1),
+                            LocalDate.of(2053, 1, 1),
                             null,
                             null,
                             no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata(false)
@@ -241,7 +241,7 @@ class PdlClientConfig {
                     bostedsadresse = bostedsadresse(),
                     forelderBarnRelasjon = familierelasjonerBarn(),
                     fødsel = fødsel(),
-                    navn = lagNavn("Barn2", null, "Barnesen"),
+                    navn = lagNavn("Barn2", null, "Barnesen")
                 )
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus.BAD_REQUEST
-import java.time.LocalDateTime
 
 internal class VedtaksbrevServiceTest {
 
@@ -121,8 +120,10 @@ internal class VedtaksbrevServiceTest {
         every { brevClient.genererHtmlFritekstbrev(any(), any(), any()) } returns "html"
         every { familieDokumentClient.genererPdfFraHtml(any()) } returns "123".toByteArray()
 
-        vedtaksbrevService.lagSaksbehandlerFritekstbrev(fritekstBrevDto,
-            saksbehandling(fagsak, behandlingForSaksbehandler))
+        vedtaksbrevService.lagSaksbehandlerFritekstbrev(
+            fritekstBrevDto,
+            saksbehandling(fagsak, behandlingForSaksbehandler)
+        )
         assertThat(vedtaksbrevSlot.captured.saksbehandlersignatur).isEqualTo(beslutterNavn)
     }
 
@@ -210,8 +211,10 @@ internal class VedtaksbrevServiceTest {
         every { vedtaksbrevRepository.update(capture(brevSlot)) } returns mockk()
         every { familieDokumentClient.genererPdfFraHtml(any()) } returns "brev".toByteArray()
         // Når
-        vedtaksbrevService.lagEndeligBeslutterbrev(saksbehandling(fagsak, behandlingForBeslutter),
-            vedtakKreverBeslutter)
+        vedtaksbrevService.lagEndeligBeslutterbrev(
+            saksbehandling(fagsak, behandlingForBeslutter),
+            vedtakKreverBeslutter
+        )
 
         assertThat(beslutterIdent).isNotNull()
         assertThat(brevSlot.captured.beslutterident).isEqualTo(beslutterIdent)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/LagreVedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/LagreVedtakControllerTest.kt
@@ -146,7 +146,7 @@ internal class LagreVedtakControllerTest : OppslagSpringRunnerTest() {
             ),
             tilleggsstønad = TilleggsstønadWrapper(false, emptyList(), null),
             saksbehandlerIdent = "julenissen",
-            opprettetAv = "julenissen",
+            opprettetAv = "julenissen"
         )
 
         val vedtakRespons: ResponseEntity<Ressurs<InnvilgelseBarnetilsyn?>> = hentVedtak(behandling.id)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
-internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
+internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
 
     @Autowired
     lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -49,5 +49,4 @@ class NyttBarnSammePartnerRegelTest {
         assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isNull()
         assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).isNull()
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -1,0 +1,53 @@
+package no.nav.familie.ef.sak.vilkår.regler.vilkår
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class NyttBarnSammePartnerRegelTest {
+
+    val hovedregelMetadataMock = mockk<HovedregelMetadata>()
+    val behandlingBarn = mockk<BehandlingBarn>()
+
+    @Test
+    fun `initiereDelvilkårsvurdering - automatisk vurdert`() {
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.terminbarnISøknad } returns false
+
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isEqualTo(SvarId.NEI)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).startsWith("Automatisk vurdert:")
+    }
+
+    @Test
+    fun `initiereDelvilkårsvurdering - kan ikke automatisk vurdere`() {
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.terminbarnISøknad } returns true
+
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isNull()
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).isNull()
+    }
+
+}


### PR DESCRIPTION
Denne PR'n dekker kun første case i favro-kort: Hvis bruker kun har 1 barn og ikke har meldt om terminbarn i søknad kan vilkåret automatisk oppfylles
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11396

![Screenshot 2023-02-17 at 14 46 35](https://user-images.githubusercontent.com/42737566/219679861-b61b923e-e2d5-45ce-b52b-04a93658168e.png)


