### PR TITLE
Legger inn vedtaksgrunnlag i andelshistorikk for å kunne bruke hentVe…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/util/DatoUtil.kt
@@ -13,6 +13,8 @@ object DatoFormat {
     val DATE_FORMAT_NORSK = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 }
 
+val YEAR_MONTH_MAX = YearMonth.from(LocalDate.MAX)
+
 fun LocalDate.norskFormat() = this.format(DATE_FORMAT_NORSK)
 
 fun datoEllerIdag(localDate: LocalDate?): LocalDate = localDate ?: LocalDate.now()

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregner.kt
@@ -125,6 +125,7 @@ object AndelHistorikkBeregner {
                 behandlingÅrsak = behandling.årsak,
                 vedtakstidspunkt = it.vedtakstidspunkt,
                 saksbehandler = it.saksbehandler,
+                vedtaksperiode = vedtaksperiode,
                 andel = AndelMedGrunnlagDto(andel = it.andel, barnetilsyn),
                 aktivitet = aktivitetOvergangsstønad(stønadstype, vedtaksperiode),
                 aktivitetBarnetilsyn = barnetilsyn?.aktivitetstype,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkDto.kt
@@ -28,14 +28,15 @@ data class AndelHistorikkDto(
     val behandlingÅrsak: BehandlingÅrsak,
     val vedtakstidspunkt: LocalDateTime,
     val saksbehandler: String,
+    val vedtaksperiode: Vedtakshistorikkperiode,
     val andel: AndelMedGrunnlagDto,
-    val aktivitet: AktivitetType?,
-    val aktivitetBarnetilsyn: AktivitetstypeBarnetilsyn?, // TODO: Skal bli non-nullable
+    val aktivitet: AktivitetType?,  // finnes i vedtaksperiode
+    val aktivitetBarnetilsyn: AktivitetstypeBarnetilsyn?, // finnes i vedtaksperiode
     val aktivitetArbeid: SvarId?,
-    val periodeType: VedtaksperiodeType?,
-    val periodetypeBarnetilsyn: PeriodetypeBarnetilsyn?,
+    val periodeType: VedtaksperiodeType?, // finnes i vedtaksperiode
+    val periodetypeBarnetilsyn: PeriodetypeBarnetilsyn?, // finnes i vedtaksperiode
     val erSanksjon: Boolean, // TODO denne kan fjernes / flyttes som en get og være beroende av periodetype / periodetypeBarnetilsyn
-    val sanksjonsårsak: Sanksjonsårsak?,
+    val sanksjonsårsak: Sanksjonsårsak?, // finnes i vedtaksperiode
     val erOpphør: Boolean,
     val endring: HistorikkEndring?,
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkUtil.kt
@@ -24,7 +24,7 @@ object AndelHistorikkUtil {
         first: AndelHistorikkDto,
         second: AndelHistorikkDto,
     ) =
-        first.andel.periode.påfølgesAv(second.andel.periode)
+        first.vedtaksperiode.periode.påfølgesAv(second.vedtaksperiode.periode)
 
     fun periodeTypeOvergangsstønad(
         stønadstype: StønadType,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkService.kt
@@ -89,9 +89,10 @@ class VedtakHistorikkService(
         return historikk
             .slåSammen { a, b ->
                 sammenhengende(a, b) &&
-                    a.aktivitet == b.aktivitet &&
-                    a.periodeType == b.periodeType &&
-                    a.periodeType != VedtaksperiodeType.SANKSJON
+                    (a.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                        b.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                        a.vedtaksperiode.aktivitet == b.vedtaksperiode.aktivitet &&
+                        a.vedtaksperiode.periodeType == b.vedtaksperiode.periodeType)
             }
             .fraDato(fra)
             .map {
@@ -110,8 +111,10 @@ class VedtakHistorikkService(
         return historikk
             .filter { it.periodeType != VedtaksperiodeType.SANKSJON }
             .slåSammen { a, b ->
-                a.andel.inntekt == b.andel.inntekt &&
-                    a.andel.samordningsfradrag == b.andel.samordningsfradrag
+                (a.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                    b.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                    a.vedtaksperiode.inntekt.forventetInntekt == b.vedtaksperiode.inntekt.forventetInntekt &&
+                    a.vedtaksperiode.inntekt.samordningsfradrag == b.vedtaksperiode.inntekt.samordningsfradrag)
             }
             .fraDato(fra)
             .map {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -56,6 +56,8 @@ import no.nav.familie.ef.sak.vedtak.historikk.AndelHistorikkDto
 import no.nav.familie.ef.sak.vedtak.historikk.AndelMedGrunnlagDto
 import no.nav.familie.ef.sak.vedtak.historikk.EndringType
 import no.nav.familie.ef.sak.vedtak.historikk.HistorikkEndring
+import no.nav.familie.ef.sak.vedtak.historikk.Sanksjonsperiode
+import no.nav.familie.ef.sak.vedtak.historikk.VedtakshistorikkperiodeOvergangsstønad
 import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
 import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.ef.felles.AvslagÅrsak
@@ -1945,6 +1947,12 @@ internal class BeregnYtelseStegTest {
             behandlingÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
             vedtakstidspunkt = LocalDateTime.now(),
             saksbehandler = "",
+            vedtaksperiode = VedtakshistorikkperiodeOvergangsstønad(
+                periode = Månedsperiode(fom, tom),
+                aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
+                periodeType = VedtaksperiodeType.HOVEDPERIODE,
+                inntekt = Inntekt(fom, BigDecimal.ZERO, BigDecimal.ZERO)
+            ),
             andel = andelDto(1, fom, tom),
             aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
             periodeType = VedtaksperiodeType.HOVEDPERIODE,
@@ -1966,6 +1974,7 @@ internal class BeregnYtelseStegTest {
             behandlingÅrsak = BehandlingÅrsak.SANKSJON_1_MND,
             vedtakstidspunkt = LocalDateTime.now(),
             saksbehandler = "",
+            vedtaksperiode = Sanksjonsperiode(Månedsperiode(sanksjonMåned), Sanksjonsårsak.SAGT_OPP_STILLING),
             andel = andelDto(0, sanksjonMåned, sanksjonMåned),
             aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
             periodeType = VedtaksperiodeType.SANKSJON,

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.barn.BehandlingBarn
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.beregning.Inntekt
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.felles.util.BehandlingOppsettUtil.lagBehandlingerForSisteIverksatte
@@ -17,20 +18,25 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.tilkjentytelse.AndelsHistorikkService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetstypeBarnetilsyn
 import no.nav.familie.ef.sak.vedtak.domain.PeriodetypeBarnetilsyn
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.historikk.AndelHistorikkDto
 import no.nav.familie.ef.sak.vedtak.historikk.AndelMedGrunnlagDto
 import no.nav.familie.ef.sak.vedtak.historikk.EndringType
 import no.nav.familie.ef.sak.vedtak.historikk.HistorikkEndring
+import no.nav.familie.ef.sak.vedtak.historikk.VedtakshistorikkperiodeOvergangsstønad
 import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
 import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
+import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -437,6 +443,12 @@ fun lagAndelHistorikkDto(
         behandlingType = BehandlingType.FØRSTEGANGSBEHANDLING,
         vedtakstidspunkt = LocalDateTime.now(),
         saksbehandler = "",
+        vedtaksperiode = VedtakshistorikkperiodeOvergangsstønad(
+            periode = Månedsperiode(fraOgMed, tilOgMed),
+            aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
+            periodeType = VedtaksperiodeType.HOVEDPERIODE,
+            inntekt = Inntekt(YearMonth.from(fraOgMed), BigDecimal.ZERO, BigDecimal.ZERO)
+        ),
         andel = AndelMedGrunnlagDto(
             lagAndelTilkjentYtelse(
                 beløp = beløp,
@@ -445,7 +457,6 @@ fun lagAndelHistorikkDto(
             ),
             null,
         ).copy(barn = behandlingBarn.map { it.id }),
-
         aktivitet = null,
         aktivitetArbeid = null,
         periodeType = null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkBeregnerTest.kt
@@ -2,9 +2,11 @@ package no.nav.familie.ef.sak.vedtak.historikk
 
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.beregning.Inntekt
 import no.nav.familie.ef.sak.beregning.Inntektsperiode
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.vedtaksperiode
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
@@ -375,6 +377,12 @@ object AndelHistorikkParser {
             behandlingÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
             vedtakstidspunkt = LocalDateTime.now(), // burde denne testes? EKs att man oppretter vedtaksdato per behandlingId
             saksbehandler = "",
+            vedtaksperiode = VedtakshistorikkperiodeOvergangsstønad(
+                periode = Månedsperiode(it.stønadFom!!, it.stønadFom!!),
+                aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
+                periodeType = VedtaksperiodeType.HOVEDPERIODE,
+                inntekt = Inntekt(YearMonth.from(it.stønadFom), BigDecimal.ZERO, BigDecimal.ZERO)
+            ),
             andel = AndelMedGrunnlagDto(mapAndel(it), null),
             aktivitet = it.aktivitet!!,
             periodeType = it.periodeType!!,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkDtoKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkDtoKtTest.kt
@@ -1,12 +1,16 @@
 package no.nav.familie.ef.sak.vedtak.historikk
 
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.beregning.Inntekt
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetstypeBarnetilsyn
 import no.nav.familie.ef.sak.vedtak.domain.PeriodetypeBarnetilsyn
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.YearMonth
 import java.util.UUID
@@ -43,6 +47,12 @@ internal class AndelHistorikkDtoKtTest {
         behandlingÅrsak = BehandlingÅrsak.NYE_OPPLYSNINGER,
         vedtakstidspunkt = LocalDateTime.now(),
         saksbehandler = "",
+        vedtaksperiode = VedtakshistorikkperiodeOvergangsstønad(
+            periode = Månedsperiode(YearMonth.now()),
+            aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
+            periodeType = VedtaksperiodeType.HOVEDPERIODE,
+            inntekt = Inntekt(YearMonth.now(), BigDecimal.ZERO, BigDecimal.ZERO)
+        ),
         andel = andelMedGrunnlagDto(),
         aktivitet = null,
         aktivitetArbeid = null,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregnerTest.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.vedtak.historikk
 
+import no.nav.familie.ef.sak.beregning.Inntekt
 import no.nav.familie.ef.sak.beregning.Inntektsperiode
 import no.nav.familie.ef.sak.felles.domain.Sporbar
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
@@ -13,6 +14,7 @@ import no.nav.familie.ef.sak.vedtak.dto.tilVedtakDto
 import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -54,7 +56,8 @@ internal class VedtakHistorikkBeregnerTest {
 
     @Test
     internal fun `revurdering frem i tiden skal kun legge på tidligere perioder`() {
-        val andreVedtak = lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2021, 4, 1), LocalDate.of(2021, 4, 30))))
+        val andreVedtak =
+            lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2021, 4, 1), LocalDate.of(2021, 4, 30))))
 
         val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(førsteVedtak, andreVedtak))
 
@@ -64,7 +67,8 @@ internal class VedtakHistorikkBeregnerTest {
 
     @Test
     internal fun `revurdering bak i tiden skal overskreve alle tidligere perioder`() {
-        val andreVedtak = lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 4, 30))))
+        val andreVedtak =
+            lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 4, 30))))
 
         val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(førsteVedtak, andreVedtak))
 
