### PR TITLE
Hent historisk bosted fra pdl

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -34,6 +35,9 @@ class PersonopplysningerMapper(
     private val innflyttingUtflyttingMapper: InnflyttingUtflyttingMapper,
     private val arbeidsfordelingService: ArbeidsfordelingService
 ) {
+
+
+    private val logger = LoggerFactory.getLogger(javaClass)
 
     fun tilPersonopplysninger(
         grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
@@ -132,6 +136,10 @@ class PersonopplysningerMapper(
         val annenForelderIdent = barn.forelderBarnRelasjon.find {
             !søkerIdenter.contains(it.relatertPersonsIdent) && it.relatertPersonsRolle != Familierelasjonsrolle.BARN
         }?.relatertPersonsIdent
+
+        barn.deltBosted.forEach(){
+            logger.info("${it.startdatoForKontrakt} historisk: ${it.metadata.historisk}")
+        }
 
         feilHvis(barn.deltBosted.filter { !it.metadata.historisk }.size > 1) { "Fant mer enn en ikke-historisk delt bosted." }
         val deltBostedDto =

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -37,7 +37,7 @@ class PersonopplysningerMapper(
 ) {
 
 
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun tilPersonopplysninger(
         grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
@@ -126,7 +126,7 @@ class PersonopplysningerMapper(
         return AdresseHjelper.sorterAdresser(adresser)
     }
 
-    fun mapBarn(
+    private fun mapBarn(
         barn: BarnMedIdent,
         søkerIdenter: Set<String>,
         bostedsadresserForelder: List<Bostedsadresse>,
@@ -138,7 +138,12 @@ class PersonopplysningerMapper(
         }?.relatertPersonsIdent
 
         barn.deltBosted.forEach(){
-            logger.info("${it.startdatoForKontrakt} historisk: ${it.metadata.historisk}")
+            secureLogger.info("${barn.personIdent} : ${it.startdatoForKontrakt} historisk: ${it.metadata.historisk}")
+        }
+
+        if (barn.deltBosted.size == 0 ){
+            secureLogger.info("barn: ${barn.personIdent} , ikke funnet delt bosted")
+
         }
 
         feilHvis(barn.deltBosted.filter { !it.metadata.historisk }.size > 1) { "Fant mer enn en ikke-historisk delt bosted." }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -24,7 +24,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 
@@ -35,9 +34,6 @@ class PersonopplysningerMapper(
     private val innflyttingUtflyttingMapper: InnflyttingUtflyttingMapper,
     private val arbeidsfordelingService: ArbeidsfordelingService
 ) {
-
-
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
     fun tilPersonopplysninger(
         grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
@@ -136,15 +132,6 @@ class PersonopplysningerMapper(
         val annenForelderIdent = barn.forelderBarnRelasjon.find {
             !søkerIdenter.contains(it.relatertPersonsIdent) && it.relatertPersonsRolle != Familierelasjonsrolle.BARN
         }?.relatertPersonsIdent
-
-        barn.deltBosted.forEach(){
-            secureLogger.info("${barn.personIdent} : ${it.startdatoForKontrakt} historisk: ${it.metadata.historisk}")
-        }
-
-        if (barn.deltBosted.size == 0 ){
-            secureLogger.info("barn: ${barn.personIdent} , ikke funnet delt bosted")
-
-        }
 
         feilHvis(barn.deltBosted.filter { !it.metadata.historisk }.size > 1) { "Fant mer enn en ikke-historisk delt bosted." }
         val deltBostedDto =

--- a/src/main/resources/pdl/forelder_barn.graphql
+++ b/src/main/resources/pdl/forelder_barn.graphql
@@ -52,7 +52,7 @@ query($identer: [ID!]!){
                     bostedskommune
                 }
             }
-            deltBosted {
+            deltBosted (historikk: true){
                 startdatoForKontrakt
                 sluttdatoForKontrakt
                 vegadresse {


### PR DESCRIPTION
**Endring: deltBosted (historikk: true) ** 
Hent delt bosted som har historisk = true fra pdl. 

relatert til
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-10042

**Spørsmål jeg vil diskutere:** 

Jeg tror dette skal gå helt greit, men: Vil dette få noen sideeffekter jeg ikke ser? 
Grunnlagsdata fra behandlinger som allerede er opprettet ville fått en "endring har skjedd" dersom denne funksjonaliteten var skrudd på i prod?
 
Det likevel være liten sannsynlighet for at dette skulle skje (ikke sa mange saker som har delt bosted) 
Andre ting?  

**Hvorfor endring:** 
Etter mye fram og tilbake har vi bestemt oss for å vise fram historisk data her (kan være interessant for saksbehandler som f.eks skal revurdere bakover i tid) 
Det hjelper ikke å vise fram hypotetisk historiske behandlinger, vi må også hente disse fra pdl. 

**Eksempler:**
Her er personinformasjon fra en bruker med to barn. Begge har delt bosted, men det ene barnet har bare "historisk". 
(Tar en prat med fag om hvordan vi burde vise dette når det er en og bare en periode og denne er historisk) 

![image](https://user-images.githubusercontent.com/53942238/222119704-5bea7206-e420-4e32-92e7-94f0c11d8bc8.png)

![image](https://user-images.githubusercontent.com/53942238/222120399-1a516719-1081-4680-9c26-d0ccd30454eb.png)

Under vilkår kan det da se slik ut: 
![image](https://user-images.githubusercontent.com/53942238/222121022-1d34c5e2-174b-44eb-9608-52888a19d5bd.png)
