### PR TITLE
Personopplysninger opprydding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -30,16 +30,8 @@ class PersonopplysningerController(
     private val personopplysningerService: PersonopplysningerService,
     private val endringerIPersonOpplysningerService: EndringerIPersonOpplysningerService,
     private val tilgangService: TilgangService,
-    private val behandlingService: BehandlingService,
-    private val fagsakService: FagsakService,
     private val fagsakPersonService: FagsakPersonService,
 ) {
-
-    @PostMapping
-    fun personopplysninger(@RequestBody personIdent: PersonIdentDto): Ressurs<PersonopplysningerDto> {
-        tilgangService.validerTilgangTilPersonMedBarn(personIdent.personIdent, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(personopplysningerService.hentPersonopplysninger(personIdent.personIdent))
-    }
 
     @GetMapping("/behandling/{behandlingId}")
     fun personopplysninger(@PathVariable behandlingId: UUID): Ressurs<PersonopplysningerDto> {
@@ -53,25 +45,11 @@ class PersonopplysningerController(
         return Ressurs.success(endringerIPersonOpplysningerService.hentEndringerPersonopplysninger(behandlingId))
     }
 
-    @GetMapping("/fagsak/{fagsakId}")
-    fun personopplysningerFraFagsakId(@PathVariable fagsakId: UUID): Ressurs<PersonopplysningerDto> {
-        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
-        val aktivIdent = fagsakService.hentAktivIdent(fagsakId)
-        return Ressurs.success(personopplysningerService.hentPersonopplysninger(aktivIdent))
-    }
-
     @GetMapping("/fagsak-person/{fagsakPersonId}")
     fun personopplysningerFraFagsakPersonId(@PathVariable fagsakPersonId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         return Ressurs.success(personopplysningerService.hentPersonopplysninger(aktivIdent))
-    }
-
-    @GetMapping("/nav-kontor/behandling/{behandlingId}")
-    fun hentNavKontor(@PathVariable behandlingId: UUID): Ressurs<NavKontorEnhet?> {
-        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        val aktivIdent = behandlingService.hentAktivIdent(behandlingId)
-        return Ressurs.success(personopplysningerService.hentNavKontor(aktivIdent))
     }
 
     @PostMapping("/nav-kontor")

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
-import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
-import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -24,7 +24,6 @@ data class PersonopplysningerDto(
     val adresse: List<AdresseDto>,
     val fullmakt: List<FullmaktDto>,
     val egenAnsatt: Boolean,
-    val navEnhet: String,
     val barn: List<BarnDto>,
     val innflyttingTilNorge: List<InnflyttingDto>,
     val utflyttingFraNorge: List<UtflyttingDto>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper
 
-import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.AnnenForelderMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
@@ -32,7 +31,6 @@ class PersonopplysningerMapper(
     private val adresseMapper: AdresseMapper,
     private val statsborgerskapMapper: StatsborgerskapMapper,
     private val innflyttingUtflyttingMapper: InnflyttingUtflyttingMapper,
-    private val arbeidsfordelingService: ArbeidsfordelingService,
 ) {
 
     fun tilPersonopplysninger(
@@ -77,8 +75,6 @@ class PersonopplysningerMapper(
                 )
             }.sortedByDescending { it.gyldigFraOgMed },
             egenAnsatt = egenAnsatt,
-            navEnhet = arbeidsfordelingService.hentNavEnhet(gjeldendePersonIdent)
-                ?.let { it.enhetId + " - " + it.enhetNavn } ?: "Ikke funnet",
             barn = grunnlagsdata.barn.map {
                 mapBarn(
                     it,

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/PersonopplysningerControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/PersonopplysningerControllerTest.kt
@@ -33,7 +33,7 @@ internal class PersonopplysningerControllerTest : OppslagSpringRunnerTest() {
         val personopplysningerRequest = PersonIdentDto("ikkeTilgang")
 
         return restTemplate.exchange(
-            localhost("/api/personopplysninger"),
+            localhost("/api/personopplysninger/nav-kontor"),
             HttpMethod.POST,
             HttpEntity(personopplysningerRequest, headers),
         )

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -99,7 +99,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Mangler verdi")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
             assertIngenAndreEndringer(endringer, "folkeregisterpersonstatus")
         }
 
@@ -112,7 +112,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Død")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
         }
 
         @Test
@@ -146,7 +146,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.fødselsdato.harEndringer).isTrue
             assertThat(endringer.fødselsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.fødselsdato.detaljer.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.fødselsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "fødselsdato")
         }
 
@@ -158,7 +158,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.dødsdato.harEndringer).isTrue
             assertThat(endringer.dødsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.dødsdato.detaljer.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.dødsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "dødsdato")
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/UtledEndringerUtilTest.kt
@@ -99,7 +99,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Mangler verdi")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
             assertIngenAndreEndringer(endringer, "folkeregisterpersonstatus")
         }
 
@@ -112,7 +112,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.harEndringer).isTrue
             assertThat(endringer.folkeregisterpersonstatus.detaljer!!.tidligere).isEqualTo("Død")
-            assertThat(endringer.folkeregisterpersonstatus.detaljer!!.ny).isEqualTo("Bosatt")
+            assertThat(endringer.folkeregisterpersonstatus.detaljer.ny).isEqualTo("Bosatt")
         }
 
         @Test