@@ -86,7 +90,8 @@ internal class VedtakHistorikkBeregnerTest {
 
     @Test
     internal fun `revurdering før tidligere perioder skal overskreve alle tidligere perioder`() {
-        val andreVedtak = lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 4, 30))))
+        val andreVedtak =
+            lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 4, 30))))
 
         val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(førsteVedtak, andreVedtak))
 
@@ -96,7 +101,8 @@ internal class VedtakHistorikkBeregnerTest {
 
     @Test
     internal fun `revurdering midt i tidligere periode skal overskreve overlappende perioder`() {
-        val andreVedtak = lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2021, 2, 1), LocalDate.of(2021, 4, 30))))
+        val andreVedtak =
+            lagVedtak(perioder = listOf(lagVedtaksperiode(LocalDate.of(2021, 2, 1), LocalDate.of(2021, 4, 30))))
 
         val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(førsteVedtak, andreVedtak))
 
@@ -111,6 +117,62 @@ internal class VedtakHistorikkBeregnerTest {
         )
     }
 
+    @Nested
+    inner class SplitteVedtaksperiodeBasertPåInntekter {
+
+        val januar = YearMonth.of(2021, 1)
+        val februar = YearMonth.of(2021, 2)
+        val mars = YearMonth.of(2021, 3)
+        val april = YearMonth.of(2021, 4)
+
+        @Test
+        internal fun `en periode med 2 inntektsperioder`() {
+            val vedtak = lagVedtak(
+                perioder = listOf(lagVedtaksperiode(januar.atDay(1), mars.atEndOfMonth())),
+                inntektsperioder = listOf(lagInntekt(januar, februar, 10), lagInntekt(mars, april, 5))
+            )
+
+            val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(vedtak))
+            val vedtaksperioder = vedtaksperioderPerBehandling.values.toList()
+            assertThat(vedtaksperioder).hasSize(1)
+            val vedtaksperioderForBehandling =
+                vedtaksperioder[0].filterIsInstance<VedtakshistorikkperiodeOvergangsstønad>()
+            assertThat(vedtaksperioderForBehandling).hasSize(2)
+
+            assertThat(vedtaksperioderForBehandling[0].periode).isEqualTo(Månedsperiode(januar, februar))
+            assertThat(vedtaksperioderForBehandling[0].inntekt.årMånedFra).isEqualTo(januar)
+            assertThat(vedtaksperioderForBehandling[0].inntekt.forventetInntekt?.toInt()).isEqualTo(10)
+
+            assertThat(vedtaksperioderForBehandling[1].periode).isEqualTo(Månedsperiode(mars, mars))
+            assertThat(vedtaksperioderForBehandling[1].inntekt.årMånedFra).isEqualTo(mars)
+            assertThat(vedtaksperioderForBehandling[1].inntekt.forventetInntekt?.toInt()).isEqualTo(5)
+        }
+
+        @Test
+        internal fun `2 perioder med 1 inntekt`() {
+            val vedtak = lagVedtak(
+                perioder = listOf(
+                    lagVedtaksperiode(januar.atDay(1), mars.atEndOfMonth()),
+                    lagVedtaksperiode(april.atDay(1), april.atEndOfMonth())
+                ),
+                inntektsperioder = listOf(lagInntekt(januar, april, 10))
+            )
+
+            val vedtaksperioderPerBehandling = lagVedtaksperioderPerBehandling(listOf(vedtak))
+            val vedtaksperioder = vedtaksperioderPerBehandling.values.toList()
+            assertThat(vedtaksperioder).hasSize(1)
+            val vedtaksperioderForBehandling =
+                vedtaksperioder[0].filterIsInstance<VedtakshistorikkperiodeOvergangsstønad>()
+            assertThat(vedtaksperioderForBehandling).hasSize(2)
+
+            assertThat(vedtaksperioderForBehandling[0].periode).isEqualTo(Månedsperiode(januar, mars))
+            assertThat(vedtaksperioderForBehandling[0].inntekt.årMånedFra).isEqualTo(januar)
+
+            assertThat(vedtaksperioderForBehandling[1].periode).isEqualTo(Månedsperiode(april, april))
+            assertThat(vedtaksperioderForBehandling[1].inntekt.årMånedFra).isEqualTo(januar)
+        }
+    }
+
     private fun validerFørsteVedtakErUendret(vedtaksperioderPerBehandling: Map<UUID, List<Vedtakshistorikkperiode>>) {
         validerPeriode(vedtaksperioderPerBehandling, førsteVedtak.behandlingId, førsteVedtak.vedtaksperioder())
     }
