### PR TITLE
Skal ikke returnere personer som har blitt manuelt revurdert siste to…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -158,10 +158,10 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype
-    """
+        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '2 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        """
     )
-    fun finnPersonerMedAktivStonad(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
+    fun finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
 
     @Query(
         """

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettSteg.kt
@@ -55,13 +55,12 @@ class SaksbehandlingsblankettSteg(
         val journalpostId = try {
             journalpostClient.arkiverDokument(arkiverDokumentRequest, beslutter).journalpostId
         } catch (e: RessursException) {
-             if (e.cause is HttpClientErrorException.Conflict) {
-                 finnJournalpostIdForBlankett(saksbehandling)
-             } else {
+            if (e.cause is HttpClientErrorException.Conflict) {
+                finnJournalpostIdForBlankett(saksbehandling)
+            } else {
                 throw e
-             }
+            }
         }
-
 
         behandlingService.leggTilBehandlingsjournalpost(
             journalpostId,
@@ -79,7 +78,7 @@ class SaksbehandlingsblankettSteg(
                 ),
                 antall = 100,
                 tema = listOf(Tema.ENF),
-                journalposttype = listOf(Journalposttype.N),
+                journalposttype = listOf(Journalposttype.N)
             )
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -156,10 +156,10 @@ class VedtakController(
         return Ressurs.success(forventetInntekt)
     }
 
-    @GetMapping("/personerMedAktivStonad")
+    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteToMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonad(): Ressurs<List<String>> {
-        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonad())
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(): Ressurs<List<String>> {
+        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder())
     }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettStegTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.behandlingsflyt.steg
 
-import com.github.dockerjava.api.exception.BadRequestException
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -34,7 +33,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
-import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest
 
 internal class SaksbehandlingsblankettStegTest {
 
@@ -176,7 +174,7 @@ internal class SaksbehandlingsblankettStegTest {
 
         val behandling = saksbehandling(type = BehandlingType.REVURDERING).copy(stønadstype = StønadType.BARNETILSYN)
 
-        val feil = assertThrows<RessursException> {  saksbehandlingsblankettSteg.utførSteg(behandling, null)}
+        val feil = assertThrows<RessursException> { saksbehandlingsblankettSteg.utførSteg(behandling, null) }
         assertThat(feil.httpStatus).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.SATT_PÅ_VENT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.UTREDES
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.fagsak.FagsakPersonRepository
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.felles.domain.Endret
@@ -49,14 +48,10 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var fagsakPersonRepository: FagsakPersonRepository
 
-    @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
-
     private val ident = "123"
 
     @Test
     fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste to måneder`() {
-
         val person1 = fagsakPerson(identer = setOf(PersonIdent("1")))
         fagsakPersonRepository.insert(person1)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.G_OMREGNING, status = FERDIGSTILT))
@@ -75,6 +70,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder()
         assertThat(resultat.size).isEqualTo(3)
+        assertThat(resultat).containsAll(listOf("1", "2", "3"))
     }
 
     @Test


### PR DESCRIPTION
… måneder for 10% endringsjekk. 

### Hvorfor er dette nødvendig? ✨
For å minimere antall treff på inntektsjekken, fjernes personer som har blitt manuelt revurdert siste to måneder

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12220