### PR TITLE
Vilkårsvurdering gjenbruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -24,6 +24,8 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     AUTOMATISK_VURDER_NYTT_BARN_SAMME_PARTNER("familie.ef.sak.nytt-barn-samme-partner"),
     BEHANDLING_KORRIGERING("familie.ef.sak.behandling-korrigering", "Permission"),
 
+    VILKÅR_GJENBRUK("familie.ef.sak.vilkaar-gjenruk"),
+
     FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER("familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler"),
     FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR("familie.ef.sak.frontend-automatisk-utfylle-vilkar"),
     FRONTEND_SATSENDRING("familie.ef.sak.frontend-vis-satsendring"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import org.springframework.data.relational.core.mapping.Embedded
 import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -31,12 +32,19 @@ data class Vilkårsvurdering(
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
     @Column("delvilkar")
-    val delvilkårsvurdering: DelvilkårsvurderingWrapper
+    val delvilkårsvurdering: DelvilkårsvurderingWrapper,
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "gjenbrukt_")
+    val gjenbrukt: Gjenbrukt? = null
 ) {
     init {
         require(resultat.erIkkeDelvilkårsresultat()) // Verdien AUTOMATISK_OPPFYLT er kun forbeholdt delvilkår
     }
 }
+
+data class Gjenbrukt(
+    val behandlingId: UUID,
+    val endretTid: LocalDateTime
+)
 
 // Ingen støtte for å ha en liste direkt i entiteten, wrapper+converter virker
 data class DelvilkårsvurderingWrapper(val delvilkårsvurderinger: List<Delvilkårsvurdering>)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
@@ -35,7 +35,7 @@ data class Vilkårsvurdering(
     @Column("delvilkar")
     val delvilkårsvurdering: DelvilkårsvurderingWrapper,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "gjenbrukt_")
