### PR TITLE
For å se personopplysninger for relasjoner kan det søkes etter person…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
@@ -3,12 +3,19 @@ package no.nav.familie.ef.sak.fagsak
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.dto.FagsakPersonDto
 import no.nav.familie.ef.sak.fagsak.dto.FagsakPersonUtvidetDto
+import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
+import no.nav.familie.ef.sak.felles.util.FnrUtil
+import no.nav.familie.ef.sak.felles.util.FnrUtil.validerIdent
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -20,7 +27,8 @@ import java.util.UUID
 class FagsakPersonController(
     private val tilgangService: TilgangService,
     private val fagsakPersonService: FagsakPersonService,
-    private val fagsakService: FagsakService
+    private val fagsakService: FagsakService,
+    private val personService: PersonService,
 ) {
 
     @GetMapping("{fagsakPersonId}")
@@ -33,8 +41,8 @@ class FagsakPersonController(
                 person.id,
                 overgangsstønad = fagsaker.overgangsstønad?.id,
                 barnetilsyn = fagsaker.barnetilsyn?.id,
-                skolepenger = fagsaker.skolepenger?.id
-            )
+                skolepenger = fagsaker.skolepenger?.id,
+            ),
         )
     }
 
@@ -48,8 +56,22 @@ class FagsakPersonController(
                 person.id,
                 overgangsstønad = fagsaker.overgangsstønad?.let { fagsakService.fagsakTilDto(it) },
                 barnetilsyn = fagsaker.barnetilsyn?.let { fagsakService.fagsakTilDto(it) },
-                skolepenger = fagsaker.skolepenger?.let { fagsakService.fagsakTilDto(it) }
-            )
+                skolepenger = fagsaker.skolepenger?.let { fagsakService.fagsakTilDto(it) },
+            ),
+        )
+    }
+
+    @PostMapping("", "/person")
+    fun hentFagsakPersonIdForPerson(@RequestBody personIdentRequest: PersonIdentDto): Ressurs<UUID> {
+        validerIdent(personIdentRequest.personIdent)
+        val personIdenter = personService.hentPersonIdenter(personIdentRequest.personIdent)
+        tilgangService.validerTilgangTilPersonMedBarn(personIdentRequest.personIdent, AuditLoggerEvent.ACCESS)
+        val fagsakPersonId = fagsakPersonService.hentEllerOpprettPerson(
+            personIdenter.identer(),
+            personIdenter.gjeldende().ident,
+        ).id
+        return Ressurs.success(
+            fagsakPersonId,
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
@@ -61,7 +61,7 @@ class FagsakPersonController(
         )
     }
 
-    @PostMapping("", "/person")
+    @PostMapping
     fun hentFagsakPersonIdForPerson(@RequestBody personIdentRequest: PersonIdentDto): Ressurs<UUID> {
         validerIdent(personIdentRequest.personIdent)
         val personIdenter = personService.hentPersonIdenter(personIdentRequest.personIdent)

--- a/src/test/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonControllerTest.kt
@@ -1,12 +1,15 @@
 package no.nav.familie.ef.sak.fagsak
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
+import no.nav.familie.ef.sak.infrastruktur.exception.PdlNotFoundException
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.getDataOrThrow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 
 internal class FagsakPersonControllerTest : OppslagSpringRunnerTest() {
@@ -37,5 +40,23 @@ internal class FagsakPersonControllerTest : OppslagSpringRunnerTest() {
         assertThat(fagsakPersonDto.overgangsstønad).isNull()
         assertThat(fagsakPersonDto.barnetilsyn).isNull()
         assertThat(fagsakPersonDto.skolepenger).isNull()
+    }
+
+    @Test
+    internal fun `skal opprette fagsakperson når man søker etter gyldig personident fagsaker til person`() {
+        val fagsakPersonId =
+            testWithBrukerContext { fagsakPersonController.hentFagsakPersonIdForPerson(PersonIdentDto("01010172272")).getDataOrThrow() }
+
+        assertThat(fagsakPersonId).isNotNull
+    }
+
+    @Test
+    internal fun `skal ikke opprette fagsakperson når man søker etter personident som ikke finnes i pdl`() {
+        assertThrows<PdlNotFoundException> {
+            testWithBrukerContext {
+                fagsakPersonController.hentFagsakPersonIdForPerson(PersonIdentDto("19117313797"))
+                    .getDataOrThrow()
+            }
+        }
     }
 }


### PR DESCRIPTION
…er og deretter opprette fagsakperson for disse. Da vil personopplysningssiden være tilgjengelig med fagsakpersonId

**Hvorfor**
Når saksbehandler skal slå opp personopplysninger for relasjoner på søker så trigger vi dette endepunktet for å opprette en fagsakperson på relasjonen. 
Den fagsakpersonen som blir opprettet kan da brukes til å vise frem personopplysningssiden. 


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-10025)