### PR TITLE
Slett innslag av fremleggsoppgave hvis vedtaket nullstilles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.vedtak
 
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.brev.MellomlagringBrevService
@@ -23,6 +24,7 @@ class NullstillVedtakService(
     private val tilbakekrevingService: TilbakekrevingService,
     private val mellomlagringBrevService: MellomlagringBrevService,
     private val vedtaksbrevService: VedtaksbrevService,
+    private val oppgaverForOpprettelseService: OppgaverForOpprettelseService,
 ) {
 
     @Transactional
@@ -42,5 +44,6 @@ class NullstillVedtakService(
         }
         vedtakService.slettVedtakHvisFinnes(behandlingId)
         vedtaksbrevService.slettVedtaksbrev(saksbehandling)
+        oppgaverForOpprettelseService.slettOppgaverForOpprettelse(behandlingId)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
@@ -69,6 +69,7 @@ class NullstillVedtakServiceTest {
             vedtaksbrevService.slettVedtaksbrev(any())
             vedtakService.slettVedtakHvisFinnes(behandlingId)
             stegService.resetSteg(behandlingId, StegType.BEREGNE_YTELSE)
+            oppgaverForOpprettelseService.slettOppgaverForOpprettelse(any())
         }
 
         Assertions.assertThat(saksbehandling.captured.id).isEqualTo(behandlingId)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.verifyAll
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.brev.MellomlagringBrevService
@@ -35,6 +36,7 @@ class NullstillVedtakServiceTest {
     private val tilbakekrevingService = mockk<TilbakekrevingService>(relaxed = true)
     private val mellomlagringBrevService = mockk<MellomlagringBrevService>(relaxed = true)
     private val vedtaksbrevService = mockk<VedtaksbrevService>(relaxed = true)
+    private val oppgaverForOpprettelseService = mockk<OppgaverForOpprettelseService>(relaxed = true)
 
     private val nullstillVedtakService = NullstillVedtakService(
         vedtakService,
@@ -45,6 +47,7 @@ class NullstillVedtakServiceTest {
         tilbakekrevingService,
         mellomlagringBrevService,
         vedtaksbrevService,
+        oppgaverForOpprettelseService
     )
     private val behandlingId = UUID.randomUUID()
 


### PR DESCRIPTION
Ved "ta av vent", så kan vedtaket evt nullstilles , og derfor må også et mulig innslag av fremleggsoppgave slettes. 