-    val gjenbrukt: Gjenbrukt? = null
+    val gjenbrukt: Gjenbrukt?
 ) {
     init {
         require(resultat.erIkkeDelvilkårsresultat()) // Verdien AUTOMATISK_OPPFYLT er kun forbeholdt delvilkår
@@ -48,6 +48,14 @@ data class Vilkårsvurdering(
         gjenbrukt ?: Gjenbrukt(behandlingId, sporbar.endret.endretTid)
 }
 
+/**
+ * Inneholder informasjon fra hvilken behandling dette vilkår ble gjenrukt fra
+ * Hvis man gjenbruker et vilkår som allerede er gjenbrukt fra en annen behandling,
+ * så skal man peke til den opprinnelige behandlingen. Dvs
+ * Behandling A
+ * Behandling B gjenbruker fra behandling A
+ * Behandling C gjenbruker fra B, men peker mot A sitt vilkår
+ */
 data class Gjenbrukt(
     val behandlingId: UUID,
     val endretTid: LocalDateTime

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
@@ -20,7 +20,7 @@ import java.util.UUID
  *
  * Hver vilkårsvurdering har delvilkår. Hvert delvilkår har vurderinger med svar, og kanskje begrunnelse.
  *
- * Husk at [gjenbrukt] må tas stilling til når man kopierer denne
+ * Husk at [opphavsvilkår] må tas stilling til når man kopierer denne
  */
 @Table("vilkarsvurdering")
 data class Vilkårsvurdering(
@@ -34,8 +34,8 @@ data class Vilkårsvurdering(
     val sporbar: Sporbar = Sporbar(),
     @Column("delvilkar")
     val delvilkårsvurdering: DelvilkårsvurderingWrapper,
-    @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "gjenbrukt_")
-    val gjenbrukt: Gjenbrukt?
+    @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "opphavsvilkaar_")
+    val opphavsvilkår: Opphavsvilkår?
 ) {
     init {
         require(resultat.erIkkeDelvilkårsresultat()) // Verdien AUTOMATISK_OPPFYLT er kun forbeholdt delvilkår
@@ -44,8 +44,8 @@ data class Vilkårsvurdering(
     /**
      * Brukes når man skal gjenbruke denne vilkårsvurderingen i en annan vilkårsvurdering
      */
-    fun lagGjenbrukt(): Gjenbrukt =
-        gjenbrukt ?: Gjenbrukt(behandlingId, sporbar.endret.endretTid)
+    fun opprettOpphavsvilkår(): Opphavsvilkår =
+        opphavsvilkår ?: Opphavsvilkår(behandlingId, sporbar.endret.endretTid)
 }
 
 /**
@@ -56,9 +56,9 @@ data class Vilkårsvurdering(
  * Behandling B gjenbruker fra behandling A
  * Behandling C gjenbruker fra B, men peker mot A sitt vilkår
  */
-data class Gjenbrukt(
+data class Opphavsvilkår(
     val behandlingId: UUID,
-    val endretTid: LocalDateTime
+    val vurderingstidspunkt: LocalDateTime
 )
 
 // Ingen støtte for å ha en liste direkt i entiteten, wrapper+converter virker

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
@@ -20,6 +20,7 @@ import java.util.UUID
  *
  * Hver vilkårsvurdering har delvilkår. Hvert delvilkår har vurderinger med svar, og kanskje begrunnelse.
  *
+ * Husk at [gjenbrukt] må tas stilling til når man kopierer denne
  */
 @Table("vilkarsvurdering")
 data class Vilkårsvurdering(
@@ -39,6 +40,12 @@ data class Vilkårsvurdering(
     init {
         require(resultat.erIkkeDelvilkårsresultat()) // Verdien AUTOMATISK_OPPFYLT er kun forbeholdt delvilkår
     }
+
+    /**
+     * Brukes når man skal gjenbruke denne vilkårsvurderingen i en annan vilkårsvurdering
+     */
+    fun lagGjenbrukt(): Gjenbrukt =
+        gjenbrukt ?: Gjenbrukt(behandlingId, sporbar.endret.endretTid)
 }
 
 data class Gjenbrukt(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -234,7 +234,7 @@ class VurderingService(
         barnPåGjeldendeBehandling: List<BehandlingBarn>,
         nyBehandlingsId: UUID,
         barnIdMap: Map<UUID, BehandlingBarn>
-    ) =
+    ): Map<UUID, Vilkårsvurdering> =
         tidligereVurderinger.values
             .filter { skalKopiereVurdering(it, barnPåGjeldendeBehandling.isNotEmpty()) }
             .associate { vurdering ->
@@ -242,7 +242,8 @@ class VurderingService(
                     id = UUID.randomUUID(),
                     behandlingId = nyBehandlingsId,
                     sporbar = Sporbar(),
-                    barnId = finnBarnId(vurdering.barnId, barnIdMap)
+                    barnId = finnBarnId(vurdering.barnId, barnIdMap),
+                    gjenbrukt = vurdering.lagGjenbrukt()
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -249,7 +249,7 @@ class VurderingService(
                     behandlingId = nyBehandlingsId,
                     sporbar = Sporbar(),
                     barnId = finnBarnId(vurdering.barnId, barnIdMap),
-                    gjenbrukt = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) vurdering.lagGjenbrukt() else null
+                    opphavsvilkår = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) vurdering.opprettOpphavsvilkår() else null
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -249,7 +249,7 @@ class VurderingService(
                     behandlingId = nyBehandlingsId,
                     sporbar = Sporbar(),
                     barnId = finnBarnId(vurdering.barnId, barnIdMap),
-                    gjenbrukt = vurdering.lagGjenbrukt()
+                    gjenbrukt = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) vurdering.lagGjenbrukt() else null
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
@@ -116,7 +116,8 @@ class VurderingStegService(
         return vilkårsvurderingRepository.update(
             vilkårsvurdering.copy(
                 resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
-                delvilkårsvurdering = delvilkårsvurdering
+                delvilkårsvurdering = delvilkårsvurdering,
+                gjenbrukt = null
             )
         ).tilDto()
     }
@@ -134,7 +135,8 @@ class VurderingStegService(
         return vilkårsvurderingRepository.update(
             vilkårsvurdering.copy(
                 resultat = Vilkårsresultat.SKAL_IKKE_VURDERES,
-                delvilkårsvurdering = delvilkårsvurdering
+                delvilkårsvurdering = delvilkårsvurdering,
+                gjenbrukt = null
             )
         ).tilDto()
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
@@ -117,7 +117,7 @@ class VurderingStegService(
             vilkårsvurdering.copy(
                 resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
                 delvilkårsvurdering = delvilkårsvurdering,
-                gjenbrukt = null
+                opphavsvilkår = null
             )
         ).tilDto()
     }
@@ -136,7 +136,7 @@ class VurderingStegService(
             vilkårsvurdering.copy(
                 resultat = Vilkårsresultat.SKAL_IKKE_VURDERES,
                 delvilkårsvurdering = delvilkårsvurdering,
-                gjenbrukt = null
+                opphavsvilkår = null
             )
         ).tilDto()
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårsvurderingDto.kt
@@ -18,7 +18,13 @@ data class VilkårsvurderingDto(
     val barnId: UUID? = null,
     val endretAv: String,
     val endretTid: LocalDateTime,
-    val delvilkårsvurderinger: List<DelvilkårsvurderingDto> = emptyList()
+    val delvilkårsvurderinger: List<DelvilkårsvurderingDto> = emptyList(),
+    val gjenbrukt: GjenbruktDto?
+)
+
+data class GjenbruktDto(
+    val behandlingId: UUID,
+    val endretTid: LocalDateTime
 )
 
 data class OppdaterVilkårsvurderingDto(val id: UUID, val behandlingId: UUID)
@@ -63,7 +69,8 @@ fun Vilkårsvurdering.tilDto() =
         endretTid = this.sporbar.endret.endretTid,
         delvilkårsvurderinger = this.delvilkårsvurdering.delvilkårsvurderinger
             .filter { it.resultat != Vilkårsresultat.IKKE_AKTUELL }
-            .map { it.tilDto() }
+            .map { it.tilDto() },
+        gjenbrukt = this.gjenbrukt?.let { GjenbruktDto(it.behandlingId, it.endretTid) }
     )
 
 fun DelvilkårsvurderingDto.svarTilDomene() = this.vurderinger.map { it.tilDomene() }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårsvurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårsvurderingDto.kt
@@ -19,10 +19,10 @@ data class VilkårsvurderingDto(
     val endretAv: String,
     val endretTid: LocalDateTime,
     val delvilkårsvurderinger: List<DelvilkårsvurderingDto> = emptyList(),
-    val gjenbrukt: GjenbruktDto?
+    val opphavsvilkår: OpphavsvilkårDto?
 )
 
-data class GjenbruktDto(
+data class OpphavsvilkårDto(
     val behandlingId: UUID,
     val endretTid: LocalDateTime
 )
@@ -70,7 +70,7 @@ fun Vilkårsvurdering.tilDto() =
         delvilkårsvurderinger = this.delvilkårsvurdering.delvilkårsvurderinger
             .filter { it.resultat != Vilkårsresultat.IKKE_AKTUELL }
             .map { it.tilDto() },
-        gjenbrukt = this.gjenbrukt?.let { GjenbruktDto(it.behandlingId, it.endretTid) }
+        opphavsvilkår = this.opphavsvilkår?.let { OpphavsvilkårDto(it.behandlingId, it.vurderingstidspunkt) }
     )
 
 fun DelvilkårsvurderingDto.svarTilDomene() = this.vurderinger.map { it.tilDomene() }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -89,7 +89,8 @@ class GjenbrukVilkårService(
                     id = it.id,
                     behandlingId = behandlingId,
                     sporbar = it.sporbar,
-                    barnId = it.barnId
+                    barnId = it.barnId,
+                    gjenbrukt = tidligereVurdering.lagGjenbrukt()
                 )
             }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -93,7 +93,7 @@ class GjenbrukVilkårService(
                     behandlingId = behandlingId,
                     sporbar = it.sporbar,
                     barnId = it.barnId,
-                    gjenbrukt = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) tidligereVurdering.lagGjenbrukt() else null
+                    opphavsvilkår = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) tidligereVurdering.opprettOpphavsvilkår() else null
                 )
             }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -10,6 +10,8 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
@@ -27,7 +29,8 @@ class GjenbrukVilkårService(
     private val fagsakService: FagsakService,
     private val vilkårsvurderingRepository: VilkårsvurderingRepository,
     private val grunnlagsdataService: GrunnlagsdataService,
-    private val barnService: BarnService
+    private val barnService: BarnService,
+    private val featureToggleService: FeatureToggleService
 ) {
 
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -90,7 +93,7 @@ class GjenbrukVilkårService(
                     behandlingId = behandlingId,
                     sporbar = it.sporbar,
                     barnId = it.barnId,
-                    gjenbrukt = tidligereVurdering.lagGjenbrukt()
+                    gjenbrukt = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) tidligereVurdering.lagGjenbrukt() else null
                 )
             }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -43,7 +43,8 @@ object OppdaterVilkår {
         val oppdaterteDelvilkår = oppdaterDelvilkår(vilkårsvurdering, vilkårsresultat, oppdatering)
         return vilkårsvurdering.copy(
             resultat = vilkårsresultat.vilkår,
-            delvilkårsvurdering = oppdaterteDelvilkår
+            delvilkårsvurdering = oppdaterteDelvilkår,
+            gjenbrukt = null
         )
     }
 
@@ -199,7 +200,8 @@ object OppdaterVilkår {
             type = vilkårsregel.vilkårType,
             barnId = barnId,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
-            resultat = utledResultat(vilkårsregel, delvilkårsvurdering.map { it.tilDto() }).vilkår
+            resultat = utledResultat(vilkårsregel, delvilkårsvurdering.map { it.tilDto() }).vilkår,
+            gjenbrukt = null
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -44,7 +44,7 @@ object OppdaterVilkår {
         return vilkårsvurdering.copy(
             resultat = vilkårsresultat.vilkår,
             delvilkårsvurdering = oppdaterteDelvilkår,
-            gjenbrukt = null
+            opphavsvilkår = null
         )
     }
 
@@ -201,7 +201,7 @@ object OppdaterVilkår {
             barnId = barnId,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
             resultat = utledResultat(vilkårsregel, delvilkårsvurdering.map { it.tilDto() }).vilkår,
-            gjenbrukt = null
+            opphavsvilkår = null
         )
     }
 }

