### PR TITLE
Skal sende med fødselsnummer i sivilstandsregistergrunnlag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/SivilstandMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/SivilstandMapper.kt
@@ -23,7 +23,7 @@ object SivilstandMapper {
         val sivilstand = søker.sivilstand.gjeldende()
         return SivilstandRegistergrunnlagDto(
             type = Sivilstandstype.valueOf(sivilstand.type.name),
-            fødselsnummer = sivilstand.relatertVedSivilstand,
+            personIdent = sivilstand.relatertVedSivilstand,
             navn = sivilstand.navn,
             gyldigFraOgMed = sivilstand.gyldigFraOgMed,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/SivilstandMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/SivilstandMapper.kt
@@ -23,6 +23,7 @@ object SivilstandMapper {
         val sivilstand = søker.sivilstand.gjeldende()
         return SivilstandRegistergrunnlagDto(
             type = Sivilstandstype.valueOf(sivilstand.type.name),
+            fødselsnummer = sivilstand.relatertVedSivilstand,
             navn = sivilstand.navn,
             gyldigFraOgMed = sivilstand.gyldigFraOgMed,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/SivilstandInngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/SivilstandInngangsvilkårDto.kt
@@ -23,6 +23,7 @@ data class SivilstandSøknadsgrunnlagDto(
 
 data class SivilstandRegistergrunnlagDto(
     val type: Sivilstandstype,
+    val fødselsnummer: String?,
     val navn: String?,
     val gyldigFraOgMed: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/SivilstandInngangsvilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/SivilstandInngangsvilkårDto.kt
@@ -23,7 +23,7 @@ data class SivilstandSøknadsgrunnlagDto(
 
 data class SivilstandRegistergrunnlagDto(
     val type: Sivilstandstype,
-    val fødselsnummer: String?,
+    val personIdent: String?,
     val navn: String?,
     val gyldigFraOgMed: LocalDate?,
 )

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -103,7 +103,7 @@ internal class VurderingServiceTest {
         every { fagsakService.hentFagsakForBehandling(behandlingId) } returns fagsak(stønadstype = OVERGANGSSTØNAD)
         val sivilstand = SivilstandInngangsvilkårDto(
             mockk(relaxed = true),
-            SivilstandRegistergrunnlagDto(Sivilstandstype.GIFT, "Navn", null),
+            SivilstandRegistergrunnlagDto(Sivilstandstype.GIFT,"1", "Navn", null),
         )
 
         val barnMedSamvær = barn.map { lagBarnetilsynBarn(it.id) }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -120,7 +120,7 @@ internal class VurderingStegServiceTest {
         every { vilkårsvurderingRepository.insertAll(any()) } answers { firstArg() }
         val sivilstand = SivilstandInngangsvilkårDto(
             mockk(relaxed = true),
-            SivilstandRegistergrunnlagDto(Sivilstandstype.GIFT, "Navn", null),
+            SivilstandRegistergrunnlagDto(Sivilstandstype.GIFT, "1", "Navn", null),
         )
         every { vilkårGrunnlagService.hentGrunnlag(any(), any(), any(), any()) } returns
             mockVilkårGrunnlagDto(sivilstand = sivilstand)


### PR DESCRIPTION
Hvorfor er dette nødvendig? ✨ 
Trenger fødselsnummer for å kunne lenke brukers relasjon sin personoversikt, som er ønskelig i [favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12152).

Henger sammen med [PR i ef-sak-frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2215)