@@ -146,7 +146,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.fødselsdato.harEndringer).isTrue
             assertThat(endringer.fødselsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.fødselsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.fødselsdato.detaljer.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "fødselsdato")
         }
 
@@ -158,7 +158,7 @@ internal class UtledEndringerUtilTest {
             assertThat(endringer.harEndringer).isTrue
             assertThat(endringer.dødsdato.harEndringer).isTrue
             assertThat(endringer.dødsdato.detaljer!!.tidligere).isEqualTo(tidligere.norskFormat())
-            assertThat(endringer.dødsdato.detaljer!!.ny).isEqualTo(ny.norskFormat())
+            assertThat(endringer.dødsdato.detaljer.ny).isEqualTo(ny.norskFormat())
             assertIngenAndreEndringer(endringer, "dødsdato")
         }
 
@@ -550,7 +550,6 @@ internal class UtledEndringerUtilTest {
         adresse = adresse,
         fullmakt = fullmakt,
         egenAnsatt = false,
-        navEnhet = "",
         barn = barn,
         innflyttingTilNorge = innflyttingTilNorge,
         utflyttingFraNorge = utflyttingFraNorge,

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapperTest.kt
@@ -35,7 +35,6 @@ internal class PersonopplysningerMapperTest {
         adresseMapper = adresseMapper,
         statsborgerskapMapper = statsborgerskapMapper,
         innflyttingUtflyttingMapper = innflyttingUtflyttingMapper,
-        arbeidsfordelingService = arbeidsfordelingService,
     )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -3,8 +3,6 @@ package no.nav.familie.ef.sak.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
-import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
@@ -33,7 +31,6 @@ internal class PersonopplysningerServiceTest {
     private lateinit var personopplysningerService: PersonopplysningerService
     private lateinit var personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient
     private lateinit var adresseMapper: AdresseMapper
-    private lateinit var arbeidsfordelingService: ArbeidsfordelingService
     private lateinit var grunnlagsdataService: GrunnlagsdataService
     private lateinit var søknadService: SøknadService
     private lateinit var behandlingService: BehandlingService
@@ -45,7 +42,6 @@ internal class PersonopplysningerServiceTest {
         personopplysningerIntegrasjonerClient = mockk(relaxed = true)
         behandlingService = mockk(relaxed = true)
         adresseMapper = AdresseMapper(kodeverkService)
-        arbeidsfordelingService = mockk(relaxed = true)
         søknadService = mockk()
         val personService = PersonService(PdlClientConfig().pdlClient(), ConcurrentMapCacheManager())
 
@@ -87,7 +83,6 @@ internal class PersonopplysningerServiceTest {
             emptyList(),
             emptyList(),
         )
-        every { arbeidsfordelingService.hentNavEnhet(any()) } returns Arbeidsfordelingsenhet("1", "Enhet")
         val søker = personopplysningerService.hentPersonopplysninger("01010172272")
         assertThat(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(søker))
             .isEqualToIgnoringWhitespace(readFile("/json/personopplysningerDto.json"))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -67,7 +67,6 @@ internal class PersonopplysningerServiceTest {
                 adresseMapper,
                 StatsborgerskapMapper(kodeverkService),
                 InnflyttingUtflyttingMapper(kodeverkService),
-                arbeidsfordelingService,
             )
         personopplysningerService = PersonopplysningerService(
             personService,

--- a/src/test/resources/json/personopplysningerDto.json
+++ b/src/test/resources/json/personopplysningerDto.json
@@ -51,7 +51,6 @@
     "områder" : [ ]
   } ],
   "egenAnsatt" : true,
-  "navEnhet" : "1 - Enhet",
   "barn" : [ {
     "personIdent" : "01012067050",
     "navn" : "Barn Barnesen",


### PR DESCRIPTION
- Fjerner endepunkter fra personopplysninger som ikke blir brukt
- Fjerner navEnhet (saksbehandlerenhet) fra PersonopplysningerDto som ikke blir brukt. 

[PR for å fjerne navenhet i frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2226)

[Opprydning som forarbeid til forbedring av uthenting av personopplysninger](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-7323)