--- a/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
+++ b/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
@@ -1,4 +1,4 @@
 ALTER TABLE vilkarsvurdering
     ADD COLUMN gjenbrukt_behandling_id UUID;
 ALTER TABLE vilkarsvurdering
-    ADD COLUMN gjenbrukt_endret_tid TIMESTAMP;
+    ADD COLUMN gjenbrukt_endret_tid TIMESTAMP(3);

--- a/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
+++ b/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
@@ -1,0 +1,4 @@
+ALTER TABLE vilkarsvurdering
+    ADD COLUMN gjenbrukt_behandling_id UUID;
+ALTER TABLE vilkarsvurdering
+    ADD COLUMN gjenbrukt_endret_tid TIMESTAMP;

--- a/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
+++ b/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
@@ -1,4 +1,4 @@
 ALTER TABLE vilkarsvurdering
-    ADD COLUMN gjenbrukt_behandling_id UUID;
+    ADD COLUMN opphavsvilkaar_behandling_id UUID;
 ALTER TABLE vilkarsvurdering
-    ADD COLUMN gjenbrukt_endret_tid TIMESTAMP(3);
+    ADD COLUMN opphavsvilkaar_endret_tid TIMESTAMP(3);

--- a/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
+++ b/src/main/resources/db/migration/V132__vilkårsvurdering_gjenbruk.sql
@@ -1,4 +1,4 @@
 ALTER TABLE vilkarsvurdering
     ADD COLUMN opphavsvilkaar_behandling_id UUID;
 ALTER TABLE vilkarsvurdering
-    ADD COLUMN opphavsvilkaar_endret_tid TIMESTAMP(3);
+    ADD COLUMN opphavsvilkaar_vurderingstidspunkt TIMESTAMP(3);

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -234,7 +234,8 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
                             }
                         )
                     }
-                )
+                ),
+                gjenbrukt = null
             )
         }
         return vilkårsvurderinger

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -235,7 +235,7 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
                         )
                     }
                 ),
