### PR TITLE
Patch for å sende alle aktive vedtak til arbeidsoppfølging.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -163,6 +163,15 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
     )
     fun finnPersonerMedAktivStonad(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
 
+    @Query(
+        """
+        SELECT DISTINCT gib.id
+        FROM gjeldende_iverksatte_behandlinger gib
+        WHERE gib.stonadstype=:stønadstype
+        """
+    )
+    fun finnBehandlingerForPersonerMedAktivStønad(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<UUID>
+
     // language=PostgreSQL
     @Query(
         """

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettClient.kt
@@ -88,6 +88,10 @@ class IverksettClient(
     fun sendKonsistensavstemming(request: KonsistensavstemmingDto, transaksjonId: UUID) =
         konsistensavstemming(request, sendStartmelding = false, sendAvsluttmelding = false, transaksjonId)
 
+    fun sendTilArbeidsoppfølging(behandlingId: String) {
+        postForEntity<Any>(URI.create("$familieEfIverksettUri/api/arbeidsoppfolging/patch/$behandlingId"), "")
+    }
+
     private fun konsistensavstemming(
         request: KonsistensavstemmingDto,
         sendStartmelding: Boolean = true,

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -30,9 +30,9 @@ class PatchArbeidsoppfølgingController(
 
     @GetMapping
     fun patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(@PathVariable liveRun: Boolean = false) {
-        logger.info("Starter patch for sending av aktive iverksatte behandlinger til arbeidsoppfølging (liverun=$liveRun")
+        logger.info("Starter patch for sending av aktive iverksatte behandlinger til arbeidsoppfølging (liverun=$liveRun)")
         val behandlingIds = behandlingRepository.finnBehandlingerForPersonerMedAktivStønad(StønadType.OVERGANGSSTØNAD)
-        logger.info("Antall aktive behandlinger for overgangsstønad funnet: $behandlingIds")
+        logger.info("Antall aktive behandlinger for overgangsstønad funnet: ${behandlingIds.size}")
 
         val tasks = behandlingIds.map { PatchSendTilArbeidsoppfølgingTask.opprettTask(it) }
         if (liveRun) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -12,8 +12,8 @@ import no.nav.security.token.support.core.api.Unprotected
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.Properties
 import java.util.UUID
@@ -29,7 +29,7 @@ class PatchArbeidsoppfølgingController(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     @GetMapping
-    fun patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(@PathVariable liveRun: Boolean = false) {
+    fun patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(@RequestParam liveRun: Boolean = false) {
         logger.info("Starter patch for sending av aktive iverksatte behandlinger til arbeidsoppfølging (liverun=$liveRun)")
         val behandlingIds = behandlingRepository.finnBehandlingerForPersonerMedAktivStønad(StønadType.OVERGANGSSTØNAD)
         logger.info("Antall aktive behandlinger for overgangsstønad funnet: ${behandlingIds.size}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -37,6 +37,7 @@ class PatchArbeidsoppfølgingController(
         val tasks = behandlingIds.map { PatchSendTilArbeidsoppfølgingTask.opprettTask(it) }
         if (liveRun) {
             taskService.saveAll(tasks)
+            logger.info("Lagret ${tasks.size} patchSendTilArbeidsoppfølging-tasks")
         }
     }
 }
@@ -61,7 +62,7 @@ class PatchSendTilArbeidsoppfølgingTask(val iverksettClient: IverksettClient) :
 
         fun opprettTask(behandlingId: UUID): Task {
             return Task(
-                type = OpprettOppgaveForOpprettetBehandlingTask.TYPE,
+                type = PatchSendTilArbeidsoppfølgingTask.TYPE,
                 payload = behandlingId.toString(),
                 properties = Properties().apply {
                     this["behandlingId"] = behandlingId.toString()

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.sak.iverksett.arbeidsoppfolging
 
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.AsyncTaskStep
@@ -62,7 +61,7 @@ class PatchSendTilArbeidsoppfølgingTask(val iverksettClient: IverksettClient) :
 
         fun opprettTask(behandlingId: UUID): Task {
             return Task(
-                type = PatchSendTilArbeidsoppfølgingTask.TYPE,
+                type = TYPE,
                 payload = behandlingId.toString(),
                 properties = Properties().apply {
                     this["behandlingId"] = behandlingId.toString()

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchArbeidsoppfølgingController.kt
@@ -1,0 +1,72 @@
+package no.nav.familie.ef.sak.iverksett.arbeidsoppfolging
+
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
+import no.nav.familie.ef.sak.iverksett.IverksettClient
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.security.token.support.core.api.Unprotected
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.Properties
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/arbeidsoppfolging-patch"])
+@Unprotected
+class PatchArbeidsoppfølgingController(
+    val behandlingRepository: BehandlingRepository,
+    val taskService: TaskService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @GetMapping
+    fun patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(@PathVariable liveRun: Boolean = false) {
+        logger.info("Starter patch for sending av aktive iverksatte behandlinger til arbeidsoppfølging (liverun=$liveRun")
+        val behandlingIds = behandlingRepository.finnBehandlingerForPersonerMedAktivStønad(StønadType.OVERGANGSSTØNAD)
+        logger.info("Antall aktive behandlinger for overgangsstønad funnet: $behandlingIds")
+
+        val tasks = behandlingIds.map { PatchSendTilArbeidsoppfølgingTask.opprettTask(it) }
+        if (liveRun) {
+            taskService.saveAll(tasks)
+        }
+    }
+}
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = PatchSendTilArbeidsoppfølgingTask.TYPE,
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 15 * 60L,
+    beskrivelse = "Patch for å sende alle med aktiv overgangsstønad til arbeidsoppfølging"
+)
+class PatchSendTilArbeidsoppfølgingTask(val iverksettClient: IverksettClient) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        iverksettClient.sendTilArbeidsoppfølging(task.payload)
+    }
+
+    companion object {
+
+        const val TYPE = "patchSendTilArbeidsoppfølging"
+
+        fun opprettTask(behandlingId: UUID): Task {
+            return Task(
+                type = OpprettOppgaveForOpprettetBehandlingTask.TYPE,
+                payload = behandlingId.toString(),
+                properties = Properties().apply {
+                    this["behandlingId"] = behandlingId.toString()
+                }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonRequestVariables.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonRequestVariables.kt
@@ -29,6 +29,6 @@ data class Paging(val pageNumber: Int, val resultsPerPage: Int)
 
 sealed interface SearchRule
 
-data class SearchRuleEquals(val equals: String): SearchRule
+data class SearchRuleEquals(val equals: String) : SearchRule
 
-data class SearchRuleExists(val exists: Boolean): SearchRule
+data class SearchRuleExists(val exists: Boolean) : SearchRule

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchSendTilArbeidsoppfølgingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchSendTilArbeidsoppfølgingTaskTest.kt
@@ -1,0 +1,45 @@
+package no.nav.familie.ef.sak.iverksett.arbeidsoppfolging
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
+
+class PatchSendTilArbeidsoppfølgingTaskTest : OppslagSpringRunnerTest() {
+
+    val behandlingRepository: BehandlingRepository = mockk()
+
+    val taskService: TaskService = mockk()
+
+    val patchArbeidsoppfølgingController: PatchArbeidsoppfølgingController =
+        PatchArbeidsoppfølgingController(behandlingRepository, taskService)
+
+    val taskSlot = slot<List<Task>>()
+
+    @Test
+    fun testTriggertidFremITid() {
+        val behandlingIds = mutableListOf<UUID>()
+
+        for (i in 0..16000) {
+            behandlingIds.add(UUID.randomUUID())
+        }
+
+        every { behandlingRepository.finnBehandlingerForPersonerMedAktivStønad(StønadType.OVERGANGSSTØNAD) } returns behandlingIds
+        every { taskService.saveAll(capture(taskSlot)) } answers { listOf() }
+
+        patchArbeidsoppfølgingController.patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(true)
+
+        Assertions.assertThat(taskSlot.captured.size).isEqualTo(behandlingIds.size)
+        Assertions.assertThat(taskSlot.captured[600].triggerTid).isAfter(LocalDateTime.now().plusMinutes(19))
+        Assertions.assertThat(taskSlot.captured[1200].triggerTid).isAfter(LocalDateTime.now().plusMinutes(39))
+        // Assertions.assertThat(taskSlot.captured.last().triggerTid).isAfter(LocalDateTime.now().plusMinutes(639))
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchSendTilArbeidsoppfølgingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/arbeidsoppfolging/PatchSendTilArbeidsoppfølgingTaskTest.kt
@@ -38,8 +38,8 @@ class PatchSendTilArbeidsoppfølgingTaskTest : OppslagSpringRunnerTest() {
         patchArbeidsoppfølgingController.patchSendArbeidsoppfølgingInfoForPersonerMedAktivOvergangsstønad(true)
 
         Assertions.assertThat(taskSlot.captured.size).isEqualTo(behandlingIds.size)
-        Assertions.assertThat(taskSlot.captured[600].triggerTid).isAfter(LocalDateTime.now().plusMinutes(19))
-        Assertions.assertThat(taskSlot.captured[1200].triggerTid).isAfter(LocalDateTime.now().plusMinutes(39))
-        // Assertions.assertThat(taskSlot.captured.last().triggerTid).isAfter(LocalDateTime.now().plusMinutes(639))
+        Assertions.assertThat(taskSlot.captured[600].triggerTid).isAfter(LocalDateTime.now().plusMinutes(9))
+        Assertions.assertThat(taskSlot.captured[1200].triggerTid).isAfter(LocalDateTime.now().plusMinutes(19))
+        Assertions.assertThat(taskSlot.captured.last().triggerTid).isAfter(LocalDateTime.now().plusMinutes(319))
     }
 }


### PR DESCRIPTION
Opprettet patch-endepunkt som oppretter en task pr behandling med aktivt vedtak for overgangsstønad. Sender dette til iverksett som henter ut iverksettdata i sin database basert på behandlingId, og mapper og sender dette på topic til arbeidsoppfølging. Det trengs ingen filtrering på meldinger på personer med aktiv stønad som allerede er sendt, fordi de håndterer duplikate meldinger.

PR for endepunktet som blir kalt: https://github.com/navikt/familie-ef-iverksett/pull/696

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12219