@@ -123,7 +185,8 @@ internal class VedtakHistorikkBeregnerTest {
         assertThat(vedtaksperioderPerBehandling.getValue(behandlingId)).isEqualTo(vedtaksperioder)
     }
 
-    private fun Vedtak.vedtaksperioder(): List<Vedtakshistorikkperiode> = this.perioder!!.perioder.map { it.tilHistorikk() }
+    private fun Vedtak.vedtaksperioder(): List<Vedtakshistorikkperiode> =
+        this.perioder!!.perioder.map { it.tilHistorikk() }
 
     private fun lagVedtaksperioderPerBehandling(vedtak: List<Vedtak>): Map<UUID, List<Vedtakshistorikkperiode>> {
         var datoCount = 0L
@@ -159,12 +222,14 @@ internal class VedtakHistorikkBeregnerTest {
         Månedsperiode(this.datoFra, this.datoTil),
         this.aktivitet,
         this.periodeType,
+        Inntekt(YearMonth.from(this.datoFra), BigDecimal.ZERO, BigDecimal.ZERO)
     )
 
     private fun lagVedtak(
         behandlingId: UUID = UUID.randomUUID(),
         perioder: List<Vedtaksperiode>?,
         opphørFom: YearMonth? = null,
+        inntektsperioder: List<Inntektsperiode>? = null,
     ): Vedtak {
         require((perioder == null) xor (opphørFom == null)) { "Må definiere perioder eller opphørFom" }
         return Vedtak(
@@ -174,23 +239,23 @@ internal class VedtakHistorikkBeregnerTest {
             inntektBegrunnelse = null,
             avslåBegrunnelse = null,
             perioder = perioder?.let { PeriodeWrapper(it.toList()) },
-            inntekter = perioder?.let {
-                InntektWrapper(
-                    listOfNotNull(
-                        it.firstOrNull()
-                            ?.let {
-                                Inntektsperiode(
-                                    periode = it.periode,
-                                    inntekt = BigDecimal.ZERO,
-                                    samordningsfradrag = BigDecimal.ZERO,
-                                )
-                            },
-                    ),
-                )
-            },
+            inntekter = inntektsperioder?.let { InntektWrapper(it) } ?: defaultInntektsperioder(perioder),
             saksbehandlerIdent = null,
             opphørFom = opphørFom,
             beslutterIdent = null,
         )
+    }
+
+    private fun lagInntekt(
+        fom: YearMonth,
+        tom: YearMonth,
+        inntekt: Int,
+    ) = Inntektsperiode(periode = Månedsperiode(fom, tom),
+        inntekt = inntekt.toBigDecimal(),
+        samordningsfradrag = BigDecimal.ZERO)
+
+    private fun defaultInntektsperioder(perioder: List<Vedtaksperiode>?): InntektWrapper? = perioder?.let {
+        val inntekt = it.firstOrNull()?.let { lagInntekt(it.periode.fom, it.periode.tom, 0) }
+        InntektWrapper(listOfNotNull(inntekt))
     }
 }


### PR DESCRIPTION
…dtakForOvergangsstønadFraDato med inntekt fra vedtaket og ikke andelen.

* Flere ulike inntekter trenger dette, då dagsats og månedsinntekt ikke finnes på andelen som er brukt i VedtakHistorikkService

I inntekter så ble det feil når vi tok "revurder fra" med et tidligere vedtak med dagsats. Dette fordi VedtakHistorikkService brukte inntekt fra andelen og ikke selve vedtaket. 
Av den grunnen legger jeg inn vedtaket som grunnlagsinformasjon i andelen