### PR TITLE
Endrer port på familie-integrasjoner lokalt sånn at man kan kjøre tes…

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -39,9 +39,11 @@ import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
+import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -136,8 +138,8 @@ class FamilieIntegrasjonerMock(integrasjonerConfig: IntegrasjonerConfig) {
 
     @Bean("mock-integrasjoner")
     @Profile("mock-integrasjoner")
-    fun integrationMockServer(): WireMockServer {
-        val mockServer = WireMockServer(8385)
+    fun integrationMockServer(@Value("\${FAMILIE_INTEGRASJONER_URL}") uri: URI): WireMockServer {
+        val mockServer = WireMockServer(uri.port)
         responses.forEach {
             mockServer.stubFor(it)
         }

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -18,7 +18,7 @@ no.nav.security.jwt:
     cookie_name: azure_token
 
 AZUREAD_TOKEN_ENDPOINT_URL: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/v2.0/token
-FAMILIE_INTEGRASJONER_URL: http://localhost:8385
+FAMILIE_INTEGRASJONER_URL: http://localhost:8386
 FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BLANKETT_API_URL: http://localhost:8033
 #FAMILIE_EF_IVERKSETT_URL: http://localhost:8094 # Fordi iverksett og klage er på samme url/port lokalt så må vi kommentere ut den av de vi ikke vil kjøre opp mot lokalt


### PR DESCRIPTION
…ter og applikasjonen lokalt samtidig

Dette gjør det mulig å ha applikasjonen kjørendes lokalt, og samtidig kunne kjøre tester

![image](https://user-images.githubusercontent.com/937168/229133867-21d96e58-c6b2-499a-97f4-e5bdf4e45dda.png)
