### PR TITLE
Fikser feil koblet til å legge inn vedtaksgrunnlag i andelshistorikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/AndelHistorikkUtil.kt
@@ -24,7 +24,7 @@ object AndelHistorikkUtil {
         first: AndelHistorikkDto,
         second: AndelHistorikkDto,
     ) =
-        first.vedtaksperiode.periode.påfølgesAv(second.vedtaksperiode.periode)
+        first.andel.periode.påfølgesAv(second.andel.periode)
 
     fun periodeTypeOvergangsstønad(
         stønadstype: StønadType,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
@@ -182,10 +182,14 @@ object VedtakHistorikkBeregner {
     private fun perioderForOvergangsstønad(vedtak: InnvilgelseOvergangsstønad): List<Vedtakshistorikkperiode> {
         val inntekter = inntektsperioder(vedtak)
         return vedtak.perioder.flatMap {
-            if (it.periodeType == VedtaksperiodeType.SANKSJON) {
-                listOf(Sanksjonsperiode(it.periode, it.sanksjonsårsak ?: error("Mangler sanksjonsårsak")))
-            } else {
-                splittOppVedtaksperioderOgInntekter(inntekter, it)
+            when (it.periodeType) {
+                VedtaksperiodeType.SANKSJON ->
+                    listOf(Sanksjonsperiode(it.periode, it.sanksjonsårsak ?: error("Mangler sanksjonsårsak")))
+                VedtaksperiodeType.MIDLERTIDIG_OPPHØR -> {
+                    val inntekt = Inntekt(it.periode.fom, BigDecimal.ZERO, BigDecimal.ZERO)
+                    listOf(VedtakshistorikkperiodeOvergangsstønad(it.periode, it.aktivitet, it.periodeType, inntekt))
+                }
+                else -> splittOppVedtaksperioderOgInntekter(inntekter, it)
             }
         }
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -239,7 +239,12 @@ class StepDefinitions {
         }
 
         gittVedtak.map {
-            beregnYtelseSteg.utførSteg(saksbehandlinger[it.behandlingId]!!.second, it.tilVedtakDto())
+            try {
+                beregnYtelseSteg.utførSteg(saksbehandlinger[it.behandlingId]!!.second, it.tilVedtakDto())
+            } catch (e: Exception) {
+                logger.error("Feilet for behandling ${behandlingIdFraUUID(it.behandlingId)}")
+                throw e
+            }
             // kan ikke beregne historikk ennå
             if (stønadstype != StønadType.SKOLEPENGER) {
                 beregnetAndelHistorikkList = AndelHistorikkBeregner.lagHistorikk(
@@ -488,24 +493,33 @@ class StepDefinitions {
             } catch (e: Throwable) {
                 logger.info("Expected: {}", it)
                 logger.info("Actual: {}", andelHistorikkDto)
-                beregnetAndelHistorikkList.forEach { andel ->
-                    logger.info(
-                        listOf(
-                            behandlingIdTilUUID.entries.find { it.value == andel.behandlingId }!!.key,
-                            andel.andel.periode.fom.format(YEAR_MONTH_FORMAT_NORSK),
-                            andel.andel.periode.tom.format(YEAR_MONTH_FORMAT_NORSK),
-                            andel.endring?.type ?: "",
-                            andel.endring?.behandlingId?.let { bid -> behandlingIdTilUUID.entries.find { it.value == bid }!!.key }
-                                ?: "",
-                            "opphør=${andel.erOpphør}",
-                        ).joinToString("|", prefix = "|", postfix = "|"),
-                    )
-                }
+                loggForventet()
 
                 throw Throwable("Feilet rad $index", e)
             }
         }
-        assertThat(dataTable.asMaps()).hasSize(forventetHistorikkEndringer.size)
+        try {
+            assertThat(dataTable.asMaps()).hasSize(beregnetAndelHistorikkList.size)
+        } catch (e: Throwable) {
+            loggForventet()
+            throw e
+        }
+    }
+
+    private fun loggForventet() {
+        beregnetAndelHistorikkList.forEach { andel ->
+            logger.info(
+                listOf(
+                    behandlingIdTilUUID.entries.find { it.value == andel.behandlingId }!!.key,
+                    andel.andel.periode.fom.format(YEAR_MONTH_FORMAT_NORSK),
+                    andel.andel.periode.tom.format(YEAR_MONTH_FORMAT_NORSK),
+                    andel.endring?.type ?: "",
+                    andel.endring?.behandlingId?.let { bid -> behandlingIdTilUUID.entries.find { it.value == bid }!!.key }
+                        ?: "",
+                    "opphør=${andel.erOpphør}",
+                ).joinToString("|", prefix = "|", postfix = "|"),
+            )
+        }
     }
 
     private fun assertBeregnetAndel(

--- a/src/test/resources/no/nav/familie/ef/sak/midlertidig_opphør.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/midlertidig_opphør.feature
@@ -1,0 +1,35 @@
+# language: no
+# encoding: UTF-8
+
+Egenskap: Vedtak med midlertidig opphør
+
+  Scenario: Revurdering legger inn midlertidig opphør, som då ikke har med inntektsperiode for opphøret
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksperiode     | Aktivitet            |
+      | 1            | 05.2022         | 04.2023         | HOVEDPERIODE       | BARN_UNDER_ETT_ÅR    |
+      | 2            | 07.2022         | 07.2022         | MIDLERTIDIG_OPPHØR | IKKE_AKTIVITETSPLIKT |
+      | 2            | 08.2022         | 04.2023         | HOVEDPERIODE       | BARN_UNDER_ETT_ÅR    |
+
+    Og følgende inntekter
+      | BehandlingId | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 1            | 05.2022         | 100     | 0                  |
+      | 2            | 08.2022         | 222     | 0                  |
+
+    Når beregner ytelse
+
+    Så forvent følgende historikk
+      | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
+      | 1            | 05.2022         | 06.2022         | SPLITTET     | 2                     |
+      | 1            | 07.2022         | 04.2023         | FJERNET      | 2                     |
+      | 2            | 08.2022         | 04.2023         |              |                       |
+
+    Så forvent følgende vedtaksperioder fra dato: 05.2022
+      | Fra og med dato | Til og med dato | Vedtaksperiode | Aktivitet         |
+      | 05.2022         | 06.2022         | HOVEDPERIODE   | BARN_UNDER_ETT_ÅR |
+      | 08.2022         | 04.2023         | HOVEDPERIODE   | BARN_UNDER_ETT_ÅR |
+
+    Så forvent følgende inntektsperioder fra dato: 05.2022
+      | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 05.2022         | 100     | 0                  |
+      | 08.2022         | 222     | 0                  |

--- a/src/test/resources/no/nav/familie/ef/sak/opphør.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/opphør.feature
@@ -114,7 +114,7 @@ Egenskap: Andelhistorikk: Opphør
     Gitt følgende vedtak
       | BehandlingId | Fra og med dato | Til og med dato |
       | 1            | 01.2021         | 03.2021         |
-      | 2            | 02.2021         |                 |
+      | 2            | 02.2021         | 03.2021         |
 
     Når beregner ytelse
 
@@ -122,6 +122,7 @@ Egenskap: Andelhistorikk: Opphør
       | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
       | 1            | 01.2021         | 01.2021         | SPLITTET     | 2                     |
       | 1            | 02.2021         | 03.2021         | FJERNET      | 2                     |
+      | 2            | 02.2021         | 03.2021         |              |                       |
 
   Scenario: Innvilger 2 ganger, og sen opphør andre perioden
 

--- a/src/test/resources/no/nav/familie/ef/sak/vedtak_fra_gitt_dato/vedtak_fra_dato.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/vedtak_fra_gitt_dato/vedtak_fra_dato.feature
@@ -145,3 +145,46 @@ Egenskap: hentVedtakForOvergangsstønadFraDato
     Så forvent følgende inntektsperioder fra dato: 03.2021
       | Fra og med dato | Inntekt | Samordningsfradrag |
       | 05.2021         | 20      | 10                 |
+
+  Scenario: Periode som strekker seg over flere g-beløp
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Aktivitet         | Vedtaksperiode |
+      | 1            | 01.2021         | 07.2021         | INNVILGE        | BARN_UNDER_ETT_ÅR | HOVEDPERIODE   |
+
+    Og følgende inntekter
+      | BehandlingId | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 1            | 01.2021         | 10      | 20                 |
+
+    Når beregner ytelse
+
+    Så forvent følgende vedtaksperioder fra dato: 01.2021
+      | Fra og med dato | Til og med dato | Aktivitet         | Vedtaksperiode |
+      | 01.2021         | 07.2021         | BARN_UNDER_ETT_ÅR | HOVEDPERIODE   |
+
+    Så forvent følgende inntektsperioder fra dato: 01.2021
+      | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 01.2021         | 10      | 20                 |
+
+  Scenario: Periode som med flere inntekter
+
+    Gitt følgende vedtak
+      | BehandlingId | Fra og med dato | Til og med dato | Vedtaksresultat | Aktivitet         | Vedtaksperiode |
+      | 1            | 01.2021         | 07.2021         | INNVILGE        | BARN_UNDER_ETT_ÅR | HOVEDPERIODE   |
+
+    Og følgende inntekter
+      | BehandlingId | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 1            | 01.2021         | 10      | 20                 |
+      | 1            | 02.2021         | 10      | 20                 |
+      | 1            | 03.2021         | 20      | 20                 |
+
+    Når beregner ytelse
+
+    Så forvent følgende vedtaksperioder fra dato: 01.2021
+      | Fra og med dato | Til og med dato | Aktivitet         | Vedtaksperiode |
+      | 01.2021         | 07.2021         | BARN_UNDER_ETT_ÅR | HOVEDPERIODE   |
+
+    Så forvent følgende inntektsperioder fra dato: 01.2021
+      | Fra og med dato | Inntekt | Samordningsfradrag |
+      | 01.2021         | 10      | 20                 |
+      | 03.2021         | 20      | 20                 |


### PR DESCRIPTION
* Revurderinger som begynner med midlertidig opphør har inntekt fra perioden etter opphøret, dvs man har ett hull av inntekt
* Vedtaksgrunnlaget blir ikke splittet når det vært g-omregning, sånn at sjekk på sammenhengende perioder må gjøres på andelen

https://nav-it.slack.com/archives/C033WGAFAQ1/p1681714431072339?thread_ts=1681710687.393229&cid=C033WGAFAQ1

Det begynte med at en saksbehandler fikk denne feilen når man gikk inn på vedtakshistorikken
> "Feil: Forventer å inneholde minimum en inntektsperiode som overlapper",
https://ensligmorellerfar.intern.nav.no/person/e0e26abb-f378-432e-9165-566f52bdf70e/vedtak

Det som feilet var att i https://github.com/navikt/familie-ef-sak/pull/2147 så splittes vedtaksperiodene opp mot inntektsperiodene, for å kunne få med riktige inntekter for dagsats og månedsinntekt. 

#### Vedtaksgrunnlaget er også feil
En annen feil som då ble funnen er ju at vedtaksgrunnlaget ikke blir splittet opp ved g-omregning. Noe som jeg prøvde på i den tidligere pull requesten, men som feilet. 

Det er mulig vi egentlige ikke burde lagre ned vedtaksgrunnlaget på denne måten. Jeg hadde en tanke om at hvis man gjør det sånn her, så kan man også få bort bruket av periodetype/aktivitet direkt inne i objektet sen også. 