-                gjenbrukt = null
+                opphavsvilkår = null
             )
         }
         return vilkårsvurderinger

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -53,6 +53,7 @@ import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
+import no.nav.familie.ef.sak.vilkår.Gjenbrukt
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
@@ -239,14 +240,16 @@ fun vilkårsvurdering(
     resultat: Vilkårsresultat = Vilkårsresultat.OPPFYLT,
     type: VilkårType = VilkårType.LOVLIG_OPPHOLD,
     delvilkårsvurdering: List<Delvilkårsvurdering> = emptyList(),
-    barnId: UUID? = null
+    barnId: UUID? = null,
+    gjenbrukt: Gjenbrukt? = null
 ): Vilkårsvurdering =
     Vilkårsvurdering(
         behandlingId = behandlingId,
         resultat = resultat,
         type = type,
         barnId = barnId,
-        delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering)
+        delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
+        gjenbrukt = gjenbrukt
     )
 
 fun fagsakpersoner(vararg identer: String): Set<PersonIdent> = identer.map {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -53,7 +53,7 @@ import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
-import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
@@ -241,7 +241,7 @@ fun vilkårsvurdering(
     type: VilkårType = VilkårType.LOVLIG_OPPHOLD,
     delvilkårsvurdering: List<Delvilkårsvurdering> = emptyList(),
     barnId: UUID? = null,
-    gjenbrukt: Gjenbrukt? = null
+    opphavsvilkår: Opphavsvilkår? = null
 ): Vilkårsvurdering =
     Vilkårsvurdering(
         behandlingId = behandlingId,
@@ -249,7 +249,7 @@ fun vilkårsvurdering(
         type = type,
         barnId = barnId,
         delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
-        gjenbrukt = gjenbrukt
+        opphavsvilkår = opphavsvilkår
     )
 
 fun fagsakpersoner(vararg identer: String): Set<PersonIdent> = identer.map {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
@@ -4,10 +4,15 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.Gjenbrukt
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
+import no.nav.familie.ef.sak.vilkår.Vurdering
+import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,15 +33,32 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
+        val vurderinger = listOf(Vurdering(RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE, SvarId.JA, "ja"))
         val vilkårsvurdering = vilkårsvurderingRepository.insert(
             vilkårsvurdering(
-                behandling.id,
-                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
-                VilkårType.FORUTGÅENDE_MEDLEMSKAP
+                behandlingId = behandling.id,
+                resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                type = VilkårType.FORUTGÅENDE_MEDLEMSKAP,
+                delvilkårsvurdering = listOf(Delvilkårsvurdering(Vilkårsresultat.OPPFYLT, vurderinger)),
+                barnId = null,
+                gjenbrukt = Gjenbrukt(behandling.id, LocalDateTime.now())
             )
         )
 
         assertThat(vilkårsvurderingRepository.findByBehandlingId(UUID.randomUUID())).isEmpty()
+        assertThat(vilkårsvurderingRepository.findByBehandlingId(behandling.id)).containsOnly(vilkårsvurdering)
+    }
+
+    @Test
+    internal fun `vilkårsvurdering uten gjenbrukt`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val vilkårsvurdering = vilkårsvurderingRepository.insert(vilkårsvurdering(
+            behandlingId = behandling.id,
+            resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            type = VilkårType.FORUTGÅENDE_MEDLEMSKAP,
+            gjenbrukt = null
+        ))
         assertThat(vilkårsvurderingRepository.findByBehandlingId(behandling.id)).containsOnly(vilkårsvurdering)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.felles.domain.SporbarUtils
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
@@ -41,7 +42,7 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
                 type = VilkårType.FORUTGÅENDE_MEDLEMSKAP,
                 delvilkårsvurdering = listOf(Delvilkårsvurdering(Vilkårsresultat.OPPFYLT, vurderinger)),
                 barnId = null,
-                gjenbrukt = Gjenbrukt(behandling.id, LocalDateTime.now())
+                gjenbrukt = Gjenbrukt(behandling.id, SporbarUtils.now())
             )
         )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingRepositoryTest.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ef.sak.felles.domain.SporbarUtils
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
-import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
@@ -42,7 +42,7 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
                 type = VilkårType.FORUTGÅENDE_MEDLEMSKAP,
                 delvilkårsvurdering = listOf(Delvilkårsvurdering(Vilkårsresultat.OPPFYLT, vurderinger)),
                 barnId = null,
-                gjenbrukt = Gjenbrukt(behandling.id, SporbarUtils.now())
+                opphavsvilkår = Opphavsvilkår(behandling.id, SporbarUtils.now())
             )
         )
 
