### PR TITLE
G-Omregning: Ikke lag tasks for fagsaker med samordningsfradrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakRepository.kt
@@ -95,9 +95,10 @@ interface FagsakRepository : RepositoryInterface<FagsakDomain, UUID>, InsertUpda
         """SELECT DISTINCT b.fagsak_id 
               FROM gjeldende_iverksatte_behandlinger b   
               JOIN tilkjent_ytelse ty ON b.id = ty.behandling_id
-              AND ty.grunnbelopsdato < :gjeldendeGrunnbeløpFraOgMedDato
-              JOIN andel_tilkjent_ytelse aty ON aty.tilkjent_ytelse = ty.id
-              AND aty.stonad_tom > :gjeldendeGrunnbeløpFraOgMedDato
+                AND ty.grunnbelopsdato < :gjeldendeGrunnbeløpFraOgMedDato
+              JOIN andel_tilkjent_ytelse aty ON aty.tilkjent_ytelse = ty.id 
+                AND aty.samordningsfradrag = 0
+                AND aty.stonad_tom > :gjeldendeGrunnbeløpFraOgMedDato
               WHERE b.stonadstype = 'OVERGANGSSTØNAD'
               AND b.fagsak_id NOT IN (SELECT b2.fagsak_id FROM behandling b2 
                                       WHERE b2.fagsak_id = b.fagsak_id

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringKlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringKlageService.kt
@@ -56,7 +56,7 @@ class JournalføringKlageService(
                 "fagsak=${fagsak.id} stønadstype=${fagsak.stønadstype} ",
         )
 
-        if(journalføringRequest.klageGjelderTilbakekreving){
+        if (journalføringRequest.klageGjelderTilbakekreving) {
             oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId)
         }
 
@@ -119,10 +119,10 @@ class JournalføringKlageService(
         oppgaveService.ferdigstillOppgave(journalføringRequest.oppgaveId.toLong())
     }
 
-    private fun oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId: UUID){
+    private fun oppdaterOppgaveTilÅGjeldeTilbakekreving(behandlingId: UUID) {
         taskService.save(
             OppdaterOppgaveTilÅGjeldeTilbakekrevingTask.opprettTask(
-                behandlingId = behandlingId
+                behandlingId = behandlingId,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/OppdaterOppgaveTilÅGjeldeTilbakekrevingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/OppdaterOppgaveTilÅGjeldeTilbakekrevingTask.kt
@@ -25,7 +25,7 @@ class OppdaterOppgaveTilÅGjeldeTilbakekrevingTask(private val klageClient: Klag
         fun opprettTask(behandlingId: UUID): Task {
             return Task(
                 type = TYPE,
-                payload = behandlingId.toString()
+                payload = behandlingId.toString(),
             )
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringKlageRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringKlageRequest.kt
@@ -9,7 +9,7 @@ data class JournalføringKlageRequest(
     val oppgaveId: String,
     val behandling: JournalføringKlageBehandling,
     val journalførendeEnhet: String,
-    val klageGjelderTilbakekreving: Boolean = false
+    val klageGjelderTilbakekreving: Boolean = false,
 )
 
 data class JournalføringKlageBehandling(

--- a/src/main/kotlin/no/nav/familie/ef/sak/klage/KlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/klage/KlageService.kt
@@ -75,7 +75,7 @@ class KlageService(
                 fagsystem = Fagsystem.EF,
                 klageMottatt = klageMottatt,
                 behandlendeEnhet = enhetId,
-                klageGjelderTilbakekreving = klageGjelderTilbakekreving
+                klageGjelderTilbakekreving = klageGjelderTilbakekreving,
             ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/OppgaveEfDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/OppgaveEfDto.kt
@@ -2,11 +2,11 @@ package no.nav.familie.ef.sak.oppgave.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
+import jakarta.validation.constraints.Pattern
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
-import jakarta.validation.constraints.Pattern
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
@@ -80,7 +80,7 @@ data class VedtakshistorikkperiodeOvergangsstønad(
     override fun medFra(fra: YearMonth): Vedtakshistorikkperiode {
         return this.copy(
             periode = this.periode.copy(fom = fra),
-            inntekt = this.inntekt.copy(årMånedFra = fra)
+            inntekt = this.inntekt.copy(årMånedFra = fra),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkService.kt
@@ -113,12 +113,14 @@ class VedtakHistorikkService(
         return historikk
             .filter { it.periodeType != VedtaksperiodeType.SANKSJON }
             .slåSammen { a, b ->
-                (a.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
-                    b.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
-                    a.vedtaksperiode.inntekt.dagsats nullOrEquals b.vedtaksperiode.inntekt.dagsats &&
-                    a.vedtaksperiode.inntekt.månedsinntekt nullOrEquals b.vedtaksperiode.inntekt.månedsinntekt &&
-                    a.vedtaksperiode.inntekt.forventetInntekt nullOrEquals b.vedtaksperiode.inntekt.forventetInntekt &&
-                    a.vedtaksperiode.inntekt.samordningsfradrag nullOrEquals b.vedtaksperiode.inntekt.samordningsfradrag)
+                (
+                    a.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                        b.vedtaksperiode is VedtakshistorikkperiodeOvergangsstønad &&
+                        a.vedtaksperiode.inntekt.dagsats nullOrEquals b.vedtaksperiode.inntekt.dagsats &&
+                        a.vedtaksperiode.inntekt.månedsinntekt nullOrEquals b.vedtaksperiode.inntekt.månedsinntekt &&
+                        a.vedtaksperiode.inntekt.forventetInntekt nullOrEquals b.vedtaksperiode.inntekt.forventetInntekt &&
+                        a.vedtaksperiode.inntekt.samordningsfradrag nullOrEquals b.vedtaksperiode.inntekt.samordningsfradrag
+                    )
             }
             .fraDato(fra)
             .mapNotNull {


### PR DESCRIPTION
Opprettet ny test som viser at tilkjent ytelse med 0 beløp får oppdatert G

Pr nå er det 193 fagsaker med samordningsfradrag med utdatert G, fordi de ikke behandles i G-omregningen. Med denne endringen blir det ikke lenger opprettet G-omregning tasks for disse.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12348)