### PR TITLE
Bugfix: send til beslutter raskt etter angret sendt til beslutter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
@@ -46,6 +46,7 @@ class OpprettOppgaveTask(private val oppgaveService: OppgaveService, private val
 
             if(listOf(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.IVERKSETTER_VEDTAK, BehandlingStatus.FERDIGSTILT).contains(behandling.status)){
                 logger.info("Opprettet ikke oppgave med oppgavetype = $oppgavetype fordi status = ${behandling.status}")
+                return
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.ef.sak.behandlingsflyt.task
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -8,6 +10,7 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
@@ -19,7 +22,9 @@ import java.util.UUID
     beskrivelse = "Opprett oppgave i GOSYS for behandling",
     maxAntallFeil = 3,
 )
-class OpprettOppgaveTask(private val oppgaveService: OppgaveService) : AsyncTaskStep {
+class OpprettOppgaveTask(private val oppgaveService: OppgaveService, private val behandlingService: BehandlingService) : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     /**
      * Då payload er unik per task type, så settes unik inn
@@ -34,12 +39,23 @@ class OpprettOppgaveTask(private val oppgaveService: OppgaveService) : AsyncTask
 
     override fun doTask(task: Task) {
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(task.payload)
+        val oppgavetype = data.oppgavetype
+
+        if(oppgavetype == Oppgavetype.BehandleSak ) {
+            val behandling = behandlingService.hentBehandling(data.behandlingId)
+
+            if(listOf(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.IVERKSETTER_VEDTAK, BehandlingStatus.FERDIGSTILT).contains(behandling.status)){
+                logger.info("Opprettet ikke oppgave med oppgavetype = $oppgavetype fordi status = ${behandling.status}")
+            }
+        }
+
         val oppgaveId = oppgaveService.opprettOppgave(
             behandlingId = data.behandlingId,
-            oppgavetype = data.oppgavetype,
+            oppgavetype = oppgavetype,
             tilordnetNavIdent = data.tilordnetNavIdent,
             beskrivelse = data.beskrivelse,
         )
+
         task.metadata.setProperty("oppgaveId", oppgaveId.toString())
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
@@ -41,10 +41,10 @@ class OpprettOppgaveTask(private val oppgaveService: OppgaveService, private val
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(task.payload)
         val oppgavetype = data.oppgavetype
 
-        if(oppgavetype == Oppgavetype.BehandleSak ) {
+        if (oppgavetype == Oppgavetype.BehandleSak) {
             val behandling = behandlingService.hentBehandling(data.behandlingId)
 
-            if(listOf(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.IVERKSETTER_VEDTAK, BehandlingStatus.FERDIGSTILT).contains(behandling.status)){
+            if (listOf(BehandlingStatus.FATTER_VEDTAK, BehandlingStatus.IVERKSETTER_VEDTAK, BehandlingStatus.FERDIGSTILT).contains(behandling.status)) {
                 logger.info("Opprettet ikke oppgave med oppgavetype = $oppgavetype fordi status = ${behandling.status}")
                 return
             }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
@@ -29,10 +29,12 @@ internal class OpprettOppgaveTaskTest {
     fun `skal ikke opprette behandle sak oppgave om status er ugyldig`() {
         every { behandlingService.hentBehandling(behandlingId) } returns behandling(id = behandlingId, status = BehandlingStatus.FATTER_VEDTAK)
 
-        val task = OpprettOppgaveTask.opprettTask(OpprettOppgaveTask.OpprettOppgaveTaskData(
-            behandlingId = behandlingId,
-            oppgavetype = Oppgavetype.BehandleSak
-        ))
+        val task = OpprettOppgaveTask.opprettTask(
+            OpprettOppgaveTask.OpprettOppgaveTaskData(
+                behandlingId = behandlingId,
+                oppgavetype = Oppgavetype.BehandleSak,
+            ),
+        )
 
         opprettOppgaveTask.doTask(task)
         verifyKall(0)
@@ -42,16 +44,18 @@ internal class OpprettOppgaveTaskTest {
     fun `skal opprette behandle sak oppgave om status er gyldig`() {
         every { behandlingService.hentBehandling(behandlingId) } returns behandling(id = behandlingId, status = BehandlingStatus.UTREDES)
 
-        val task = OpprettOppgaveTask.opprettTask(OpprettOppgaveTask.OpprettOppgaveTaskData(
-            behandlingId = behandlingId,
-            oppgavetype = Oppgavetype.BehandleSak
-        ))
+        val task = OpprettOppgaveTask.opprettTask(
+            OpprettOppgaveTask.OpprettOppgaveTaskData(
+                behandlingId = behandlingId,
+                oppgavetype = Oppgavetype.BehandleSak,
+            ),
+        )
 
         opprettOppgaveTask.doTask(task)
         verifyKall(1)
     }
 
     private fun verifyKall(opprettOppgaveKall: Int) {
-        verify(exactly = opprettOppgaveKall) {oppgaveService.opprettOppgave(any(), any())}
+        verify(exactly = opprettOppgaveKall) { oppgaveService.opprettOppgave(any(), any()) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
@@ -1,0 +1,57 @@
+package no.nav.familie.ef.sak.behandlingsflyt.task
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+internal class OpprettOppgaveTaskTest {
+    val oppgaveService = mockk<OppgaveService>()
+    val behandlingService = mockk<BehandlingService>()
+
+    val opprettOppgaveTask = OpprettOppgaveTask(oppgaveService, behandlingService)
+
+    val behandlingId = UUID.randomUUID()
+
+    @BeforeEach
+    fun setUp() {
+        every { oppgaveService.opprettOppgave(any(), any()) } returns 1L
+    }
+
+    @Test
+    fun `skal ikke opprette behandle sak oppgave om status er ugyldig`() {
+        every { behandlingService.hentBehandling(behandlingId) } returns behandling(id = behandlingId, status = BehandlingStatus.FATTER_VEDTAK)
+
+        val task = OpprettOppgaveTask.opprettTask(OpprettOppgaveTask.OpprettOppgaveTaskData(
+            behandlingId = behandlingId,
+            oppgavetype = Oppgavetype.BehandleSak
+        ))
+
+        opprettOppgaveTask.doTask(task)
+        verifyKall(0)
+    }
+
+    @Test
+    fun `skal opprette behandle sak oppgave om status er gyldig`() {
+        every { behandlingService.hentBehandling(behandlingId) } returns behandling(id = behandlingId, status = BehandlingStatus.UTREDES)
+
+        val task = OpprettOppgaveTask.opprettTask(OpprettOppgaveTask.OpprettOppgaveTaskData(
+            behandlingId = behandlingId,
+            oppgavetype = Oppgavetype.BehandleSak
+        ))
+
+        opprettOppgaveTask.doTask(task)
+        verifyKall(1)
+    }
+
+    private fun verifyKall(opprettOppgaveKall: Int) {
+        verify(exactly = opprettOppgaveKall) {oppgaveService.opprettOppgave(any(), any())}
+    }
+}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? 
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12353)
Dersom man trykker på "Send til beslutter" raskt etter at man har angret har det blitt opprettet en task for å lage en behandleSakOppgave, men oppgaven er ikke laget enda. Dette gjør at oppgaven aldri blir lukket. 

### Hvordan er det løst?
Lagt inn en sjekk på behandlingsstatus dersom oppgavetype = behandle sak
