### PR TITLE
Hent inntekt fra forrige iverksatte behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.math.BigDecimal
 import java.util.UUID
 
 @RestController
@@ -52,5 +53,12 @@ class BeregningController(
         val startDatoForVedtak = vedtakForBehandling.perioder?.perioder?.minByOrNull { it.datoFra }?.datoFra
             ?: error("Fant ingen startdato for vedtak på behandling med id=$behandlingId")
         return Ressurs.success(tilkjentYtelseService.hentForBehandling(behandlingId).tilBeløpsperiode(startDatoForVedtak))
+    }
+
+    @GetMapping("/{behandlingId}/forrigeInntektsgrunnlag")
+    fun hentInntektFraForrigeIverksatteBehandling(@PathVariable behandlingId: UUID): Ressurs<BigDecimal> {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+
+        return Ressurs.success(beregningService.hentInntektFraForrigeIverksatteBehandling(behandlingId = behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
@@ -56,9 +56,9 @@ class BeregningController(
     }
 
     @GetMapping("/{behandlingId}/forrigeInntektsgrunnlag")
-    fun hentInntektFraForrigeIverksatteBehandling(@PathVariable behandlingId: UUID): Ressurs<BigDecimal> {
+    fun hentSisteInntektFraForrigeIverksatteBehandling(@PathVariable behandlingId: UUID): Ressurs<BigDecimal> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
 
-        return Ressurs.success(beregningService.hentInntektFraForrigeIverksatteBehandling(behandlingId = behandlingId))
+        return Ressurs.success(beregningService.hentSisteInntektFraForrigeIverksatteBehandling(behandlingId = behandlingId))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
@@ -68,7 +68,7 @@ class BeregningService(
         ) { "Inntektsperioder $inntektsperioder overlapper eller er ikke sammenhengde" }
     }
 
-    fun hentInntektFraForrigeIverksatteBehandling(behandlingId: UUID): BigDecimal {
+    fun hentSisteInntektFraForrigeIverksatteBehandling(behandlingId: UUID): BigDecimal {
         val fagsakId = behandlingService.hentBehandling(behandlingId).fagsakId
         val forrigeIverksatteBehandling = behandlingService.finnSisteIverksatteBehandling(fagsakId)
             ?: throw Feil("Finnes ikke en tidligere vedtak med beløpsperioder for fagsak med id=$fagsakId")

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
@@ -75,6 +75,6 @@ class BeregningService(
 
         val vedtakForBehandling = vedtakService.hentVedtak(forrigeIverksatteBehandling.id)
 
-        return vedtakForBehandling.inntekter?.inntekter?.last()?.inntekt ?: throw Feil("Ingen inntekt")
+        return vedtakForBehandling.inntekter?.inntekter?.last()?.inntekt ?: throw Feil("Finner ingen inntak på behandling med id=${vedtakForBehandling.behandlingId}")
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.beregning
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.repository.vedtaksperiodeDto
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -27,9 +28,10 @@ internal class BeregningControllerUnitTest {
 
     val tilkjentytelseService = mockk<TilkjentYtelseService>()
     val vedtakService = mockk<VedtakService>()
+    val behandlingService = mockk<BehandlingService>()
 
     val beregningController = BeregningController(
-        beregningService = BeregningService(),
+        beregningService = BeregningService(behandlingService, vedtakService),
         tilgangService = mockk(relaxed = true),
         tilkjentYtelseService = tilkjentytelseService,
         vedtakService = vedtakService

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -1,6 +1,9 @@
 package no.nav.familie.ef.sak.beregning
 
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -10,8 +13,9 @@ import java.math.RoundingMode
 import java.time.LocalDate
 
 internal class BeregningServiceTest {
-
-    private val beregningService = BeregningService()
+    private val behandlingService = mockk<BehandlingService>()
+    private val vedtakService = mockk<VedtakService>()
+    private val beregningService = BeregningService(behandlingService, vedtakService)
 
     @Test
     internal fun `skal beregne full ytelse når det ikke foreligger inntekt`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.beregning
 
 import io.mockk.every
 import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.beregning.BeregningService
 import no.nav.familie.ef.sak.beregning.ValiderOmregningService
@@ -36,8 +37,9 @@ import java.util.UUID
 class ValiderOmregningServiceTest {
 
     val vedtakService = mockk<VedtakService>()
+    val behandlingService = mockk<BehandlingService>()
     val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
-    val beregningService = BeregningService()
+    val beregningService = BeregningService(behandlingService, vedtakService)
     val vedtakHistorikkService = mockk<VedtakHistorikkService>()
     val featureToggleService = mockFeatureToggleService()
     val validerOmregningService = ValiderOmregningService(

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -92,7 +92,7 @@ class StepDefinitions {
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>(relaxed = true)
     private val andelsHistorikkService = mockk<AndelsHistorikkService>(relaxed = true)
     private val vedtakService = mockk<VedtakService>(relaxed = true)
-    private val beregningService = BeregningService()
+    private val beregningService = BeregningService(behandlingService, vedtakService)
     private val featureToggleService = mockFeatureToggleService()
     private val beregningBarnetilsynService = BeregningBarnetilsynService(featureToggleService)
     private val beregningSkolepengerService = BeregningSkolepengerService(


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
For å automatisk legge inn inntekt og +/- 10% endring i revurderinger som avslås pga. for lite endring i inntekt trenger man å vite hvilken inntekt eksisterende overgangsstønad er basert på. 

### Hvordan er det gjort?
Laget et endepunkt for å hente inntekten. Denne bruker eksisterende metoder for å skaffe seg informasjonen som er nødvendig. Endepunktet skal kun kalles fra frontend hvis det er en revurdering som avslås med for lite endring som begrunnelse, som vil si at i tilfellene hvor endepunktet kalles skal det eksistere en innvilget søknad med inntekt lagt inn.