### PR TITLE
MVP: Automatisk vurdering av Nytt barn samme partner.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -21,7 +21,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS("familie.ef.sak.bruk-nye-maxsatser"),
 
     OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST("familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost", "Permission"),
-
+    AUTOMATISK_VURDER_NYTT_BARN_SAMME_PARTNER("familie.ef.sak.nytt-barn-samme-partner"),
     BEHANDLING_KORRIGERING("familie.ef.sak.behandling-korrigering", "Permission"),
 
     FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER("familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseHjelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/AdresseHjelper.kt
@@ -48,5 +48,4 @@ object AdresseHjelper {
     private fun BarnMedIdent.erOver18År(): Boolean {
         return !fødsel.gjeldende().erUnder18År()
     }
-
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
@@ -164,10 +164,12 @@ object AndelHistorikkBeregner {
                 val andelFraHistorikk = finnTilsvarendeAndelIHistorikk(historikk, andel)
                 val index = finnIndeksForNyAndel(historikk, andel)
                 if (andelFraHistorikk == null) {
-                    val kildeTilkjentYtelse = tilkjentYtelseForKildeBehandlingId(andel,
+                    val kildeTilkjentYtelse = tilkjentYtelseForKildeBehandlingId(
+                        andel,
                         vedtaksdataPerBehandling,
                         tilkjentYtelser,
-                        tilkjentYtelseMedVedtakstidspunkt)
+                        tilkjentYtelseMedVedtakstidspunkt
+                    )
                     historikk.add(index, lagNyAndel(kildeTilkjentYtelse, andel, vedtaksperiode))
                 } else {
                     markerTidligereMedEndringOgReturnerNyAndel(
@@ -194,7 +196,7 @@ object AndelHistorikkBeregner {
         andel: AndelTilkjentYtelse,
         vedtaksdataPerBehandling: Map<UUID, Vedtaksdata>,
         tilkjentYtelser: List<TilkjentYtelse>,
-        tilkjentYtelseMedVedtakstidspunkt: TilkjentYtelseMedVedtakstidspunkt,
+        tilkjentYtelseMedVedtakstidspunkt: TilkjentYtelseMedVedtakstidspunkt
     ): TilkjentYtelseMedVedtakstidspunkt {
         return if (andel.kildeBehandlingId != tilkjentYtelseMedVedtakstidspunkt.tilkjentYtelse.behandlingId) {
             tilkjentYtelseMedVedtakstidspunkt.copy(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataEndring
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -132,7 +133,8 @@ class VurderingService(
             søktOmBarnetilsyn = søktOmBarnetilsyn,
             langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() },
             vilkårgrunnlagDto = grunnlag,
-            behandling = behandling
+            behandling = behandling,
+            skalAutomatiskVurdereNyttBarnSammePartner = featureToggleService.isEnabled(Toggle.AUTOMATISK_VURDER_NYTT_BARN_SAMME_PARTNER)
         )
         return Pair(grunnlag, metadata)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -123,15 +123,24 @@ class VurderingService(
         val grunnlag = vilkårGrunnlagService.hentGrunnlag(behandlingId, søknad, personIdent, barn)
         val søktOmBarnetilsyn =
             grunnlag.barnMedSamvær.filter { it.barnepass?.skalHaBarnepass == true }.map { it.barnId }
+        val behandling = behandlingService.hentBehandling(behandlingId)
+
         val metadata = HovedregelMetadata(
             sivilstandstype = grunnlag.sivilstand.registergrunnlag.type,
             sivilstandSøknad = søknad?.sivilstand,
             barn = barn,
             søktOmBarnetilsyn = søktOmBarnetilsyn,
-            langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() }
+            langAvstandTilSøker = grunnlag.barnMedSamvær.map { it.mapTilBarnForelderLangAvstandTilSøker() },
+            vilkårgrunnlagDto = grunnlag,
+            behandling = behandling
         )
         return Pair(grunnlag, metadata)
     }
+
+    private fun harBrukerEllerAnnenForelderTidligereVedtak(grunnlag: VilkårGrunnlagDto) =
+        grunnlag.barnMedSamvær.mapNotNull { it.søknadsgrunnlag.forelder?.tidligereVedtaksperioder }
+            .any { it.harTidligereVedtaksperioder() } ||
+            grunnlag.tidligereVedtaksperioder.harTidligereVedtaksperioder()
 
     private fun hentEllerOpprettVurderinger(
         behandlingId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -137,11 +137,6 @@ class VurderingService(
         return Pair(grunnlag, metadata)
     }
 
-    private fun harBrukerEllerAnnenForelderTidligereVedtak(grunnlag: VilkårGrunnlagDto) =
-        grunnlag.barnMedSamvær.mapNotNull { it.søknadsgrunnlag.forelder?.tidligereVedtaksperioder }
-            .any { it.harTidligereVedtaksperioder() } ||
-            grunnlag.tidligereVedtaksperioder.harTidligereVedtaksperioder()
-
     private fun hentEllerOpprettVurderinger(
         behandlingId: UUID,
         metadata: HovedregelMetadata

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
@@ -7,13 +7,18 @@ data class TidligereVedtaksperioderDto(
     val infotrygd: TidligereInnvilgetVedtakDto?,
     val sak: TidligereInnvilgetVedtakDto?,
     val historiskPensjon: Boolean?
-)
+) {
+    fun harTidligereVedtaksperioder() =
+        infotrygd?.harTidligereInnvilgetVedtak() ?: false || sak?.harTidligereInnvilgetVedtak() ?: false
+}
 
 data class TidligereInnvilgetVedtakDto(
     val harTidligereOvergangsstønad: Boolean,
     val harTidligereBarnetilsyn: Boolean,
     val harTidligereSkolepenger: Boolean
-)
+) {
+    fun harTidligereInnvilgetVedtak() = harTidligereOvergangsstønad || harTidligereBarnetilsyn || harTidligereSkolepenger
+}
 
 fun TidligereVedtaksperioder?.tilDto(): TidligereVedtaksperioderDto = this?.let {
     TidligereVedtaksperioderDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
@@ -9,7 +9,7 @@ data class TidligereVedtaksperioderDto(
     val historiskPensjon: Boolean?
 ) {
     fun harTidligereVedtaksperioder() =
-        infotrygd?.harTidligereInnvilgetVedtak() ?: false || sak?.harTidligereInnvilgetVedtak() ?: false
+        infotrygd?.harTidligereInnvilgetVedtak() ?: false || sak?.harTidligereInnvilgetVedtak() ?: false || historiskPensjon ?: true
 }
 
 data class TidligereInnvilgetVedtakDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -63,16 +63,14 @@ abstract class Vilkårsregel(
         return regler[regelId] ?: throw Feil("Finner ikke regelId=$regelId for vilkårType=$vilkårType")
     }
 
-    protected fun automatiskVurdertDelvilkårList(regelId: RegelId, svarId: SvarId, begrunnelse: String): List<Delvilkårsvurdering> {
-        return listOf(
-            Delvilkårsvurdering(
-                resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,
-                listOf(
-                    Vurdering(
-                        regelId = regelId,
-                        svar = svarId,
-                        begrunnelse = "Automatisk vurdert (${LocalDate.now().norskFormat()}): $begrunnelse"
-                    )
+    protected fun automatiskVurdertDelvilkår(regelId: RegelId, svarId: SvarId, begrunnelse: String): Delvilkårsvurdering {
+        return Delvilkårsvurdering(
+            resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,
+            listOf(
+                Vurdering(
+                    regelId = regelId,
+                    svar = svarId,
+                    begrunnelse = "Automatisk vurdert (${LocalDate.now().norskFormat()}): $begrunnelse"
                 )
             )
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ef.sak.vilkår.regler
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.felles.util.norskFormat
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Sivilstand
@@ -10,6 +12,8 @@ import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vurdering
 import no.nav.familie.ef.sak.vilkår.dto.LangAvstandTilSøker
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -21,7 +25,9 @@ data class HovedregelMetadata(
     val erMigrering: Boolean = false,
     val barn: List<BehandlingBarn>,
     val søktOmBarnetilsyn: List<UUID>,
-    val langAvstandTilSøker: List<BarnForelderLangAvstandTilSøker> = listOf()
+    val langAvstandTilSøker: List<BarnForelderLangAvstandTilSøker> = listOf(),
+    val vilkårgrunnlagDto: VilkårGrunnlagDto,
+    val behandling: Behandling
 )
 
 data class BarnForelderLangAvstandTilSøker(
@@ -55,4 +61,28 @@ abstract class Vilkårsregel(
     fun regel(regelId: RegelId): RegelSteg {
         return regler[regelId] ?: throw Feil("Finner ikke regelId=$regelId for vilkårType=$vilkårType")
     }
+
+    protected fun automatiskVurdertDelvilkårList(regelId: RegelId, begrunnelse: String): List<Delvilkårsvurdering> {
+        return listOf(
+            Delvilkårsvurdering(
+                resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,
+                listOf(
+                    Vurdering(
+                        regelId = regelId,
+                        svar = SvarId.NEI,
+                        begrunnelse = "Automatisk vurdert (${LocalDate.now().norskFormat()}): $begrunnelse"
+                    )
+                )
+            )
+        )
+    }
+
+    protected fun ubesvartDelvilkårsvurdering(regelId: RegelId) = Delvilkårsvurdering(
+        resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+        vurderinger = listOf(
+            Vurdering(
+                regelId = regelId
+            )
+        )
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -62,14 +62,14 @@ abstract class Vilkårsregel(
         return regler[regelId] ?: throw Feil("Finner ikke regelId=$regelId for vilkårType=$vilkårType")
     }
 
-    protected fun automatiskVurdertDelvilkårList(regelId: RegelId, begrunnelse: String): List<Delvilkårsvurdering> {
+    protected fun automatiskVurdertDelvilkårList(regelId: RegelId, svarId: SvarId, begrunnelse: String): List<Delvilkårsvurdering> {
         return listOf(
             Delvilkårsvurdering(
                 resultat = Vilkårsresultat.AUTOMATISK_OPPFYLT,
                 listOf(
                     Vurdering(
                         regelId = regelId,
-                        svar = SvarId.NEI,
+                        svar = svarId,
                         begrunnelse = "Automatisk vurdert (${LocalDate.now().norskFormat()}): $begrunnelse"
                     )
                 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -27,7 +27,8 @@ data class HovedregelMetadata(
     val søktOmBarnetilsyn: List<UUID>,
     val langAvstandTilSøker: List<BarnForelderLangAvstandTilSøker> = listOf(),
     val vilkårgrunnlagDto: VilkårGrunnlagDto,
-    val behandling: Behandling
+    val behandling: Behandling,
+    val skalAutomatiskVurdereNyttBarnSammePartner: Boolean? = true
 )
 
 data class BarnForelderLangAvstandTilSøker(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.RegelSteg
 import no.nav.familie.ef.sak.vilkår.regler.SluttSvarRegel
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
@@ -35,9 +36,9 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
         logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId")
         if (metadata.behandling.erSøknadSomBehandlingÅrsak() &&
             !metadata.vilkårgrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() &&
-            !metadata.vilkårgrunnlagDto.barnMedSamvær.finnesBarnUtenRegistrertAnnenForelder()
+            metadata.vilkårgrunnlagDto.barnMedSamvær.alleBarnHarRegistrertAnnenForelder()
         ) {
-            return automatiskVurdertDelvilkårList(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER, "Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
+            return automatiskVurdertDelvilkårList(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER, SvarId.NEI, "Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
         }
 
         return listOf(ubesvartDelvilkårsvurdering(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER))
@@ -56,11 +57,11 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
     }
 }
 
-fun Behandling.erSøknadSomBehandlingÅrsak() = this.årsak == BehandlingÅrsak.SØKNAD
+private fun Behandling.erSøknadSomBehandlingÅrsak() = this.årsak == BehandlingÅrsak.SØKNAD
 
-fun VilkårGrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() =
+private fun VilkårGrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() =
     this.barnMedSamvær.mapNotNull { it.søknadsgrunnlag.forelder?.tidligereVedtaksperioder }
         .any { it.harTidligereVedtaksperioder() } ||
         this.tidligereVedtaksperioder.harTidligereVedtaksperioder()
 
-fun List<BarnMedSamværDto>.finnesBarnUtenRegistrertAnnenForelder() = this.any { it.registergrunnlag.forelder == null }
+private fun List<BarnMedSamværDto>.alleBarnHarRegistrertAnnenForelder() = this.all { it.registergrunnlag.forelder?.fødselsnummer != null }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -1,18 +1,47 @@
 package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.RegelSteg
 import no.nav.familie.ef.sak.vilkår.regler.SluttSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class NyttBarnSammePartnerRegel : Vilkårsregel(
     vilkårType = VilkårType.NYTT_BARN_SAMME_PARTNER,
     regler = setOf(HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER),
     hovedregler = regelIder(HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER)
 ) {
+
+    @JsonIgnore
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun initiereDelvilkårsvurdering(
+        metadata: HovedregelMetadata,
+        resultat: Vilkårsresultat,
+        barnId: UUID?
+    ): List<Delvilkårsvurdering> {
+        logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId")
+        if (metadata.behandling.erSøknadSomBehandlingÅrsak() &&
+            !metadata.vilkårgrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() &&
+            !metadata.vilkårgrunnlagDto.barnMedSamvær.finnesBarnUtenRegistrertAnnenForelder()
+        ) {
+            return automatiskVurdertDelvilkårList(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER, "Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
+        }
+
+        return listOf(ubesvartDelvilkårsvurdering(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER))
+    }
 
     companion object {
 
@@ -26,3 +55,12 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
             )
     }
 }
+
+fun Behandling.erSøknadSomBehandlingÅrsak() = this.årsak == BehandlingÅrsak.SØKNAD
+
+fun VilkårGrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() =
+    this.barnMedSamvær.mapNotNull { it.søknadsgrunnlag.forelder?.tidligereVedtaksperioder }
+        .any { it.harTidligereVedtaksperioder() } ||
+        this.tidligereVedtaksperioder.harTidligereVedtaksperioder()
+
+fun List<BarnMedSamværDto>.finnesBarnUtenRegistrertAnnenForelder() = this.any { it.registergrunnlag.forelder == null }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -34,7 +34,9 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
         barnId: UUID?
     ): List<Delvilkårsvurdering> {
         logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId")
-        if (metadata.behandling.erSøknadSomBehandlingÅrsak() &&
+
+        if (metadata.skalAutomatiskVurdereNyttBarnSammePartner == true &&
+            metadata.behandling.erSøknadSomBehandlingÅrsak() &&
             !metadata.vilkårgrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() &&
             metadata.vilkårgrunnlagDto.barnMedSamvær.alleBarnHarRegistrertAnnenForelder()
         ) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -35,16 +35,16 @@ class NyttBarnSammePartnerRegel : Vilkårsregel(
     ): List<Delvilkårsvurdering> {
         logger.info("Initiering av nytt barn samme partner regel. Antall barn: ${metadata.barn.size} - barnId: $barnId")
 
-        if (metadata.skalAutomatiskVurdereNyttBarnSammePartner == true &&
-            metadata.behandling.erSøknadSomBehandlingÅrsak() &&
-            !metadata.vilkårgrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() &&
-            metadata.vilkårgrunnlagDto.barnMedSamvær.alleBarnHarRegistrertAnnenForelder()
-        ) {
-            return automatiskVurdertDelvilkårList(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER, SvarId.NEI, "Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
+        if (metadata.skalAutomatiskVurdereNyttBarnSammePartner == true && kanAutomatiskInnvilges(metadata)) {
+            return listOf(automatiskVurdertDelvilkår(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER, SvarId.NEI, "Verken bruker eller annen forelder får eller har fått stønad for felles barn."))
         }
 
         return listOf(ubesvartDelvilkårsvurdering(RegelId.HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER))
     }
+
+    private fun kanAutomatiskInnvilges(metadata: HovedregelMetadata) = metadata.behandling.erSøknadSomBehandlingÅrsak() &&
+        !metadata.vilkårgrunnlagDto.harBrukerEllerAnnenForelderTidligereVedtak() &&
+        metadata.vilkårgrunnlagDto.barnMedSamvær.alleBarnHarRegistrertAnnenForelder()
 
     companion object {
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider
 import no.nav.familie.ef.sak.iverksett.IverksettClient
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
@@ -213,7 +214,10 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
                     sivilstandstype = Sivilstandstype.UGIFT,
                     erMigrering = false,
                     barn = listOf(barn),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    langAvstandTilSøker = listOf(),
+                    vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+                    behandling = behandling()
                 )
             )
             Vilkårsvurdering(

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -449,7 +449,7 @@ internal class JournalføringServiceTest {
             every { vurderingService.hentGrunnlagOgMetadata(behandlingId) } returns
                 Pair(
                     mockVilkårGrunnlagDto(),
-                    HovedregelMetadata(null, Sivilstandstype.UGIFT, false, emptyList(), emptyList())
+                    HovedregelMetadata(null, Sivilstandstype.UGIFT, false, emptyList(), emptyList(), emptyList(), mockk(), mockk())
                 )
 
             fullførJournalpost(
@@ -487,7 +487,7 @@ internal class JournalføringServiceTest {
             every { vurderingService.hentGrunnlagOgMetadata(behandlingId) } returns
                 Pair(
                     mockVilkårGrunnlagDto(),
-                    HovedregelMetadata(null, Sivilstandstype.UGIFT, false, emptyList(), emptyList())
+                    HovedregelMetadata(null, Sivilstandstype.UGIFT, false, emptyList(), emptyList(), emptyList(), mockk(), mockk())
                 )
             fullførJournalpost(
                 JournalføringBehandling(

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseHjelperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AdresseHjelperTest.kt
@@ -183,7 +183,7 @@ internal class AdresseHjelperTest {
 
         @Test
         internal fun `delt bosted finnes ikke, forvent harDeltBosted lik false`() {
-            val barnMedDeltBosted = opprettBarnMedIdent(personIdent = "", deltBosted = emptyList(), fødsel = PdlTestdataHelper.fødsel(now().minusYears(2)),)
+            val barnMedDeltBosted = opprettBarnMedIdent(personIdent = "", deltBosted = emptyList(), fødsel = PdlTestdataHelper.fødsel(now().minusYears(2)))
             assertThat(AdresseHjelper.harDeltBosted(barnMedDeltBosted, now())).isFalse
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapperTest.kt
@@ -164,7 +164,6 @@ internal class PersonopplysningerMapperTest {
 
     @Test
     internal fun `skal mappe barnets harDeltBostedNå til true når grunnlagsdata er opprettet i periode med delt bosted`() {
-
         val deltBostedStart = LocalDate.of(2022, 1, 1)
         val deltBostedSlutt = LocalDate.of(2023, 1, 1)
         val grunnlagsdata = grunnlagsdataMedBarnMedDeltBosted(deltBostedStart, deltBostedSlutt)
@@ -182,7 +181,6 @@ internal class PersonopplysningerMapperTest {
 
     @Test
     internal fun `skal mappe barnets harDeltBostedNå til false når grunnlagsdata ikke er opprettet i periode med delt bosted`() {
-
         val deltBostedStart = LocalDate.of(2022, 1, 1)
         val deltBostedSlutt = LocalDate.of(2023, 1, 1)
         val grunnlagsdata = grunnlagsdataMedBarnMedDeltBosted(deltBostedStart, deltBostedSlutt)

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.service
 
+import io.mockk.mockk
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.barn.BarnRepository
 import no.nav.familie.ef.sak.barn.BehandlingBarn
@@ -379,7 +380,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
                     sivilstand,
                     Sivilstandstype.ENKE_ELLER_ENKEMANN,
                     barn = barn,
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockk(),
+                    behandling = mockk()
                 )
             )
         return delvilkårsvurderingAleneomsorg
@@ -392,7 +395,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
                     sivilstand,
                     Sivilstandstype.ENKE_ELLER_ENKEMANN,
                     barn = emptyList(),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockk(),
+                    behandling = mockk()
                 )
             )
         return delvilkårsvurdering

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.vilkår
 
+import io.mockk.mockk
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.barn.BarnRepository
 import no.nav.familie.ef.sak.barn.BehandlingBarn
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.util.UUID
 
-internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
+internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
 
     @Autowired
     lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
@@ -58,7 +59,10 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
             Sivilstandstype.SKILT,
             false,
             barnPåRevurdering,
-            emptyList()
+            emptyList(),
+            listOf(),
+            mockk(),
+            mockk()
         )
         vurderingService.kopierVurderingerTilNyBehandling(behandling.id, revurdering.id, metadata, StønadType.OVERGANGSSTØNAD)
 
@@ -94,7 +98,10 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
             Sivilstandstype.SKILT,
             false,
             emptyList(),
-            emptyList()
+            emptyList(),
+            emptyList(),
+            mockk(),
+            mockk()
         )
         assertThat(
             catchThrowable {
@@ -141,7 +148,9 @@ internal class VurderingServiceIntegratsjonsTest : OppslagSpringRunnerTest() {
                 søknadskjema.sivilstand,
                 Sivilstandstype.ENKE_ELLER_ENKEMANN,
                 barn = barn,
-                søktOmBarnetilsyn = emptyList()
+                søktOmBarnetilsyn = emptyList(),
+                vilkårgrunnlagDto = mockk(),
+                behandling = mockk()
             )
         val delvilkårsvurdering = SivilstandRegel().initiereDelvilkårsvurdering(hovedregelMetadata)
         val vilkårsvurderinger = listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -37,6 +37,7 @@ import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.SivilstandRegel
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
 import no.nav.familie.kontrakter.felles.ef.StønadType.BARNETILSYN
 import no.nav.familie.kontrakter.felles.ef.StønadType.OVERGANGSSTØNAD
@@ -78,7 +79,7 @@ internal class VurderingServiceTest {
         ).build().søknadOvergangsstønad
     ).tilSøknadsverdier()
     private val barn = søknadBarnTilBehandlingBarn(søknad.barn)
-    private val behandling = behandling(fagsak(), BehandlingStatus.OPPRETTET)
+    private val behandling = behandling(fagsak(), BehandlingStatus.OPPRETTET, årsak = BehandlingÅrsak.PAPIRSØKNAD)
     private val behandlingId = UUID.randomUUID()
 
     @BeforeEach
@@ -231,7 +232,9 @@ internal class VurderingServiceTest {
                     mockk(),
                     Sivilstandstype.ENKE_ELLER_ENKEMANN,
                     barn = emptyList(),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockk(),
+                    behandling = mockk()
                 )
             )
         every { vilkårsvurderingRepository.findByBehandlingId(behandlingId) } returns

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -304,7 +304,9 @@ internal class VurderingStegServiceTest {
                     null,
                     Sivilstandstype.UGIFT,
                     barn = emptyList(),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockVilkårGrunnlagDto(),
+                    behandling = behandling
                 ),
                 OVERGANGSSTØNAD
             )
@@ -334,7 +336,9 @@ internal class VurderingStegServiceTest {
                     søknad.sivilstand,
                     Sivilstandstype.UGIFT,
                     barn = barn,
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockVilkårGrunnlagDto(),
+                    behandling = behandling
                 ),
                 OVERGANGSSTØNAD
             )

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/GrafRendererTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/GrafRendererTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.vilkår.regler
 
+import io.mockk.mockk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
@@ -60,7 +61,9 @@ internal class GrafRendererTest {
                     it.søknad.sivilstand,
                     it.sivilstandstype,
                     barn = emptyList(),
-                    søktOmBarnetilsyn = emptyList()
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockk(),
+                    behandling = mockk()
                 )
             )
             val hovedregler = initereDelvilkårsvurdering.filter { delvilkårsvurdering ->

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -1,9 +1,12 @@
 package no.nav.familie.ef.sak.vilkår.regler.evalutation
 
+import io.mockk.mockk
 import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype.GIFT
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
+import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
@@ -50,7 +53,9 @@ internal class OppdaterVilkårTest {
             sivilstandstype = GIFT,
             erMigrering = false,
             barn = listOf(barn, barnUtenSøknad),
-            søktOmBarnetilsyn = listOf(barn.id)
+            søktOmBarnetilsyn = listOf(barn.id),
+            vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+            behandling = behandling()
         )
 
         val nyeVilkårsvurderinger = opprettNyeVilkårsvurderinger(
@@ -84,7 +89,9 @@ internal class OppdaterVilkårTest {
             sivilstandstype = GIFT,
             erMigrering = false,
             barn = listOf(barn, barnUtenSøknad),
-            søktOmBarnetilsyn = listOf(barn.id)
+            søktOmBarnetilsyn = listOf(barn.id),
+            vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+            behandling = behandling()
         )
 
         val nyeVilkårsvurderinger = opprettNyeVilkårsvurderinger(
@@ -119,7 +126,9 @@ internal class OppdaterVilkårTest {
             sivilstandstype = GIFT,
             erMigrering = false,
             barn = listOf(barn, barnUtenSøknad),
-            søktOmBarnetilsyn = listOf(barn.id)
+            søktOmBarnetilsyn = listOf(barn.id),
+            vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+            behandling = behandling()
         )
 
         val nyeVilkårsvurderinger = opprettNyeVilkårsvurderinger(
@@ -149,7 +158,9 @@ internal class OppdaterVilkårTest {
             sivilstandstype = GIFT,
             erMigrering = false,
             barn = listOf(barn, barn.copy(id = UUID.randomUUID())),
-            søktOmBarnetilsyn = emptyList()
+            søktOmBarnetilsyn = emptyList(),
+            vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+            behandling = behandling()
         )
 
         val nyeVilkårsvurderinger = opprettNyeVilkårsvurderinger(
@@ -177,7 +188,9 @@ internal class OppdaterVilkårTest {
             sivilstandstype = GIFT,
             erMigrering = false,
             barn = listOf(barn, barn.copy(id = UUID.randomUUID())),
-            søktOmBarnetilsyn = emptyList()
+            søktOmBarnetilsyn = emptyList(),
+            vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+            behandling = behandling()
         )
 
         val nyeVilkårsvurderinger = opprettNyeVilkårsvurderinger(
@@ -312,7 +325,9 @@ internal class OppdaterVilkårTest {
                 søknad.sivilstand,
                 Sivilstandstype.SKILT,
                 barn = barn,
-                søktOmBarnetilsyn = emptyList()
+                søktOmBarnetilsyn = emptyList(),
+                vilkårgrunnlagDto = mockk(),
+                behandling = mockk()
             )
         )
         val aktuelleDelvilkår = initDelvilkår.filter { it.resultat == Vilkårsresultat.IKKE_TATT_STILLING_TIL }
@@ -347,7 +362,9 @@ internal class OppdaterVilkårTest {
                 søknad.sivilstand,
                 Sivilstandstype.SKILT,
                 barn = barn,
-                søktOmBarnetilsyn = emptyList()
+                søktOmBarnetilsyn = emptyList(),
+                vilkårgrunnlagDto = mockk(),
+                behandling = mockk()
             )
         )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -1,0 +1,101 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.felles.util.norskFormat
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.behandlingBarn
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.dto.AnnenForelderDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværSøknadsgrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.TidligereInnvilgetVedtakDto
+import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
+import no.nav.familie.ef.sak.vilkår.regler.vilkår.NyttBarnSammePartnerRegel
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.util.*
+
+class NyttBarnSammePartnerRegelTest {
+
+    val hovedregelMetadataMock = mockk<HovedregelMetadata>()
+    val behandlingBarn = behandlingBarn(behandlingId = UUID.randomUUID())
+
+    @BeforeEach
+    fun setup() {
+        every { hovedregelMetadataMock.behandling } returns behandling()
+    }
+
+    @Test
+    fun `Gitt at bruker eller annen foreldre ikke har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret automatisk oppfylles`() {
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto()
+
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isEqualTo(SvarId.NEI)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).startsWith("Automatisk vurdert (${LocalDate.now().norskFormat()}):")
+    }
+
+    @Test
+    fun `Gitt at bruker eller annen foreldre har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
+        val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+        val annenForelderDto = mockk<AnnenForelderDto>()
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
+            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, mockk())),
+            tidligereVedtaksperioder = TidligereVedtaksperioderDto(TidligereInnvilgetVedtakDto(true, false, false), TidligereInnvilgetVedtakDto(false, false, false), false)
+        )
+        every { annenForelderDto.tidligereVedtaksperioder } returns TidligereVedtaksperioderDto(null, null, false)
+        every { barnMedSamværSøknadsgrunnlagDto.forelder } returns annenForelderDto
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isNull()
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).isNull()
+    }
+
+    @Test
+    fun `Gitt at bruker eller annen foreldre ikke har tidligere vedtak, og det finnes barn uten registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
+        val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+        val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
+        val annenForelderDto = mockk<AnnenForelderDto>()
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
+            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto))
+        )
+        every { annenForelderDto.tidligereVedtaksperioder } returns TidligereVedtaksperioderDto(null, null, false)
+        every { barnMedSamværSøknadsgrunnlagDto.forelder } returns annenForelderDto
+        every { barnMedSamværRegistergrunnlagDto.forelder } returns null
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isNull()
+        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).isNull()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -29,12 +29,12 @@ class NyttBarnSammePartnerRegelTest {
 
     @BeforeEach
     fun setup() {
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
         every { hovedregelMetadataMock.behandling } returns behandling()
     }
 
     @Test
     fun `Gitt at bruker eller annen foreldre ikke har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret automatisk oppfylles`() {
-        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
         every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto()
 
         val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
@@ -54,7 +54,7 @@ class NyttBarnSammePartnerRegelTest {
     fun `Gitt at bruker eller annen foreldre har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
         val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
         val annenForelderDto = mockk<AnnenForelderDto>()
-        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+
         every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
             barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, mockk())),
             tidligereVedtaksperioder = TidligereVedtaksperioderDto(TidligereInnvilgetVedtakDto(true, false, false), TidligereInnvilgetVedtakDto(false, false, false), false)
@@ -79,7 +79,7 @@ class NyttBarnSammePartnerRegelTest {
         val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
         val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
         val annenForelderDto = mockk<AnnenForelderDto>()
-        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+
         every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
             barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto))
         )

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -46,8 +46,9 @@ class NyttBarnSammePartnerRegelTest {
         assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
         assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
         assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
-        assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isEqualTo(SvarId.NEI)
-        assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).startsWith("Automatisk vurdert (${LocalDate.now().norskFormat()}):")
+        val delvilkårsvurdering = listDelvilkårsvurdering.first().vurderinger.first()
+        assertThat(delvilkårsvurdering.svar).isEqualTo(SvarId.NEI)
+        assertThat(delvilkårsvurdering.begrunnelse).startsWith("Automatisk vurdert (${LocalDate.now().norskFormat()}):")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -29,6 +29,7 @@ class NyttBarnSammePartnerRegelTest {
 
     @BeforeEach
     fun setup() {
+        every { hovedregelMetadataMock.skalAutomatiskVurdereNyttBarnSammePartner } returns true
         every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
         every { hovedregelMetadataMock.behandling } returns behandling()
     }

--- a/src/test/resources/omregning/expectedIverksettDto.json
+++ b/src/test/resources/omregning/expectedIverksettDto.json
@@ -138,7 +138,7 @@
             "vurderinger": [
               {
                 "regelId": "HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER",
-                "svar": null,
+                "svar": "NEI",
                 "begrunnelse": "Godkjent"
               }
             ]


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11396

Etter ny runde med avklaringer med funksjonelle, ble denne forenklet, da det kan være flere edge caser som kan være ganske omfattende å ta hensyn til. Blant annet personer som har hatt et registrert relasjon til barn, som ikke finnes lenger pga adopsjon. Denne PR'n er mer defensiv enn forrige PR, inntil det avklares av funksjonelle hvordan edge caser skal håndteres.

Forrige PR som nå er lukket: https://github.com/navikt/familie-ef-sak/pull/2101