### PR TITLE
Vil formatere melding om endring for "ny vs tidligere" på lister. Øns…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
@@ -53,8 +53,8 @@ object UtledEndringerUtil {
         formatterEndring(BarnDto::dødsdato, "Dødsdato"),
         formatterEndring(BarnDto::fødselsdato, "Fødselsdato"),
         formatterEndring({ it.annenForelder?.personIdent }, "Annen forelder"),
-        formatterEndring(BarnDto::harDeltBostedNå, "Har delt bosted"),
-        formatterEndring(BarnDto::deltBosted, "Delt bosted")
+        formatterEndring(BarnDto::harDeltBostedNå, "Delt bosted"),
+        formatterEndring(BarnDto::deltBosted, "Delt bosted perioder")
         // TODO adresse ?? Er den interessant å vise som endret hvis man ikke har endring i borHosSøker ? si eks at barnet på > 18 flytter
     )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtil.kt
@@ -128,6 +128,7 @@ object UtledEndringerUtil {
         is Boolean -> if (verdi) "Ja" else "Nei"
         is LocalDate -> verdi.norskFormat()
         is Folkeregisterpersonstatus -> verdi.visningsnavn
+        is List<*> -> ""
         else -> "$verdi"
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -466,6 +466,8 @@ internal class UtledEndringerUtilTest {
             assertThat(endringsdetaljer).hasSize(1)
             assertThat(endringsdetaljer[0].felt).isEqualTo("Delt bosted")
             assertIngenAndreEndringer(endringer, "barn")
+            assertThat(endringsdetaljer[0].ny).isEqualTo("")
+            assertThat(endringsdetaljer[0].tidligere).isEqualTo("")
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -432,7 +432,7 @@ internal class UtledEndringerUtilTest {
             assertBarnHarEndringerMedDetaljer(endringer)
             val endringsdetaljer = detaljer[0].endringer
             assertThat(endringsdetaljer).hasSize(1)
-            assertThat(endringsdetaljer[0].felt).isEqualTo("Har delt bosted")
+            assertThat(endringsdetaljer[0].felt).isEqualTo("Delt bosted")
             assertThat(endringsdetaljer[0].tidligere).isEqualTo("Nei")
             assertThat(endringsdetaljer[0].ny).isEqualTo("Ja")
             assertIngenAndreEndringer(endringer, "barn")
@@ -464,7 +464,7 @@ internal class UtledEndringerUtilTest {
             assertBarnHarEndringerMedDetaljer(endringer)
             val endringsdetaljer = detaljer[0].endringer
             assertThat(endringsdetaljer).hasSize(1)
-            assertThat(endringsdetaljer[0].felt).isEqualTo("Delt bosted")
+            assertThat(endringsdetaljer[0].felt).isEqualTo("Delt bosted perioder")
             assertIngenAndreEndringer(endringer, "barn")
             assertThat(endringsdetaljer[0].ny).isEqualTo("")
             assertThat(endringsdetaljer[0].tidligere).isEqualTo("")


### PR DESCRIPTION
…ker at endring kun inneholde informasjon om felt, ikke tidligere/ny. Hele listen blir for mye.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11946

Vil med denne se slik ut i UI: 
![image](https://user-images.githubusercontent.com/53942238/223649848-d678bd35-a3db-4880-aaa4-9efeb700b517.png)

Nye endringer etter prat med Lars - "Har delt bosted" endres til "Delt bosted". "Delt bosted" til "Delt bosted perioder" 



Kan vurdere å oppdatere UI til ikke skrive ut "tidligere/ny"?
