### PR TITLE
Støtte automatisk vurdering av flere caser:

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
@@ -208,7 +208,7 @@ class BarnMedSamværMapper(
             ?: AvstandTilSøkerDto(avstandIKm = null, langAvstandTilSøker = LangAvstandTilSøker.UKJENT)
 
     private fun List<DeltBosted>.tilDto(): List<DeltBostedDto> {
-        return this.mapNotNull { deltBosted -> deltBosted.tilDto()  }
+        return this.mapNotNull { deltBosted -> deltBosted.tilDto() }
     }
 }
 
@@ -217,5 +217,3 @@ private fun DeltBosted?.tilDto(): DeltBostedDto? {
         DeltBostedDto(this.startdatoForKontrakt, this.sluttdatoForKontrakt, this.metadata.historisk)
     } ?: null
 }
-
-

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -45,7 +45,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNo
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Vegadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergeEllerFullmektig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergemaalEllerFremtidsfullmakt
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata as PldMetadata
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.fødsel
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.lagKjønn
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.lagNavn
@@ -59,6 +58,7 @@ import org.springframework.context.annotation.Profile
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata as PldMetadata
 
 @Configuration
 @Profile("mock-pdl")

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -269,7 +269,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `fjernet barn`() {
-            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto("ident", "", null, emptyList(), true, emptyList(), false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
                 dto(barn = listOf())
@@ -288,7 +288,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring på navn trigger ikke endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
             val barn2 = BarnDto(barnIdent, "2", null, emptyList(), true, emptyList(), false, null, null)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -304,7 +304,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring bor hos søker trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
             val barn2 = barn.copy(borHosSøker = false)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -326,7 +326,7 @@ internal class UtledEndringerUtilTest {
         internal fun `endring dødsdato på barn trigger kun endring på barn`() {
             val dødsdato = LocalDate.now()
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "Navn", null, null)
-            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto(barnIdent, "", annenForelder, emptyList(), true, emptyList(), false, null, null)
             val barn2 = barn.copy(dødsdato = dødsdato)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -346,7 +346,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `endring av personident på annen forelder trigger endring både på barn og annen forelder`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
             val barn2 = BarnDto(
                 barnIdent,
                 "2",
@@ -354,7 +354,7 @@ internal class UtledEndringerUtilTest {
                 emptyList(),
                 true,
                 emptyList(),
-               false,
+                false,
                 null,
                 null
             )
@@ -380,7 +380,7 @@ internal class UtledEndringerUtilTest {
         internal fun `dødsdato på annen forelder skal kun trigge endring på annen forelder`() {
             val annenForelder = AnnenForelderMinimumDto(forelderIdent, "", null, null)
             val dødsdato = LocalDate.now()
-            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto("ident", "", annenForelder, emptyList(), true, emptyList(), false, null, null)
             val barn2 = barn.copy(annenForelder = annenForelder.copy(dødsdato = dødsdato))
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),
@@ -422,7 +422,7 @@ internal class UtledEndringerUtilTest {
 
         @Test
         internal fun `søkers barn får delt bosted trigger endring`() {
-            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(),  false, null, null)
+            val barn = BarnDto(barnIdent, "", null, emptyList(), true, emptyList(), false, null, null)
             val barn2 = barn.copy(harDeltBostedNå = true)
             val endringer = finnEndringer(
                 dto(barn = listOf(barn)),

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegelTest.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
+package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
 import io.mockk.every
 import io.mockk.mockk
@@ -15,7 +15,6 @@ import no.nav.familie.ef.sak.vilkår.dto.TidligereInnvilgetVedtakDto
 import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
-import no.nav.familie.ef.sak.vilkår.regler.vilkår.NyttBarnSammePartnerRegel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -26,12 +25,39 @@ class NyttBarnSammePartnerRegelTest {
 
     val hovedregelMetadataMock = mockk<HovedregelMetadata>()
     val behandlingBarn = behandlingBarn(behandlingId = UUID.randomUUID())
+    val behandlingBarn2 = behandlingBarn(behandlingId = UUID.randomUUID())
 
     @BeforeEach
     fun setup() {
         every { hovedregelMetadataMock.skalAutomatiskVurdereNyttBarnSammePartner } returns true
-        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn, behandlingBarn2)
         every { hovedregelMetadataMock.behandling } returns behandling()
+    }
+
+    @Test
+    fun `Gitt at bruker har kun ett barn og uavhengig av tidligere vedtak, når initiereDelvilkår, så skal vilkåret automatisk oppfylles`() {
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn)
+        val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+        val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
+        val annenForelderDto = mockk<AnnenForelderDto>()
+        every { annenForelderDto.tidligereVedtaksperioder } returns TidligereVedtaksperioderDto(null, TidligereInnvilgetVedtakDto(false, true, false), false)
+        every { barnMedSamværSøknadsgrunnlagDto.forelder } returns annenForelderDto
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
+            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto)),
+            tidligereVedtaksperioder = TidligereVedtaksperioderDto(TidligereInnvilgetVedtakDto(true, false, false), TidligereInnvilgetVedtakDto(false, false, false), false)
+        )
+
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+        val delvilkårsvurdering = listDelvilkårsvurdering.first().vurderinger.first()
+        assertThat(delvilkårsvurdering.svar).isEqualTo(SvarId.NEI)
+        assertThat(delvilkårsvurdering.begrunnelse).isEqualTo("Automatisk vurdert (${LocalDate.now().norskFormat()}): Bruker har kun ett barn.")
     }
 
     @Test
@@ -49,20 +75,27 @@ class NyttBarnSammePartnerRegelTest {
         assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
         val delvilkårsvurdering = listDelvilkårsvurdering.first().vurderinger.first()
         assertThat(delvilkårsvurdering.svar).isEqualTo(SvarId.NEI)
-        assertThat(delvilkårsvurdering.begrunnelse).startsWith("Automatisk vurdert (${LocalDate.now().norskFormat()}):")
+        assertThat(delvilkårsvurdering.begrunnelse).isEqualTo("Automatisk vurdert (${LocalDate.now().norskFormat()}): Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
     }
 
     @Test
-    fun `Gitt at bruker eller annen foreldre har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
+    fun `Gitt at bruker med flere barn eller annen foreldre har tidligere vedtak, og alle barn har registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
         val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+        val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
         val annenForelderDto = mockk<AnnenForelderDto>()
 
+        every { barnMedSamværRegistergrunnlagDto.fødselsnummer } returns "01010199999"
         every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
-            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, mockk())),
-            tidligereVedtaksperioder = TidligereVedtaksperioderDto(TidligereInnvilgetVedtakDto(true, false, false), TidligereInnvilgetVedtakDto(false, false, false), false)
+            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto)),
+            tidligereVedtaksperioder = TidligereVedtaksperioderDto(
+                TidligereInnvilgetVedtakDto(true, false, false),
+                TidligereInnvilgetVedtakDto(false, false, false),
+                false
+            )
         )
         every { annenForelderDto.tidligereVedtaksperioder } returns TidligereVedtaksperioderDto(null, null, false)
         every { barnMedSamværSøknadsgrunnlagDto.forelder } returns annenForelderDto
