### PR TITLE
Alle delt bosted perioder skal sendes til frontend siden vi antar at …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
@@ -153,6 +153,7 @@ class BarnMedSamværMapper(
                 AdresseHjelper.harRegistrertSammeBostedsadresseSomForelder(it, søkerAdresse)
             },
             deltBosted = matchetBarn.barn?.deltBosted?.gjeldende().tilDto(),
+            deltBostedPerioder = matchetBarn.barn?.deltBosted?.tilDto() ?: emptyList(),
             harDeltBostedVedGrunnlagsdataopprettelse = AdresseHjelper.harDeltBosted(
                 matchetBarn.barn,
                 grunnlagsdataOpprettet
@@ -205,10 +206,16 @@ class BarnMedSamværMapper(
             ?.vegadresse
             ?.fjerneBoforhold(søkerAdresse.gjeldende()?.vegadresse)
             ?: AvstandTilSøkerDto(avstandIKm = null, langAvstandTilSøker = LangAvstandTilSøker.UKJENT)
+
+    private fun List<DeltBosted>.tilDto(): List<DeltBostedDto> {
+        return this.mapNotNull { deltBosted -> deltBosted.tilDto()  }
+    }
 }
 
 private fun DeltBosted?.tilDto(): DeltBostedDto? {
     return this?.let {
-        DeltBostedDto(this.startdatoForKontrakt, this.sluttdatoForKontrakt)
+        DeltBostedDto(this.startdatoForKontrakt, this.sluttdatoForKontrakt, this.metadata.historisk)
     } ?: null
 }
+
+

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -41,8 +41,6 @@ data class BarnDto(
     val adresse: List<AdresseDto>,
     val borHosSøker: Boolean,
     val deltBosted: List<DeltBostedDto>,
-    val deltBostedPerioder: List<DeltBostedDto>,
-    /** TODO : Endre på denne, siden delt bosted ikke nødvendigvis gjelder nåtid */
     val harDeltBostedNå: Boolean,
     val fødselsdato: LocalDate?,
     val dødsdato: LocalDate?

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -32,7 +32,7 @@ data class PersonopplysningerDto(
     val vergemål: List<VergemålDto>
 )
 
-data class DeltBostedDto(val startdatoForKontrakt: LocalDate, val sluttdatoForKontrakt: LocalDate?)
+data class DeltBostedDto(val startdatoForKontrakt: LocalDate, val sluttdatoForKontrakt: LocalDate?, val historisk: Boolean)
 
 data class BarnDto(
     val personIdent: String,
@@ -41,6 +41,7 @@ data class BarnDto(
     val adresse: List<AdresseDto>,
     val borHosSøker: Boolean,
     val deltBosted: List<DeltBostedDto>,
+    val deltBostedPerioder: List<DeltBostedDto>,
     /** TODO : Endre på denne, siden delt bosted ikke nødvendigvis gjelder nåtid */
     val harDeltBostedNå: Boolean,
     val fødselsdato: LocalDate?,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
@@ -53,7 +53,7 @@ object UtledEndringerUtil {
         formatterEndring(BarnDto::dødsdato, "Dødsdato"),
         formatterEndring(BarnDto::fødselsdato, "Fødselsdato"),
         formatterEndring({ it.annenForelder?.personIdent }, "Annen forelder"),
-        formatterEndring(BarnDto::harDeltBostedNå, "Har delt bosted nå"),
+        formatterEndring(BarnDto::harDeltBostedNå, "Har delt bosted"),
         formatterEndring(BarnDto::deltBosted, "Delt bosted")
         // TODO adresse ?? Er den interessant å vise som endret hvis man ikke har endring i borHosSøker ? si eks at barnet på > 18 flytter
     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -24,7 +24,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -35,8 +34,6 @@ class PersonopplysningerMapper(
     private val innflyttingUtflyttingMapper: InnflyttingUtflyttingMapper,
     private val arbeidsfordelingService: ArbeidsfordelingService
 ) {
-
-    private val logger = LoggerFactory.getLogger(javaClass)
 
     fun tilPersonopplysninger(
         grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
@@ -156,7 +153,6 @@ class PersonopplysningerMapper(
             adresse = barn.bostedsadresse.map(adresseMapper::tilAdresse),
             borHosSøker = AdresseHjelper.harRegistrertSammeBostedsadresseSomForelder(barn, bostedsadresserForelder),
             deltBosted = deltBostedDto,
-            deltBostedPerioder = deltBostedDto,
             harDeltBostedNå = AdresseHjelper.harDeltBosted(barn, grunnlagsdataOpprettet),
             fødselsdato = barn.fødsel.gjeldende().fødselsdato,
             dødsdato = barn.dødsfall.gjeldende()?.dødsdato

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -137,9 +137,8 @@ class PersonopplysningerMapper(
         }?.relatertPersonsIdent
 
         feilHvis(barn.deltBosted.filter { !it.metadata.historisk }.size > 1) { "Fant mer enn en ikke-historisk delt bosted." }
-        val bostedDto =
-            barn.deltBosted.gjeldende()?.let { listOf(DeltBostedDto(it.startdatoForKontrakt, it.sluttdatoForKontrakt)) }
-                ?: emptyList()
+        val deltBostedDto =
+            barn.deltBosted.map { DeltBostedDto(it.startdatoForKontrakt, it.sluttdatoForKontrakt, it.metadata.historisk) }
 
         return BarnDto(
             personIdent = barn.personIdent,
@@ -156,7 +155,8 @@ class PersonopplysningerMapper(
             },
             adresse = barn.bostedsadresse.map(adresseMapper::tilAdresse),
             borHosSøker = AdresseHjelper.harRegistrertSammeBostedsadresseSomForelder(barn, bostedsadresserForelder),
-            deltBosted = bostedDto,
+            deltBosted = deltBostedDto,
+            deltBostedPerioder = deltBostedDto,
             harDeltBostedNå = AdresseHjelper.harDeltBosted(barn, grunnlagsdataOpprettet),
             fødselsdato = barn.fødsel.gjeldende().fødselsdato,
             dødsdato = barn.dødsfall.gjeldende()?.dødsdato

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -45,6 +45,7 @@ data class BarnMedSamværRegistergrunnlagDto(
     val fødselsnummer: String?,
     val harSammeAdresse: Boolean?,
     val deltBosted: DeltBostedDto?,
+    val deltBostedPerioder: List<DeltBostedDto>,
     val harDeltBostedVedGrunnlagsdataopprettelse: Boolean,
     val forelder: AnnenForelderDto?,
     val dødsdato: LocalDate? = null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -45,6 +45,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNo
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Vegadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergeEllerFullmektig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergemaalEllerFremtidsfullmakt
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata as PldMetadata
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.fødsel
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.lagKjønn
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.lagNavn
@@ -223,14 +224,14 @@ class PdlClientConfig {
                             LocalDate.of(2053, 1, 1),
                             null,
                             null,
-                            no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata(false)
+                            PldMetadata(false)
                         ),
                         DeltBosted(
-                            LocalDate.now().minusDays(20),
-                            LocalDate.now().minusDays(10),
+                            LocalDate.of(2020, 1, 1),
+                            LocalDate.of(2023, 3, 31),
                             null,
                             null,
-                            no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata(true)
+                            PldMetadata(true)
                         )
                     ),
                     forelderBarnRelasjon = familierelasjonerBarn(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -34,15 +34,15 @@ internal class UtledEndringerUtilTest {
 
     @Test
     internal fun jsontest() {
-        val barnBlirFjernet = BarnDto("barnBlirFjernet", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
+        val barnBlirFjernet = BarnDto("barnBlirFjernet", "2", null, emptyList(), true, emptyList(), false, null, null)
         val annenForelder = AnnenForelderMinimumDto("1", "", null, "Adresse 1")
         val annenForelder2 = AnnenForelderMinimumDto("2", "", null, null)
         val barnsForelderBlirEndret =
-            BarnDto("forelderFårEndring", "2", annenForelder, emptyList(), true, emptyList(), emptyList(),false, null, null)
+            BarnDto("forelderFårEndring", "2", annenForelder, emptyList(), true, emptyList(), false, null, null)
         val barnFårEndring =
-            BarnDto("barnFårEndretBorHosSøker", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
-        val barnFårForelder = BarnDto("barnFårForelder", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
-        val nyttBarn = BarnDto("nyttBarn", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
+            BarnDto("barnFårEndretBorHosSøker", "2", null, emptyList(), true, emptyList(), false, null, null)
+        val barnFårForelder = BarnDto("barnFårForelder", "2", null, emptyList(), true, emptyList(), false, null, null)
+        val nyttBarn = BarnDto("nyttBarn", "2", null, emptyList(), true, emptyList(), false, null, null)
         val tidligere = dto(
             dødsdato = LocalDate.of(2021, 1, 1),
             barn = listOf(barnBlirFjernet, barnsForelderBlirEndret, barnFårForelder, barnFårEndring)
@@ -99,7 +99,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Mangler verdi")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
             assertIngenAndreEndringer(endringer, "folkeregisterpersonstatus")
         }
 
@@ -112,7 +112,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Død")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
         }
 
         @Test
@@ -146,7 +146,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.fødselsdato.harEndringer).isTrue
             assertThat(endringer.fødselsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.fødselsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.fødselsdato.detaljer.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "fødselsdato")
         }
 
@@ -158,7 +158,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.dødsdato.harEndringer).isTrue
             assertThat(endringer.dødsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.dødsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.dødsdato.detaljer.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "dødsdato")
         }
 
@@ -256,7 +256,7 @@ internal class UtledEndringerUtilTest {
     inner class Personeendringer {
         @Test
         internal fun `nytt barn`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf()),
                 dto(barn = listOf(barn))
@@ -269,7 +269,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `fjernet barn`() {
-            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(),  false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
                 dto(barn = listOf())
@@ -288,8 +288,8 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring på navn trigger ikke endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
-            val barn2 = BarnDto(barnIdent, "2", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn2 = BarnDto(barnIdent, "2", null, emptyList(), true, emptyList(), false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
                 dto(barn = listOf(barn2))
@@ -304,7 +304,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring bor hos søker trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
             val barn2 = barn.copy(borHosSøker = false)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -326,7 +326,7 @@ internal class UtledEndringerUtilTest {
         internal fun `endring dødsdato på barn trigger kun endring på barn`() {
             val dødsdato = LocalDate.now()
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "Navn", null, null)
-            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  false, null, null)
             val barn2 = barn.copy(dødsdato = dødsdato)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -346,7 +346,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring av personident på annen forelder trigger endring både på barn og annen forelder`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
             val barn2 = BarnDto(
                 barnIdent,
                 "2",
@@ -354,7 +354,7 @@ internal class UtledEndringerUtilTest {
                 emptyList(),
                 true,
                 emptyList(),
-                emptyList(),false,
+               false,
                 null,
                 null
             )
@@ -380,7 +380,7 @@ internal class UtledEndringerUtilTest {
         internal fun `dødsdato på annen forelder skal kun trigge endring på annen forelder`() {
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "", null, null)
             val dødsdato = LocalDate.now()
-            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(),  false, null, null)
             val barn2 = barn.copy(annenForelder = annenForelder.copy(dødsdato = dødsdato))
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -401,7 +401,7 @@ internal class UtledEndringerUtilTest {
         @Test
         internal fun `endring bostedsadresse på annen forelder trigger endring på annen forelder`() {
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "Navn", null, "Adresse 1")
-            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(), false, null, null)
             val barn2 = barn.copy(annenForelder = annenForelder.copy(bostedsadresse = "Adresse 2"))
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -422,7 +422,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `søkers barn får delt bosted trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
             val barn2 = barn.copy(harDeltBostedNå = true)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -453,7 +453,7 @@ internal class UtledEndringerUtilTest {
                 historisk = false
             )
             val barn = BarnDto(
-                barnIdent, "", null, emptyList(), true, listOf(deltBostedGammel),  emptyList(),true, null, null
+                barnIdent, "", null, emptyList(), true, listOf(deltBostedGammel), true, null, null
             )
             val barn2 = barn.copy(deltBosted = listOf(deltBostedGammel, deltBostedNy))
             val endringer = finnEndringer(

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -432,7 +432,7 @@ internal class UtledEndringerUtilTest {
             assertBarnHarEndringerMedDetaljer(endringer)
             val endringsdetaljer = detaljer[0].endringer
             assertThat(endringsdetaljer).hasSize(1)
-            assertThat(endringsdetaljer[0].felt).isEqualTo("Har delt bosted nå")
+            assertThat(endringsdetaljer[0].felt).isEqualTo("Har delt bosted")
             assertThat(endringsdetaljer[0].tidligere).isEqualTo("Nei")
             assertThat(endringsdetaljer[0].ny).isEqualTo("Ja")
             assertIngenAndreEndringer(endringer, "barn")

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -34,15 +34,15 @@ internal class UtledEndringerUtilTest {
 
     @Test
     internal fun jsontest() {
-        val barnBlirFjernet = BarnDto("barnBlirFjernet", "2", null, emptyList(), true, emptyList(), false, null, null)
+        val barnBlirFjernet = BarnDto("barnBlirFjernet", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
         val annenForelder = AnnenForelderMinimumDto("1", "", null, "Adresse 1")
         val annenForelder2 = AnnenForelderMinimumDto("2", "", null, null)
         val barnsForelderBlirEndret =
-            BarnDto("forelderFårEndring", "2", annenForelder, emptyList(), true, emptyList(), false, null, null)
+            BarnDto("forelderFårEndring", "2", annenForelder, emptyList(), true, emptyList(), emptyList(),false, null, null)
         val barnFårEndring =
-            BarnDto("barnFårEndretBorHosSøker", "2", null, emptyList(), true, emptyList(), false, null, null)
-        val barnFårForelder = BarnDto("barnFårForelder", "2", null, emptyList(), true, emptyList(), false, null, null)
-        val nyttBarn = BarnDto("nyttBarn", "2", null, emptyList(), true, emptyList(), false, null, null)
+            BarnDto("barnFårEndretBorHosSøker", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
+        val barnFårForelder = BarnDto("barnFårForelder", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
+        val nyttBarn = BarnDto("nyttBarn", "2", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
         val tidligere = dto(
             dødsdato = LocalDate.of(2021, 1, 1),
             barn = listOf(barnBlirFjernet, barnsForelderBlirEndret, barnFårForelder, barnFårEndring)
@@ -256,7 +256,7 @@ internal class UtledEndringerUtilTest {
     inner class Personeendringer {
         @Test
         internal fun `nytt barn`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), emptyList(),false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf()),
                 dto(barn = listOf(barn))
@@ -269,7 +269,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `fjernet barn`() {
-            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
                 dto(barn = listOf())
@@ -288,8 +288,8 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring på navn trigger ikke endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
-            val barn2 = BarnDto(barnIdent, "2", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
+            val barn2 = BarnDto(barnIdent, "2", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
                 dto(barn = listOf(barn2))
@@ -304,7 +304,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring bor hos søker trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = barn.copy(borHosSøker = false)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -326,7 +326,7 @@ internal class UtledEndringerUtilTest {
         internal fun `endring dødsdato på barn trigger kun endring på barn`() {
             val dødsdato = LocalDate.now()
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "Navn", null, null)
-            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = barn.copy(dødsdato = dødsdato)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -346,7 +346,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring av personident på annen forelder trigger endring både på barn og annen forelder`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = BarnDto(
                 barnIdent,
                 "2",
@@ -354,7 +354,7 @@ internal class UtledEndringerUtilTest {
                 emptyList(),
                 true,
                 emptyList(),
-                false,
+                emptyList(),false,
                 null,
                 null
             )
@@ -380,7 +380,7 @@ internal class UtledEndringerUtilTest {
         internal fun `dødsdato på annen forelder skal kun trigge endring på annen forelder`() {
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "", null, null)
             val dødsdato = LocalDate.now()
-            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = barn.copy(annenForelder = annenForelder.copy(dødsdato = dødsdato))
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -401,7 +401,7 @@ internal class UtledEndringerUtilTest {
         @Test
         internal fun `endring bostedsadresse på annen forelder trigger endring på annen forelder`() {
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "Navn", null, "Adresse 1")
-            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = barn.copy(annenForelder = annenForelder.copy(bostedsadresse = "Adresse 2"))
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -422,7 +422,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `søkers barn får delt bosted trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  emptyList(),false, null, null)
             val barn2 = barn.copy(harDeltBostedNå = true)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -443,15 +443,17 @@ internal class UtledEndringerUtilTest {
             val startdatoForOpprinneligKontrakt = LocalDate.now().minusYears(1)
             val sluttdatoForOpprinneligKontrakt = LocalDate.now().plusYears(1)
             val deltBostedGammel = DeltBostedDto(
-                startdatoForOpprinneligKontrakt,
-                sluttdatoForOpprinneligKontrakt
+                startdatoForKontrakt = startdatoForOpprinneligKontrakt,
+                sluttdatoForKontrakt = sluttdatoForOpprinneligKontrakt,
+                historisk = true
             )
             val deltBostedNy = DeltBostedDto(
-                sluttdatoForOpprinneligKontrakt,
-                sluttdatoForOpprinneligKontrakt.plusYears(5)
+                startdatoForKontrakt = sluttdatoForOpprinneligKontrakt,
+                sluttdatoForKontrakt = sluttdatoForOpprinneligKontrakt.plusYears(5),
+                historisk = false
             )
             val barn = BarnDto(
-                barnIdent, "", null, emptyList(), true, listOf(deltBostedGammel), true, null, null
+                barnIdent, "", null, emptyList(), true, listOf(deltBostedGammel),  emptyList(),true, null, null
             )
             val barn2 = barn.copy(deltBosted = listOf(deltBostedGammel, deltBostedNy))
             val endringer = finnEndringer(

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -99,7 +99,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Mangler verdi")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
             assertIngenAndreEndringer(endringer, "folkeregisterpersonstatus")
         }
 
@@ -112,7 +112,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Død")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
         }
 
         @Test
@@ -146,7 +146,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.fødselsdato.harEndringer).isTrue
             assertThat(endringer.fødselsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.fødselsdato.detaljer.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.fødselsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "fødselsdato")
         }
 
@@ -158,7 +158,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.dødsdato.harEndringer).isTrue
             assertThat(endringer.dødsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.dødsdato.detaljer.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.dødsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "dødsdato")
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -123,6 +123,7 @@ internal class VurderingServiceTest {
             "fnr",
             false,
             null,
+            emptyList(),
             false,
             AnnenForelderDto(
                 "navn",

--- a/src/test/resources/json/personopplysningerDto.json
+++ b/src/test/resources/json/personopplysningerDto.json
@@ -72,7 +72,12 @@
     "borHosSøker" : true,
     "deltBosted" : [ {
       "startdatoForKontrakt" : "2023-01-01",
-      "sluttdatoForKontrakt" : "2053-01-01"
+      "sluttdatoForKontrakt" : "2053-01-01",
+      "historisk" : false
+    }, {
+      "startdatoForKontrakt" : "2020-01-01",
+      "sluttdatoForKontrakt" : "2023-03-31",
+      "historisk" : true
     } ],
     "harDeltBostedNå" : true,
     "fødselsdato" : "2018-01-01",


### PR DESCRIPTION
Versjon 2: 
Legger ikke til ny liste på dto til personinformasjon (denne har allerede en liste) - mulig vi kan endre navn på denne i neste pr, men nå tar vi et skritt av gangen (beholder deltBosted her) (https://github.com/navikt/familie-ef-sak/pull/2110/commits/03a3bc185e6eaf6c4b8020a5c296ac486794a98c) 

Gjør klar til sletting av 
deltBosted = matchetBarn.barn?.deltBosted?.gjeldende().tilDto(), i [BarnMedSamværMapper.kt](https://github.com/navikt/familie-ef-sak/pull/2110/files#diff-1aca3fb4dc2bef6e8dcddf148dd45ac820c4a68594a052a08cdcf8c82a6867c9) etter at den nye listen med perioder tas i bruk i frontend. 

FrontendPR er også oppdatert til å gjenspeile endringene i backend her: 
https://github.com/navikt/familie-ef-sak-frontend/pull/2130

Plan videre før merge: 
* Skal teste ny backend + master frontend før jeg merger noe, done ✅ 

Plan etter merging
* Skal slette deltBosted når deltBostedPerioder tas i bruk i frontend (nye PR'er)
* Skal endre harDeltBostedNå til harDeltBosted ("nå" er ikke alltid riktig
* Vurdere å endre navn på deltBosted til deltBostedPerioder (brukt i personopplysninger) 

----

…historiske perioder kan være av interesse også

Vi bestemte oss for å sende med alle delt bosted perioder i stedet for bare den gjeldende perioden, siden det er noe usikkerhet rundt hva historiske perioder egentlig er. Sender foreløpig med gjeldende delt bosted og alle delte bosted for contract expansion. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10042