@@ -51,14 +51,14 @@ internal class VilkårsvurderingRepositoryTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    internal fun `vilkårsvurdering uten gjenbrukt`() {
+    internal fun `vilkårsvurdering uten opphavsvilkår`() {
         val fagsak = testoppsettService.lagreFagsak(fagsak())
         val behandling = behandlingRepository.insert(behandling(fagsak))
         val vilkårsvurdering = vilkårsvurderingRepository.insert(vilkårsvurdering(
             behandlingId = behandling.id,
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.FORUTGÅENDE_MEDLEMSKAP,
-            gjenbrukt = null
+            opphavsvilkår = null
         ))
         assertThat(vilkårsvurderingRepository.findByBehandlingId(behandling.id)).containsOnly(vilkårsvurdering)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingTest.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository
+
+import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
+import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+internal class VilkårsvurderingTest {
+
+    private val behandlingIdFørstegangsbehandling = UUID.randomUUID()
+    private val behandlingIdRevurdering = UUID.randomUUID()
+
+    @Test
+    internal fun `lagGjenbrukt - et vilkår som ikke er gjenbrukt skal peke til behandlingen`() {
+        val vilkårsvurdering = Vilkårsvurdering(
+            behandlingId = behandlingIdFørstegangsbehandling,
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
+            type = VilkårType.MOR_ELLER_FAR,
+            gjenbrukt = null
+        )
+        val gjenbrukt = vilkårsvurdering.lagGjenbrukt()
+        assertThat(gjenbrukt).isEqualTo(Gjenbrukt(behandlingIdFørstegangsbehandling,
+            vilkårsvurdering.sporbar.endret.endretTid))
+    }
+
+    @Test
+    internal fun `lagGjenbrukt - skal bruke gjenbrukt hvis den finnes og ikke lage en ny, for å peke til den opprinnelige behandlingen`() {
+        val gjenbrukt = Gjenbrukt(behandlingIdFørstegangsbehandling, LocalDateTime.now())
+        val vilkårsvurdering = Vilkårsvurdering(
+            behandlingId = behandlingIdRevurdering,
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
+            type = VilkårType.MOR_ELLER_FAR,
+            gjenbrukt = gjenbrukt
+        )
+        val nyGjenbrukt = vilkårsvurdering.lagGjenbrukt()
+        assertThat(nyGjenbrukt).isEqualTo(gjenbrukt)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/VilkårsvurderingTest.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.repository
 
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
-import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import org.assertj.core.api.Assertions.assertThat
@@ -15,28 +15,28 @@ internal class VilkårsvurderingTest {
     private val behandlingIdRevurdering = UUID.randomUUID()
 
     @Test
-    internal fun `lagGjenbrukt - et vilkår som ikke er gjenbrukt skal peke til behandlingen`() {
+    internal fun `opprettOpphavsvilkår - et vilkår som ikke er gjenbrukt skal peke til behandlingen`() {
         val vilkårsvurdering = Vilkårsvurdering(
             behandlingId = behandlingIdFørstegangsbehandling,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
             type = VilkårType.MOR_ELLER_FAR,
-            gjenbrukt = null
+            opphavsvilkår = null
         )
-        val gjenbrukt = vilkårsvurdering.lagGjenbrukt()
-        assertThat(gjenbrukt).isEqualTo(Gjenbrukt(behandlingIdFørstegangsbehandling,
+        val opphavsvilkår = vilkårsvurdering.opprettOpphavsvilkår()
+        assertThat(opphavsvilkår).isEqualTo(Opphavsvilkår(behandlingIdFørstegangsbehandling,
             vilkårsvurdering.sporbar.endret.endretTid))
     }
 
     @Test
-    internal fun `lagGjenbrukt - skal bruke gjenbrukt hvis den finnes og ikke lage en ny, for å peke til den opprinnelige behandlingen`() {
-        val gjenbrukt = Gjenbrukt(behandlingIdFørstegangsbehandling, LocalDateTime.now())
+    internal fun `opprettOpphavsvilkår - skal bruke opphavsvilkår hvis den finnes og ikke lage en ny, for å peke til den opprinnelige behandlingen`() {
+        val opphavsvilkår = Opphavsvilkår(behandlingIdFørstegangsbehandling, LocalDateTime.now())
         val vilkårsvurdering = Vilkårsvurdering(
             behandlingId = behandlingIdRevurdering,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
             type = VilkårType.MOR_ELLER_FAR,
-            gjenbrukt = gjenbrukt
+            opphavsvilkår = opphavsvilkår
         )
-        val nyGjenbrukt = vilkårsvurdering.lagGjenbrukt()
-        assertThat(nyGjenbrukt).isEqualTo(gjenbrukt)
+        val nyttOpphavsvilkår = vilkårsvurdering.opprettOpphavsvilkår()
+        assertThat(nyttOpphavsvilkår).isEqualTo(opphavsvilkår)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -39,7 +39,7 @@ import no.nav.familie.ef.sak.vedtak.domain.PeriodeMedBeløp
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.ef.sak.vedtak.dto.tilVedtakDto
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
-import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
@@ -182,9 +182,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(sivilstandVilkårForBehandling.sporbar.endret.endretTid).isEqualTo(sivilstandVilkårForRevurdering.sporbar.endret.endretTid)
         assertThat(sivilstandVilkårForRevurdering.barnId).isNull()
         assertThat(sivilstandVilkårForBehandling.barnId).isNull()
-        assertThat(sivilstandVilkårForBehandling.gjenbrukt).isNull()
-        assertThat(sivilstandVilkårForRevurdering.gjenbrukt)
-            .isEqualTo(Gjenbrukt(behandling.id, sivilstandVilkårForBehandling.sporbar.endret.endretTid))
+        assertThat(sivilstandVilkårForBehandling.opphavsvilkår).isNull()
+        assertThat(sivilstandVilkårForRevurdering.opphavsvilkår)
+            .isEqualTo(Opphavsvilkår(behandling.id, sivilstandVilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(aleneomsorgVilkårForBehandling.id).isNotEqualTo(aleneomsorgVilkårForRevurdering.id)
         assertThat(aleneomsorgVilkårForBehandling.barnId).isNotEqualTo(aleneomsorgVilkårForRevurdering.barnId)
@@ -193,15 +193,15 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(aleneomsorgVilkårForBehandling.sporbar.endret.endretTid).isEqualTo(aleneomsorgVilkårForRevurdering.sporbar.endret.endretTid)
         assertThat(aleneomsorgVilkårForBehandling.barnId).isNotNull
         assertThat(aleneomsorgVilkårForRevurdering.barnId).isEqualTo(barnPåBehandling.id)
-        assertThat(aleneomsorgVilkårForBehandling.gjenbrukt).isNull()
-        assertThat(aleneomsorgVilkårForRevurdering.gjenbrukt)
-            .isEqualTo(Gjenbrukt(behandling.id, aleneomsorgVilkårForBehandling.sporbar.endret.endretTid))
+        assertThat(aleneomsorgVilkårForBehandling.opphavsvilkår).isNull()
+        assertThat(aleneomsorgVilkårForRevurdering.opphavsvilkår)
+            .isEqualTo(Opphavsvilkår(behandling.id, aleneomsorgVilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(sivilstandVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
             .isEqualTo(sivilstandVilkårForRevurdering)
         assertThat(aleneomsorgVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
             .isEqualTo(aleneomsorgVilkårForRevurdering)
     }
 
@@ -280,7 +280,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(vilkårForBehandling.map { it.sporbar.opprettetTid }).isNotIn(vilkårForRevurdering.map { it.sporbar.opprettetTid })
 
         assertThat(vilkårForBehandling.first { it.type == VilkårType.SIVILSTAND }).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
             .isEqualTo(vilkårForRevurdering.first { it.type == VilkårType.SIVILSTAND })
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -198,10 +198,10 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
             .isEqualTo(Opphavsvilkår(behandling.id, aleneomsorgVilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(sivilstandVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkår")
             .isEqualTo(sivilstandVilkårForRevurdering)
         assertThat(aleneomsorgVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkår")
             .isEqualTo(aleneomsorgVilkårForRevurdering)
     }
 
@@ -280,7 +280,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(vilkårForBehandling.map { it.sporbar.opprettetTid }).isNotIn(vilkårForRevurdering.map { it.sporbar.opprettetTid })
 
         assertThat(vilkårForBehandling.first { it.type == VilkårType.SIVILSTAND }).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkår")
             .isEqualTo(vilkårForRevurdering.first { it.type == VilkårType.SIVILSTAND })
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -39,6 +39,7 @@ import no.nav.familie.ef.sak.vedtak.domain.PeriodeMedBeløp
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.ef.sak.vedtak.dto.tilVedtakDto
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.Gjenbrukt
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
@@ -181,6 +182,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(sivilstandVilkårForBehandling.sporbar.endret.endretTid).isEqualTo(sivilstandVilkårForRevurdering.sporbar.endret.endretTid)
         assertThat(sivilstandVilkårForRevurdering.barnId).isNull()
         assertThat(sivilstandVilkårForBehandling.barnId).isNull()
+        assertThat(sivilstandVilkårForBehandling.gjenbrukt).isNull()
+        assertThat(sivilstandVilkårForRevurdering.gjenbrukt)
+            .isEqualTo(Gjenbrukt(behandling.id, sivilstandVilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(aleneomsorgVilkårForBehandling.id).isNotEqualTo(aleneomsorgVilkårForRevurdering.id)
         assertThat(aleneomsorgVilkårForBehandling.barnId).isNotEqualTo(aleneomsorgVilkårForRevurdering.barnId)
@@ -189,12 +193,15 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(aleneomsorgVilkårForBehandling.sporbar.endret.endretTid).isEqualTo(aleneomsorgVilkårForRevurdering.sporbar.endret.endretTid)
         assertThat(aleneomsorgVilkårForBehandling.barnId).isNotNull
         assertThat(aleneomsorgVilkårForRevurdering.barnId).isEqualTo(barnPåBehandling.id)
+        assertThat(aleneomsorgVilkårForBehandling.gjenbrukt).isNull()
+        assertThat(aleneomsorgVilkårForRevurdering.gjenbrukt)
+            .isEqualTo(Gjenbrukt(behandling.id, aleneomsorgVilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(sivilstandVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
             .isEqualTo(sivilstandVilkårForRevurdering)
         assertThat(aleneomsorgVilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
             .isEqualTo(aleneomsorgVilkårForRevurdering)
     }
 
@@ -273,7 +280,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(vilkårForBehandling.map { it.sporbar.opprettetTid }).isNotIn(vilkårForRevurdering.map { it.sporbar.opprettetTid })
 
         assertThat(vilkårForBehandling.first { it.type == VilkårType.SIVILSTAND }).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
             .isEqualTo(vilkårForRevurdering.first { it.type == VilkårType.SIVILSTAND })
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -80,7 +80,7 @@ internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
             .isEqualTo(Opphavsvilkår(behandling.id, vilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(vilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkår")
             .isEqualTo(vilkårForRevurdering)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -74,9 +74,13 @@ internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
         assertThat(vilkårForBehandling.sporbar.endret).isEqualTo(vilkårForRevurdering.sporbar.endret)
         assertThat(vilkårForBehandling.barnId).isNotEqualTo(vilkårForRevurdering.barnId)
         assertThat(vilkårForBehandling.barnId).isEqualTo(barnPåFørsteSøknad.first().id)
+        assertThat(vilkårForBehandling.gjenbrukt).isNull()
         assertThat(vilkårForRevurdering.barnId).isEqualTo(barnPåRevurdering.first().id)
+        assertThat(vilkårForRevurdering.gjenbrukt)
+            .isEqualTo(Gjenbrukt(behandling.id, vilkårForBehandling.sporbar.endret.endretTid))
 
-        assertThat(vilkårForBehandling).usingRecursiveComparison().ignoringFields("id", "sporbar", "behandlingId", "barnId")
+        assertThat(vilkårForBehandling).usingRecursiveComparison()
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
             .isEqualTo(vilkårForRevurdering)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -74,13 +74,13 @@ internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
         assertThat(vilkårForBehandling.sporbar.endret).isEqualTo(vilkårForRevurdering.sporbar.endret)
         assertThat(vilkårForBehandling.barnId).isNotEqualTo(vilkårForRevurdering.barnId)
         assertThat(vilkårForBehandling.barnId).isEqualTo(barnPåFørsteSøknad.first().id)
-        assertThat(vilkårForBehandling.gjenbrukt).isNull()
+        assertThat(vilkårForBehandling.opphavsvilkår).isNull()
         assertThat(vilkårForRevurdering.barnId).isEqualTo(barnPåRevurdering.first().id)
-        assertThat(vilkårForRevurdering.gjenbrukt)
-            .isEqualTo(Gjenbrukt(behandling.id, vilkårForBehandling.sporbar.endret.endretTid))
+        assertThat(vilkårForRevurdering.opphavsvilkår)
+            .isEqualTo(Opphavsvilkår(behandling.id, vilkårForBehandling.sporbar.endret.endretTid))
 
         assertThat(vilkårForBehandling).usingRecursiveComparison()
-            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "gjenbrukt")
+            .ignoringFields("id", "sporbar", "behandlingId", "barnId", "opphavsvilkaar")
             .isEqualTo(vilkårForRevurdering)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -242,7 +242,8 @@ internal class VurderingServiceTest {
                 Vilkårsvurdering(
                     behandlingId = behandlingId,
                     type = VilkårType.SIVILSTAND,
-                    delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering)
+                    delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
+                    gjenbrukt = null
                 )
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -243,7 +243,7 @@ internal class VurderingServiceTest {
                     behandlingId = behandlingId,
                     type = VilkårType.SIVILSTAND,
                     delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
-                    gjenbrukt = null
+                    opphavsvilkår = null
                 )
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -177,7 +177,7 @@ internal class VurderingStegServiceTest {
 
         assertThat(lagretVilkårsvurdering.captured.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
         assertThat(lagretVilkårsvurdering.captured.type).isEqualTo(vilkårsvurdering.type)
-        assertThat(lagretVilkårsvurdering.captured.gjenbrukt).isNull()
+        assertThat(lagretVilkårsvurdering.captured.opphavsvilkår).isNull()
 
         val delvilkårsvurdering = lagretVilkårsvurdering.captured.delvilkårsvurdering.delvilkårsvurderinger.first()
         assertThat(delvilkårsvurdering.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
@@ -201,7 +201,7 @@ internal class VurderingStegServiceTest {
 
         assertThat(oppdatertVurdering.captured.resultat).isEqualTo(Vilkårsresultat.SKAL_IKKE_VURDERES)
         assertThat(oppdatertVurdering.captured.type).isEqualTo(vilkårsvurdering.type)
-        assertThat(oppdatertVurdering.captured.gjenbrukt).isNull()
+        assertThat(oppdatertVurdering.captured.opphavsvilkår).isNull()
 
         val delvilkårsvurdering = oppdatertVurdering.captured.delvilkårsvurdering.delvilkårsvurderinger.first()
         assertThat(delvilkårsvurdering.resultat).isEqualTo(Vilkårsresultat.SKAL_IKKE_VURDERES)
@@ -211,7 +211,7 @@ internal class VurderingStegServiceTest {
     }
 
     @Test
-    internal fun `nullstille skal fjerne gjenbrukt fra vilkårsvurdering`() {
+    internal fun `nullstille skal fjerne opphavsvilkår fra vilkårsvurdering`() {
         every { barnService.finnBarnPåBehandling(behandlingId) } returns barn
         val oppdatertVurdering = slot<Vilkårsvurdering>()
         val vilkårsvurdering = initiererVurderinger(oppdatertVurdering)
@@ -220,7 +220,7 @@ internal class VurderingStegServiceTest {
 
         assertThat(oppdatertVurdering.captured.resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
         assertThat(oppdatertVurdering.captured.type).isEqualTo(vilkårsvurdering.type)
-        assertThat(oppdatertVurdering.captured.gjenbrukt).isNull()
+        assertThat(oppdatertVurdering.captured.opphavsvilkår).isNull()
     }
 
     @Test
@@ -344,7 +344,7 @@ internal class VurderingStegServiceTest {
                         listOf(Vurdering(RegelId.SØKER_MEDLEM_I_FOLKETRYGDEN))
                     )
                 ),
-                gjenbrukt = Gjenbrukt(UUID.randomUUID(), LocalDateTime.now())
+                opphavsvilkår = Opphavsvilkår(UUID.randomUUID(), LocalDateTime.now())
             )
         val vilkårsvurderinger =
             opprettNyeVilkårsvurderinger(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 import java.util.UUID
 
 internal class VurderingStegServiceTest {
@@ -176,6 +177,7 @@ internal class VurderingStegServiceTest {
 
         assertThat(lagretVilkårsvurdering.captured.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
         assertThat(lagretVilkårsvurdering.captured.type).isEqualTo(vilkårsvurdering.type)
+        assertThat(lagretVilkårsvurdering.captured.gjenbrukt).isNull()
 
         val delvilkårsvurdering = lagretVilkårsvurdering.captured.delvilkårsvurdering.delvilkårsvurderinger.first()
         assertThat(delvilkårsvurdering.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
@@ -199,12 +201,26 @@ internal class VurderingStegServiceTest {
 
         assertThat(oppdatertVurdering.captured.resultat).isEqualTo(Vilkårsresultat.SKAL_IKKE_VURDERES)
         assertThat(oppdatertVurdering.captured.type).isEqualTo(vilkårsvurdering.type)
+        assertThat(oppdatertVurdering.captured.gjenbrukt).isNull()
 
         val delvilkårsvurdering = oppdatertVurdering.captured.delvilkårsvurdering.delvilkårsvurderinger.first()
         assertThat(delvilkårsvurdering.resultat).isEqualTo(Vilkårsresultat.SKAL_IKKE_VURDERES)
         assertThat(delvilkårsvurdering.vurderinger).hasSize(1)
         assertThat(delvilkårsvurdering.vurderinger.first().svar).isNull()
         assertThat(delvilkårsvurdering.vurderinger.first().begrunnelse).isNull()
+    }
+
+    @Test
+    internal fun `nullstille skal fjerne gjenbrukt fra vilkårsvurdering`() {
+        every { barnService.finnBarnPåBehandling(behandlingId) } returns barn
+        val oppdatertVurdering = slot<Vilkårsvurdering>()
+        val vilkårsvurdering = initiererVurderinger(oppdatertVurdering)
+
+        vurderingStegService.nullstillVilkår(OppdaterVilkårsvurderingDto(vilkårsvurdering.id, behandlingId))
+
+        assertThat(oppdatertVurdering.captured.resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+        assertThat(oppdatertVurdering.captured.type).isEqualTo(vilkårsvurdering.type)
+        assertThat(oppdatertVurdering.captured.gjenbrukt).isNull()
     }
 
     @Test
@@ -320,14 +336,15 @@ internal class VurderingStegServiceTest {
         val vilkårsvurdering =
             vilkårsvurdering(
                 behandlingId,
-                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                Vilkårsresultat.OPPFYLT,
                 VilkårType.FORUTGÅENDE_MEDLEMSKAP,
                 listOf(
                     Delvilkårsvurdering(
                         Vilkårsresultat.OPPFYLT,
                         listOf(Vurdering(RegelId.SØKER_MEDLEM_I_FOLKETRYGDEN))
                     )
-                )
+                ),
+                gjenbrukt = Gjenbrukt(UUID.randomUUID(), LocalDateTime.now())
             )
         val vilkårsvurderinger =
             opprettNyeVilkårsvurderinger(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.felles.util.mockFeatureToggleService
 import no.nav.familie.ef.sak.felles.util.opprettGrunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
@@ -52,7 +53,8 @@ internal class GjenbrukVilkårServiceTest {
         fagsakService = fagsakService,
         vilkårsvurderingRepository = vilkårsvurderingRepository,
         grunnlagsdataService = grunnlagsdataService,
-        barnService = barnService
+        barnService = barnService,
+        mockFeatureToggleService()
     )
 
     private val barn1 = FnrGenerator.generer(LocalDate.now())

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
+import no.nav.familie.ef.sak.vilkår.Gjenbrukt
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
@@ -32,6 +33,7 @@ import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 internal class OppdaterVilkårTest {
@@ -266,6 +268,21 @@ internal class OppdaterVilkårTest {
     }
 
     @Test
+    internal fun `skal fjerne gjenbrukt når man oppdaterer et vilkår`() {
+        val regel = VilkårsregelEnHovedregel()
+        val vilkårsvurdering = opprettVurdering(regel)
+            .copy(gjenbrukt = Gjenbrukt(UUID.randomUUID(), LocalDateTime.now()))
+        val resultat = validerOgOppdater(
+            vilkårsvurdering,
+            regel,
+            VurderingDto(RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE, SvarId.NEI, "a"),
+            VurderingDto(RegelId.KRAV_SIVILSTAND_PÅKREVD_BEGRUNNELSE, SvarId.NEI)
+        )
+
+        assertThat(resultat.gjenbrukt).isNull()
+    }
+
+    @Test
     fun `två rotRegler - en IKKE_OPPFYLT og en OPPFYLT`() {
         val regel = VilkårsregelToHovedregler()
         val vilkårsvurdering = opprettVurdering(regel)
@@ -339,7 +356,8 @@ internal class OppdaterVilkårTest {
             behandlingId = UUID.randomUUID(),
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.SIVILSTAND,
-            delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår)
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår),
+            gjenbrukt = null
         )
 
         val oppdatering = listOf(
@@ -372,7 +390,8 @@ internal class OppdaterVilkårTest {
             behandlingId = UUID.randomUUID(),
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.SIVILSTAND,
-            delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår)
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår),
+            gjenbrukt = null
         )
 
         val oppdatering = listOf(
@@ -593,7 +612,8 @@ internal class OppdaterVilkårTest {
             behandlingId = UUID.randomUUID(),
             resultat = vilkårsresultat,
             type = VilkårType.ALENEOMSORG,
-            delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList())
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
+            gjenbrukt = null
         )
 
     private fun Vilkårsvurdering.delvilkår(regelId: RegelId) =
@@ -633,7 +653,8 @@ internal class OppdaterVilkårTest {
             behandlingId = UUID.randomUUID(),
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.ALENEOMSORG,
-            delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurderinger)
+            delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurderinger),
+            gjenbrukt = null
         )
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -10,7 +10,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.DelvilkårsvurderingWrapper
-import no.nav.familie.ef.sak.vilkår.Gjenbrukt
+import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
@@ -268,10 +268,10 @@ internal class OppdaterVilkårTest {
     }
 
     @Test
-    internal fun `skal fjerne gjenbrukt når man oppdaterer et vilkår`() {
+    internal fun `skal fjerne opphavsvilkår når man oppdaterer et vilkår`() {
         val regel = VilkårsregelEnHovedregel()
         val vilkårsvurdering = opprettVurdering(regel)
-            .copy(gjenbrukt = Gjenbrukt(UUID.randomUUID(), LocalDateTime.now()))
+            .copy(opphavsvilkår = Opphavsvilkår(UUID.randomUUID(), LocalDateTime.now()))
         val resultat = validerOgOppdater(
             vilkårsvurdering,
             regel,
@@ -279,7 +279,7 @@ internal class OppdaterVilkårTest {
             VurderingDto(RegelId.KRAV_SIVILSTAND_PÅKREVD_BEGRUNNELSE, SvarId.NEI)
         )
 
-        assertThat(resultat.gjenbrukt).isNull()
+        assertThat(resultat.opphavsvilkår).isNull()
     }
 
     @Test
@@ -357,7 +357,7 @@ internal class OppdaterVilkårTest {
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.SIVILSTAND,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår),
-            gjenbrukt = null
+            opphavsvilkår = null
         )
 
         val oppdatering = listOf(
@@ -391,7 +391,7 @@ internal class OppdaterVilkårTest {
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.SIVILSTAND,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(initDelvilkår),
-            gjenbrukt = null
+            opphavsvilkår = null
         )
 
         val oppdatering = listOf(
@@ -613,7 +613,7 @@ internal class OppdaterVilkårTest {
             resultat = vilkårsresultat,
             type = VilkårType.ALENEOMSORG,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(emptyList()),
-            gjenbrukt = null
+            opphavsvilkår = null
         )
 
     private fun Vilkårsvurdering.delvilkår(regelId: RegelId) =
@@ -654,7 +654,7 @@ internal class OppdaterVilkårTest {
             resultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
             type = VilkårType.ALENEOMSORG,
             delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurderinger),
-            gjenbrukt = null
+            opphavsvilkår = null
         )
     }
 }


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9688

Når vi gjenbruker et vilkår, både vid manuell revurdering og ved gjenbruk inngangsvilkår så skal vi ha en peker til den opprinnelige behandlinger som vilkåret ble kopiert fra.

Når man nullstiller eller endrer vilkåret så skal gjenbrukt nullstilles.

https://github.com/navikt/familie-ef-sak-frontend/pull/2159