+        every { barnMedSamværRegistergrunnlagDto.forelder } returns annenForelderDto
         val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
             hovedregelMetadataMock,
             Vilkårsresultat.IKKE_TATT_STILLING_TIL,
@@ -77,11 +110,12 @@ class NyttBarnSammePartnerRegelTest {
     }
 
     @Test
-    fun `Gitt at bruker eller annen foreldre ikke har tidligere vedtak, og det finnes barn uten registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
+    fun `Gitt at bruker med flere barn eller annen foreldre ikke har tidligere vedtak, og det finnes barn uten registrert annen forelder, når initiereDelvilkår, så skal vilkåret ikke automatisk oppfylles`() {
         val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
         val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
         val annenForelderDto = mockk<AnnenForelderDto>()
 
+        every { barnMedSamværRegistergrunnlagDto.fødselsnummer } returns "01010199999"
         every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
             barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto))
         )
@@ -99,5 +133,51 @@ class NyttBarnSammePartnerRegelTest {
         assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
         assertThat(listDelvilkårsvurdering.first().vurderinger.first().svar).isNull()
         assertThat(listDelvilkårsvurdering.first().vurderinger.first().begrunnelse).isNull()
+    }
+
+    @Test
+    fun `Gitt bruker uten tidligere vedtak med to barn, hvorav ett terminbarn uten annen forelder, når initieredelvilkår, så skal vilkåret automatisk oppfylles`() {
+        // Poenget med testen er at den ikke skal bry seg om at det ikke er registrert annen forelder på terminbarn
+        val behandlingBarn = behandlingBarn(behandlingId = UUID.randomUUID())
+        val behandlingBarnTerminbarn = behandlingBarn(behandlingId = UUID.randomUUID(), fødselTermindato = LocalDate.now().plusWeeks(8))
+        every { hovedregelMetadataMock.barn } returns listOf(behandlingBarn, behandlingBarnTerminbarn)
+
+        val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+
+        val annenForelderDto = mockk<AnnenForelderDto>()
+        every { annenForelderDto.fødselsnummer } returns "01010199999"
+        every { annenForelderDto.tidligereVedtaksperioder } returns tidligereVedtaksperioderDtoIkkeTidligereInnvilget()
+
+        val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
+        every { barnMedSamværRegistergrunnlagDto.forelder } returns annenForelderDto
+        every { barnMedSamværRegistergrunnlagDto.fødselsnummer } returns "01010199999"
+
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns VilkårTestUtil.mockVilkårGrunnlagDto(
+            barnMedSamvær = listOf(BarnMedSamværDto(UUID.randomUUID(), barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto)),
+            tidligereVedtaksperioder = tidligereVedtaksperioderDtoIkkeTidligereInnvilget()
+        )
+        val annenForelderUtenFødselsnummer = mockk<AnnenForelderDto>()
+        every { barnMedSamværSøknadsgrunnlagDto.forelder } returns annenForelderUtenFødselsnummer
+        every { annenForelderUtenFødselsnummer.fødselsnummer } returns null
+        val listDelvilkårsvurdering = NyttBarnSammePartnerRegel().initiereDelvilkårsvurdering(
+            hovedregelMetadataMock,
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            null
+        )
+
+        assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+        assertThat(listDelvilkårsvurdering.first().vurderinger.size).isEqualTo(1)
+        val delvilkårsvurdering = listDelvilkårsvurdering.first().vurderinger.first()
+        assertThat(delvilkårsvurdering.svar).isEqualTo(SvarId.NEI)
+        assertThat(delvilkårsvurdering.begrunnelse).isEqualTo("Automatisk vurdert (${LocalDate.now().norskFormat()}): Verken bruker eller annen forelder får eller har fått stønad for felles barn.")
+    }
+
+    private fun tidligereVedtaksperioderDtoIkkeTidligereInnvilget(): TidligereVedtaksperioderDto {
+        return TidligereVedtaksperioderDto(
+            TidligereInnvilgetVedtakDto(false, false, false),
+            TidligereInnvilgetVedtakDto(false, false, false),
+            false
+        )
     }
 }


### PR DESCRIPTION
- 1 barn skal godkjennes
- Ikke ta hensyn til annen forelder for terminbarn, kun annen forelder på registerbarn

Testcaser skissert her: https://www.figma.com/file/U2lKxgydWDSpDTMVQDwuPH/Skisser-EF-Sak-2023?node-id=398%3A21880&t=b6h60rSa9xqkcQyr-0

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11396