### PR TITLE
Gamle åpne behandlinger uten oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -65,15 +65,12 @@ class BehandlingController(
 
         val eksternFagsakIds = gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
 
-        val fagsakerMedÅpenBehandlingSomManglerOppgaveAvType : List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
+        val fagsakerMedÅpenBehandlingSomManglerOppgaveAvType: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
 
-        fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.forEach{
+        fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.forEach {
             logger.info("Fagsak med åpen behandling uten oppgave: $it")
         }
     }
-
-
-
 
     @PostMapping("{behandlingId}/vent")
     fun settPåVent(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -56,7 +56,7 @@ class BehandlingController(
     }
 
     @GetMapping("gamle-behandlinger-oppgavemangler")
-    fun hentGamleUferdigeBehandlingerUtenOppgave() {
+    fun hentGamleUferdigeBehandlingerUtenOppgave() :  Ressurs<List<String>> {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
@@ -65,12 +65,13 @@ class BehandlingController(
 
         val eksternFagsakIds = gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
 
-        val fagsakerMedÅpenBehandlingSomManglerOppgaveAvType: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
+        val fagsakerMedÅpenBehandlingSomManglerOppgave: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
 
-        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.size}")
-        fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.forEach {
+        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
+        fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
             logger.info("Fagsak med åpen behandling uten oppgave: $it")
         }
+        return Ressurs.success(fagsakerMedÅpenBehandlingSomManglerOppgave)
     }
 
     @PostMapping("{behandlingId}/vent")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -9,19 +9,16 @@ import no.nav.familie.ef.sak.behandling.dto.tilDto
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
-import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.vilkår.gjenbruk.GjenbrukVilkårService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDateTime
 import java.util.UUID
 
 @RestController
@@ -34,10 +31,7 @@ class BehandlingController(
     private val henleggService: HenleggService,
     private val tilgangService: TilgangService,
     private val gjenbrukVilkårService: GjenbrukVilkårService,
-    private val oppgaveService: OppgaveService,
 ) {
-
-    private val logger = LoggerFactory.getLogger(javaClass)
 
     @GetMapping("{behandlingId}")
     fun hentBehandling(@PathVariable behandlingId: UUID): Ressurs<BehandlingDto> {
@@ -53,25 +47,6 @@ class BehandlingController(
             behandlingService.hentGamleUferdigeBehandlinger(stønadstype).map { it.tilDto(stønadstype) }
         }
         return Ressurs.success(gamleBehandlinger)
-    }
-
-    @GetMapping("gamle-behandlinger-oppgavemangler")
-    fun finnÅpneBehandlingerUtenOppgave(): Ressurs<List<String>> {
-        val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
-        val toUkerSiden = LocalDateTime.now().minusWeeks(2)
-        val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
-            behandlingService.hentGamleUferdigeBehandlinger(stønadstype, toUkerSiden)
-        }
-
-        val eksternFagsakIds = gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
-
-        val fagsakerMedÅpenBehandlingSomManglerOppgave: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
-
-        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
-        fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
-            logger.info("Fagsak med åpen behandling uten oppgave: $it")
-        }
-        return Ressurs.success(fagsakerMedÅpenBehandlingSomManglerOppgave)
     }
 
     @PostMapping("{behandlingId}/vent")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -56,7 +56,7 @@ class BehandlingController(
     }
 
     @GetMapping("gamle-behandlinger-oppgavemangler")
-    fun finnÅpneBehandlingerUtenOppgave() :  Ressurs<List<String>> {
+    fun finnÅpneBehandlingerUtenOppgave(): Ressurs<List<String>> {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -44,7 +44,7 @@ class BehandlingController(
     fun hentGamleUferdigeBehandlinger(): Ressurs<List<BehandlingDto>> {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
-            behandlingService.hentGamleUferdigeBehandlinger(stønadstype).map { it.tilDto(stønadstype) }
+            behandlingService.hentUferdigeBehandlingerOpprettetFørDato(stønadstype).map { it.tilDto(stønadstype) }
         }
         return Ressurs.success(gamleBehandlinger)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -56,7 +56,7 @@ class BehandlingController(
     }
 
     @GetMapping("gamle-behandlinger-oppgavemangler")
-    fun hentGamleUferdigeBehandlingerUtenOppgave() :  Ressurs<List<String>> {
+    fun finnÅpneBehandlingerUtenOppgave() :  Ressurs<List<String>> {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -67,6 +67,7 @@ class BehandlingController(
 
         val fagsakerMedÅpenBehandlingSomManglerOppgaveAvType: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
 
+        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.size}")
         fagsakerMedÅpenBehandlingSomManglerOppgaveAvType.forEach {
             logger.info("Fagsak med åpen behandling uten oppgave: $it")
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -191,5 +191,5 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         AND f.stonadstype=:stønadstype
         """,
     )
-    fun hentUferdigeBehandlingerFørDato(stønadstype: StønadType, opprettetTidFør: LocalDateTime): List<Behandling>
+    fun hentUferdigeBehandlingerOpprettetFørDato(stønadstype: StønadType, opprettetTidFør: LocalDateTime): List<Behandling>
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -62,7 +62,7 @@ class BehandlingService(
 
     fun hentGamleUferdigeBehandlinger(
         stønadtype: StønadType,
-        enMånedSiden: LocalDateTime = LocalDateTime.now().minusMonths(1)
+        enMånedSiden: LocalDateTime = LocalDateTime.now().minusMonths(1),
     ): List<Behandling> {
         return behandlingRepository.hentUferdigeBehandlingerFørDato(stønadtype, enMånedSiden)
     }
@@ -114,13 +114,13 @@ class BehandlingService(
         }
         feilHvis(
             behandlingsårsak == BehandlingÅrsak.G_OMREGNING &&
-                    !featureToggleService.isEnabled(Toggle.G_BEREGNING),
+                !featureToggleService.isEnabled(Toggle.G_BEREGNING),
         ) {
             "Feature toggle for g-omregning er disabled"
         }
         feilHvis(
             behandlingsårsak == BehandlingÅrsak.KORRIGERING_UTEN_BREV &&
-                    !featureToggleService.isEnabled(Toggle.BEHANDLING_KORRIGERING),
+                !featureToggleService.isEnabled(Toggle.BEHANDLING_KORRIGERING),
         ) {
             "Feature toggle for korrigering er ikke skrudd på for bruker"
         }
@@ -170,7 +170,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer status på behandling $behandlingId " +
-                    "fra ${behandling.status} til $status",
+                "fra ${behandling.status} til $status",
         )
         return behandlingRepository.update(behandling.copy(status = status))
     }
@@ -179,7 +179,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer kategori på behandling $behandlingId " +
-                    "fra ${behandling.kategori} til $kategori",
+                "fra ${behandling.kategori} til $kategori",
         )
         return behandlingRepository.update(behandling.copy(kategori = kategori))
     }
@@ -191,7 +191,7 @@ class BehandlingService(
         }
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer forrigeBehandlingId på behandling $behandlingId " +
-                    "fra ${behandling.forrigeBehandlingId} til $forrigeBehandlingId",
+                "fra ${behandling.forrigeBehandlingId} til $forrigeBehandlingId",
         )
         return behandlingRepository.update(behandling.copy(forrigeBehandlingId = forrigeBehandlingId))
     }
@@ -200,7 +200,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer steg på behandling $behandlingId " +
-                    "fra ${behandling.steg} til $steg",
+                "fra ${behandling.steg} til $steg",
         )
         return behandlingRepository.update(behandling.copy(steg = steg))
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -60,11 +60,11 @@ class BehandlingService(
     fun finnSisteIverksatteBehandling(fagsakId: UUID) =
         behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
 
-    fun hentGamleUferdigeBehandlinger(
+    fun hentUferdigeBehandlingerOpprettetFørDato(
         stønadtype: StønadType,
-        enMånedSiden: LocalDateTime = LocalDateTime.now().minusMonths(1),
+        opprettetFørDato: LocalDateTime = LocalDateTime.now().minusMonths(1),
     ): List<Behandling> {
-        return behandlingRepository.hentUferdigeBehandlingerFørDato(stønadtype, enMånedSiden)
+        return behandlingRepository.hentUferdigeBehandlingerOpprettetFørDato(stønadtype, opprettetFørDato)
     }
 
     fun finnesÅpenBehandling(fagsakId: UUID) =

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -60,9 +60,10 @@ class BehandlingService(
     fun finnSisteIverksatteBehandling(fagsakId: UUID) =
         behandlingRepository.finnSisteIverksatteBehandling(fagsakId)
 
-    fun hentGamleUferdigeBehandlinger(stønadtype: StønadType): List<Behandling> {
-        val enMånedSiden = LocalDateTime.now().minusMonths(1)
-
+    fun hentGamleUferdigeBehandlinger(
+        stønadtype: StønadType,
+        enMånedSiden: LocalDateTime = LocalDateTime.now().minusMonths(1)
+    ): List<Behandling> {
         return behandlingRepository.hentUferdigeBehandlingerFørDato(stønadtype, enMånedSiden)
     }
 
@@ -113,13 +114,13 @@ class BehandlingService(
         }
         feilHvis(
             behandlingsårsak == BehandlingÅrsak.G_OMREGNING &&
-                !featureToggleService.isEnabled(Toggle.G_BEREGNING),
+                    !featureToggleService.isEnabled(Toggle.G_BEREGNING),
         ) {
             "Feature toggle for g-omregning er disabled"
         }
         feilHvis(
             behandlingsårsak == BehandlingÅrsak.KORRIGERING_UTEN_BREV &&
-                !featureToggleService.isEnabled(Toggle.BEHANDLING_KORRIGERING),
+                    !featureToggleService.isEnabled(Toggle.BEHANDLING_KORRIGERING),
         ) {
             "Feature toggle for korrigering er ikke skrudd på for bruker"
         }
@@ -169,7 +170,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer status på behandling $behandlingId " +
-                "fra ${behandling.status} til $status",
+                    "fra ${behandling.status} til $status",
         )
         return behandlingRepository.update(behandling.copy(status = status))
     }
@@ -178,7 +179,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer kategori på behandling $behandlingId " +
-                "fra ${behandling.kategori} til $kategori",
+                    "fra ${behandling.kategori} til $kategori",
         )
         return behandlingRepository.update(behandling.copy(kategori = kategori))
     }
@@ -190,7 +191,7 @@ class BehandlingService(
         }
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer forrigeBehandlingId på behandling $behandlingId " +
-                "fra ${behandling.forrigeBehandlingId} til $forrigeBehandlingId",
+                    "fra ${behandling.forrigeBehandlingId} til $forrigeBehandlingId",
         )
         return behandlingRepository.update(behandling.copy(forrigeBehandlingId = forrigeBehandlingId))
     }
@@ -199,7 +200,7 @@ class BehandlingService(
         val behandling = hentBehandling(behandlingId)
         secureLogger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer steg på behandling $behandlingId " +
-                "fra ${behandling.steg} til $steg",
+                    "fra ${behandling.steg} til $steg",
         )
         return behandlingRepository.update(behandling.copy(steg = steg))
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.ef.sak.behandling.oppgavekontroll
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = BehandlingUtenOppgaveTask.TYPE,
+    maxAntallFeil = 2,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 60L * 60L * 2,
+    beskrivelse = "Finn åpne behandlinger uten behandle sak oppgave",
+)
+class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService) : AsyncTaskStep {
+
+    override fun doTask(task: Task) {
+        behandlingsoppgaveService.validerHarIkkeÅpneBehandligerUtenOppgave()
+    }
+
+    companion object {
+
+        const val TYPE = "finnBehandlingUtenOppgave"
+
+        fun opprettTask(): Task {
+            return Task(
+                TYPE,
+                "finnBehandlingUtenOppgave",
+                Properties(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
@@ -17,7 +17,7 @@ import java.util.*
 class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        behandlingsoppgaveService.validerHarIkkeÅpneBehandligerUtenOppgave()
+        behandlingsoppgaveService.loggÅpneBehandligerUtenOppgave()
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
@@ -9,25 +9,24 @@ import java.util.*
 @Service
 @TaskStepBeskrivelse(
     taskStepType = BehandlingUtenOppgaveTask.TYPE,
-    maxAntallFeil = 2,
+    maxAntallFeil = 1,
     settTilManuellOppfølgning = true,
-    triggerTidVedFeilISekunder = 60L * 60L * 2,
     beskrivelse = "Finn åpne behandlinger uten behandle sak oppgave",
 )
 class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        behandlingsoppgaveService.loggÅpneBehandligerUtenOppgave()
+        behandlingsoppgaveService.loggÅpneBehandlingerUtenOppgave()
     }
 
     companion object {
 
         const val TYPE = "finnBehandlingUtenOppgave"
 
-        fun opprettTask(): Task {
+        fun opprettTask(ukenummer: Int): Task {
             return Task(
                 TYPE,
-                "finnBehandlingUtenOppgave",
+                ukenummer.toString(),
                 Properties(),
             )
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
@@ -1,5 +1,8 @@
 package no.nav.familie.ef.sak.behandling.oppgavekontroll
 
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -13,10 +16,12 @@ import java.util.*
     settTilManuellOppfølgning = true,
     beskrivelse = "Finn åpne behandlinger uten behandle sak oppgave",
 )
-class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService) : AsyncTaskStep {
+class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService, val featureToggleService: FeatureToggleService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
-        behandlingsoppgaveService.loggÅpneBehandlingerUtenOppgave()
+        val antallÅpneBehandlingerUtenOppgave = behandlingsoppgaveService.antallÅpneBehandlingerUtenOppgave()
+        val skalKasteFeilHvisOppgaveMangler = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
+        feilHvis(skalKasteFeilHvisOppgaveMangler && antallÅpneBehandlingerUtenOppgave > 0) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -37,7 +37,7 @@ class BehandlingsoppgaveService(
         }
     }
 
-    fun validerHarIkkeÅpneBehandligerUtenOppgave() {
+    fun loggÅpneBehandligerUtenOppgave() {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -1,0 +1,64 @@
+package no.nav.familie.ef.sak.behandling.oppgavekontroll
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import kotlin.random.Random
+
+@Service
+class BehandlingsoppgaveService(
+    val taskService: TaskService,
+    val behandlingService: BehandlingService,
+    val fagsakService: FagsakService,
+    val oppgaveService: OppgaveService,
+    val featureToggleService: FeatureToggleService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    fun opprettTask() {
+        Thread.sleep(Random.nextLong(5_000)) // YOLO unngå feil med att 2 samtidige podder oppretter task
+        val finnesTask =
+            taskService.finnTaskMedPayloadOgType("finnBehandlingUtenOppgave", BehandlingUtenOppgaveTask.TYPE)
+        if (finnesTask == null) {
+            logger.info("Oppretter satsendring-task, da den ikke finnes fra før")
+            val task = BehandlingUtenOppgaveTask.opprettTask()
+            taskService.save(task)
+        }
+    }
+
+    fun validerHarIkkeÅpneBehandligerUtenOppgave() {
+        val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
+        val toUkerSiden = LocalDateTime.now().minusWeeks(2)
+        val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
+            behandlingService.hentGamleUferdigeBehandlinger(stønadstype, toUkerSiden)
+        }
+
+        val eksternFagsakIds =
+            gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
+
+        val alleOppgaver = oppgaveService.finnBehandleSakOppgaver()
+        val oppgaveSaksreferanser: List<String> = alleOppgaver.flatMap { it.oppgaver.mapNotNull { oppgave -> oppgave.saksreferanse } }
+        val fagsakerMedÅpenBehandlingSomManglerOppgave = eksternFagsakIds.filterNot { oppgaveSaksreferanser.contains(it) }
+
+        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
+        fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
+            logger.warn("Fagsaker med åpen behandling uten oppgave: $it")
+        }
+
+        val enabled = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
+        val harFunnetFagsakUtenOppgave = fagsakerMedÅpenBehandlingSomManglerOppgave.size > 0
+        feilHvis(enabled && harFunnetFagsakUtenOppgave){"Åpne behandlinger uten behandleSak oppgave funnet på fagsak "}
+
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -56,6 +56,5 @@ class BehandlingsoppgaveService(
         }
 
         return fagsakerMedÅpenBehandlingSomManglerOppgave.size
-
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -34,7 +34,7 @@ class BehandlingsoppgaveService(
         val finnesTask =
             taskService.finnTaskMedPayloadOgType(ukenummer.toString(), BehandlingUtenOppgaveTask.TYPE)
         if (finnesTask == null) {
-            logger.info("Oppretter satsendring-task, da den ikke finnes fra før")
+            logger.info("Oppretter finnBehandlingUtenOppgave-task, da den ikke finnes fra før")
             val task = BehandlingUtenOppgaveTask.opprettTask(ukenummer)
             taskService.save(task)
         }
@@ -44,7 +44,7 @@ class BehandlingsoppgaveService(
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
-            behandlingService.hentGamleUferdigeBehandlinger(stønadstype, toUkerSiden)
+            behandlingService.hentUferdigeBehandlingerOpprettetFørDato(stønadstype, toUkerSiden)
         }
 
         val eksternFagsakIds =
@@ -59,8 +59,8 @@ class BehandlingsoppgaveService(
             logger.warn("Fagsaker med åpen behandling uten oppgave: $it")
         }
 
-        val enabled = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
+        val skalKasteFeilHvisOppgaveMangler = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
         val harFunnetFagsakUtenOppgave = fagsakerMedÅpenBehandlingSomManglerOppgave.size > 0
-        feilHvis(enabled && harFunnetFagsakUtenOppgave) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
+        feilHvis(skalKasteFeilHvisOppgaveMangler && harFunnetFagsakUtenOppgave) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -2,9 +2,6 @@ package no.nav.familie.ef.sak.behandling.oppgavekontroll
 
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
@@ -22,7 +19,6 @@ class BehandlingsoppgaveService(
     val behandlingService: BehandlingService,
     val fagsakService: FagsakService,
     val oppgaveService: OppgaveService,
-    val featureToggleService: FeatureToggleService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -40,7 +36,7 @@ class BehandlingsoppgaveService(
         }
     }
 
-    fun loggÅpneBehandlingerUtenOppgave() {
+    fun antallÅpneBehandlingerUtenOppgave(): Int {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
         val toUkerSiden = LocalDateTime.now().minusWeeks(2)
         val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
@@ -59,8 +55,7 @@ class BehandlingsoppgaveService(
             logger.warn("Fagsaker med åpen behandling uten oppgave: $it")
         }
 
-        val skalKasteFeilHvisOppgaveMangler = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
-        val harFunnetFagsakUtenOppgave = fagsakerMedÅpenBehandlingSomManglerOppgave.size > 0
-        feilHvis(skalKasteFeilHvisOppgaveMangler && harFunnetFagsakUtenOppgave) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
+        return fagsakerMedÅpenBehandlingSomManglerOppgave.size
+
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -1,37 +1,18 @@
 package no.nav.familie.ef.sak.behandling.oppgavekontroll
 
-import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.oppgave.OppgaveService
-import no.nav.familie.kontrakter.felles.ef.StønadType
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
+import org.springframework.transaction.annotation.Transactional
 
 @Profile("!integrasjonstest")
 @Service
-class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingService: BehandlingService, val fagsakService: FagsakService, val oppgaveService: OppgaveService) {
+class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingsoppgaveService: BehandlingsoppgaveService) {
 
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    // @Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
+    // TODO @Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
     @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L)
-    fun opprettGOmregningTaskForBehandlingerMedUtdatertG() {
-        val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
-        val toUkerSiden = LocalDateTime.now().minusWeeks(2)
-        val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
-            behandlingService.hentGamleUferdigeBehandlinger(stønadstype, toUkerSiden)
-        }
-
-        val eksternFagsakIds = gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
-
-        val fagsakerMedÅpenBehandlingSomManglerOppgave: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
-
-        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
-        fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
-            logger.info("Fagsak med åpen behandling uten oppgave: $it")
-        }
+    @Transactional
+    fun sjekkOmViHarÅpneBehandlingerUtenOppgave() {
+        behandlingsoppgaveService.opprettTask()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -16,7 +16,7 @@ class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingService: BehandlingSer
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    //@Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
+    // @Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
     @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L)
     fun opprettGOmregningTaskForBehandlingerMedUtdatertG() {
         val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -11,7 +11,7 @@ class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingsoppgaveService: Behan
 
     @Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
     @Transactional
-    fun sjekkOmViHarÅpneBehandlingerUtenOppgave() {
+    fun opprettTaskFinnÅpneBehandlingerUtenOppgave() {
         behandlingsoppgaveService.opprettTask()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ef.sak.behandling.oppgavekontroll
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Profile("!integrasjonstest")
+@Service
+class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingService: BehandlingService, val fagsakService: FagsakService, val oppgaveService: OppgaveService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    //@Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
+    @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L)
+    fun opprettGOmregningTaskForBehandlingerMedUtdatertG() {
+        val stønadstyper = listOf(StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER, StønadType.BARNETILSYN)
+        val toUkerSiden = LocalDateTime.now().minusWeeks(2)
+        val gamleBehandlinger = stønadstyper.flatMap { stønadstype ->
+            behandlingService.hentGamleUferdigeBehandlinger(stønadstype, toUkerSiden)
+        }
+
+        val eksternFagsakIds = gamleBehandlinger.map { fagsakService.hentFagsakForBehandling(it.id).eksternId.id.toString() }
+
+        val fagsakerMedÅpenBehandlingSomManglerOppgave: List<String> = oppgaveService.finnFagsakerSomManglerOppgave(eksternFagsakIds)
+
+        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
+        fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
+            logger.info("Fagsak med åpen behandling uten oppgave: $it")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -9,7 +9,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingsoppgaveService: BehandlingsoppgaveService) {
 
-    @Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
+    //@Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
+    @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) // kun første kjøring
     @Transactional
     fun opprettTaskFinnÅpneBehandlingerUtenOppgave() {
         behandlingsoppgaveService.opprettTask()

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -9,8 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingsoppgaveService: BehandlingsoppgaveService) {
 
-    // TODO @Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
-    @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L)
+    @Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
     @Transactional
     fun sjekkOmViHarÅpneBehandlingerUtenOppgave() {
         behandlingsoppgaveService.opprettTask()

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/ÅpneBehandlingerUtenOppgaveScheduler.kt
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ÅpneBehandlingerUtenOppgaveScheduler(val behandlingsoppgaveService: BehandlingsoppgaveService) {
 
-    //@Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
+    // @Scheduled(cron = "\${FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION}")
     @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) // kun første kjøring
     @Transactional
     fun opprettTaskFinnÅpneBehandlingerUtenOppgave() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -33,7 +33,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     FRONTEND_VIS_INNTEKT_PERSONOVERSIKT("familie.ef.sak.frontend.vis-inntekt-personoversikt"),
     SETT_PÅ_VENT_MED_OPPGAVESTYRING("familie.ef.sak.sett-paa-vent-med-oppgavestyring"),
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),
-    KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-på-åpen-behandling"),
+    KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-pa-apen-behandling"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -33,6 +33,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     FRONTEND_VIS_INNTEKT_PERSONOVERSIKT("familie.ef.sak.frontend.vis-inntekt-personoversikt"),
     SETT_PÅ_VENT_MED_OPPGAVESTYRING("familie.ef.sak.sett-paa-vent-med-oppgavestyring"),
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),
+    KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-på-åpen-behandling"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.ENHET_NR_NAY
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -308,7 +309,7 @@ class OppgaveService(
         }
     }
 
-    fun finnFagsakerSomManglerOppgave(fagsakEksternId: List<String>): List<String> {
+    fun finnBehandleSakOppgaver(): List<FinnOppgaveResponseDto> {
         val oppgaveTyper =
             listOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUderkjentVedtak, Oppgavetype.GodkjenneVedtak)
 
@@ -328,12 +329,7 @@ class OppgaveService(
                 ),
             )
         }
-
-        if (alleOppgaver.any { it.antallTreffTotalt >= limit }) {
-            error("For mange oppgaver, kan ikke sjekke mot behandlinger som mangler oppgave. ")
-        }
-
-        val oppgaveSaksreferanser: List<String> = alleOppgaver.flatMap { it.oppgaver.mapNotNull { oppgave -> oppgave.saksreferanse } }
-        return fagsakEksternId.filterNot { oppgaveSaksreferanser.contains(it) }
+        feilHvis(alleOppgaver.any { it.antallTreffTotalt >= limit }) {"For mange oppgaver - limit truffet: + $limit "}
+        return alleOppgaver.toList()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -134,7 +134,7 @@ class OppgaveService(
             val mapper = finnMapper(enhetsnummer)
             val mappeIdForGodkjenneVedtak = mapper.find {
                 (it.navn.contains("70 Godkjennevedtak") || it.navn.contains("70 Godkjenne vedtak")) &&
-                        !it.navn.contains("EF Sak")
+                    !it.navn.contains("EF Sak")
             }?.id?.toLong()
             mappeIdForGodkjenneVedtak?.let {
                 logger.info("Legger oppgave i Godkjenne vedtak-mappe")
@@ -329,7 +329,7 @@ class OppgaveService(
                 ),
             )
         }
-        feilHvis(alleOppgaver.any { it.antallTreffTotalt >= limit }) {"For mange oppgaver - limit truffet: + $limit "}
+        feilHvis(alleOppgaver.any { it.antallTreffTotalt >= limit }) { "For mange oppgaver - limit truffet: + $limit " }
         return alleOppgaver.toList()
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -239,10 +239,10 @@ class OppgaveService(
         } else {
             ""
         } +
-                "----- Opprettet av familie-ef-sak ${
-                    LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
-                } --- \n" +
-                "$frontendOppgaveUrl" + "\n----- Oppgave må behandles i ny løsning"
+            "----- Opprettet av familie-ef-sak ${
+                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
+            } --- \n" +
+            "$frontendOppgaveUrl" + "\n----- Oppgave må behandles i ny løsning"
     }
 
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
@@ -293,7 +293,7 @@ class OppgaveService(
             if (mappeRespons.antallTreffTotalt > mappeRespons.mapper.size) {
                 logger.error(
                     "Det finnes flere mapper (${mappeRespons.antallTreffTotalt}) " +
-                            "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. ",
+                        "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. ",
                 )
             }
             mappeRespons.mapper
@@ -322,10 +322,10 @@ class OppgaveService(
                         finnOppgaveRequest = FinnOppgaveRequest(
                             tema = Tema.ENF,
                             oppgavetype = it,
-                            limit = limit
-                        )
-                    )
-                )
+                            limit = limit,
+                        ),
+                    ),
+                ),
             )
         }
 
@@ -333,7 +333,7 @@ class OppgaveService(
             error("For mange oppgaver, kan ikke sjekke mot behandlinger som mangler oppgave. ")
         }
 
-        val oppgaveSaksreferanser :List<String>  = alleOppgaver.flatMap { it.oppgaver.mapNotNull { oppgave -> oppgave.saksreferanse } }
-        return fagsakEksternId.filterNot{ oppgaveSaksreferanser.contains(it)  }
+        val oppgaveSaksreferanser: List<String> = alleOppgaver.flatMap { it.oppgaver.mapNotNull { oppgave -> oppgave.saksreferanse } }
+        return fagsakEksternId.filterNot { oppgaveSaksreferanser.contains(it) }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/OppgaveEfDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/OppgaveEfDto.kt
@@ -2,11 +2,11 @@ package no.nav.familie.ef.sak.oppgave.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonInclude
+import jakarta.validation.constraints.Pattern
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
-import jakarta.validation.constraints.Pattern
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -238,7 +238,7 @@ FRONTEND_OPPGAVE_URL: https://ensligmorellerfar.intern.nav.no/oppgavebenk
 GYLDIGE_SERVICE_BRUKERE: srvArena
 
 G_OMREGNING_CRON_EXPRESSION: 0 0 15 * * WED
-
+FINN_BEHANDLINGER_UTEN_OPPGAVE_CRON_EXPRESSION: 0 0 8 * * MON
 
 rolle:
   veileder: "31778fd8-3b71-4867-8db6-a81235fbe001"

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveServiceTest.kt
@@ -4,34 +4,44 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.EksternFagsakId
 import no.nav.familie.ef.sak.oppgave.OppgaveService
-import no.nav.familie.ef.sak.vedtak.NullstillVedtakService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
-import org.springframework.http.HttpStatus
 
-class BehandlingsoppgaveServiceTest(){
-
+class BehandlingsoppgaveServiceTest {
 
     private val taskService = mockk<TaskService>(relaxed = true)
     private val behandlingService: BehandlingService = mockk()
-    private val fagsakService: FagsakService= mockk()
+    private val fagsakService: FagsakService = mockk()
     private val oppgaveService: OppgaveService = mockk()
 
     val behandlingsoppgaveService = BehandlingsoppgaveService(taskService, behandlingService, fagsakService, oppgaveService)
 
     @Test
     internal fun `Skal returnere riktig antall uten oppgave når vi finner to`() {
-      //  every {  }
+        val returnGamleÅpneBehandlinger = listOf(behandling(), behandling(), behandling())
+        every { behandlingService.hentUferdigeBehandlingerOpprettetFørDato(StønadType.OVERGANGSSTØNAD, any()) } returns returnGamleÅpneBehandlinger
+        every { behandlingService.hentUferdigeBehandlingerOpprettetFørDato(StønadType.BARNETILSYN, any()) } returns emptyList()
+        every { behandlingService.hentUferdigeBehandlingerOpprettetFørDato(StønadType.SKOLEPENGER, any()) } returns emptyList()
+
+        val fagsakMedOppgave = fagsak(eksternId = EksternFagsakId(0))
+        every { fagsakService.hentFagsakForBehandling(returnGamleÅpneBehandlinger[0].id) } returns fagsakMedOppgave
+        every { fagsakService.hentFagsakForBehandling(returnGamleÅpneBehandlinger[1].id) } returns fagsak(eksternId = EksternFagsakId(1))
+        every { fagsakService.hentFagsakForBehandling(returnGamleÅpneBehandlinger[2].id) } returns fagsak(eksternId = EksternFagsakId(2))
+
+        every { oppgaveService.finnBehandleSakOppgaver() } returns listOf(
+            FinnOppgaveResponseDto(1, listOf(Oppgave(saksreferanse = fagsakMedOppgave.eksternId.id.toString()))),
+        )
 
         val antallÅpneBehandlingerUtenOppgave = behandlingsoppgaveService.antallÅpneBehandlingerUtenOppgave()
 
-
         Assertions.assertThat(antallÅpneBehandlingerUtenOppgave).isEqualTo(2)
-
-
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveServiceTest.kt
@@ -1,0 +1,37 @@
+package no.nav.familie.ef.sak.behandling.oppgavekontroll
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.vedtak.NullstillVedtakService
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class BehandlingsoppgaveServiceTest(){
+
+
+    private val taskService = mockk<TaskService>(relaxed = true)
+    private val behandlingService: BehandlingService = mockk()
+    private val fagsakService: FagsakService= mockk()
+    private val oppgaveService: OppgaveService = mockk()
+
+    val behandlingsoppgaveService = BehandlingsoppgaveService(taskService, behandlingService, fagsakService, oppgaveService)
+
+    @Test
+    internal fun `Skal returnere riktig antall uten oppgave når vi finner to`() {
+      //  every {  }
+
+        val antallÅpneBehandlingerUtenOppgave = behandlingsoppgaveService.antallÅpneBehandlingerUtenOppgave()
+
+
+        Assertions.assertThat(antallÅpneBehandlingerUtenOppgave).isEqualTo(2)
+
+
+    }
+
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -100,7 +100,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         behandlingRepository.insert(behandling(annenFagsak, opprettetTid = LocalDateTime.now().minusWeeks(1)))
 
         assertThat(
-            behandlingRepository.hentUferdigeBehandlingerFørDato(
+            behandlingRepository.hentUferdigeBehandlingerOpprettetFørDato(
                 OVERGANGSSTØNAD,
                 enMånedSiden,
             ),

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/FagsakRepositoryTest.kt
@@ -98,7 +98,7 @@ internal class FagsakRepositoryTest : OppslagSpringRunnerTest() {
                     fagsak.personIdenter.first().ident,
                     2022,
                     grunnbeløpsmåned = YearMonth.of(2021, 5),
-                    samordningsfradrag = 1500
+                    samordningsfradrag = 1500,
                 ),
             )
             assertThat(fagsakRepository.finnFerdigstilteFagsakerMedUtdatertGBelop(LocalDate.of(2022, 5, 1))).isEmpty()

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingClientTest.kt
@@ -34,7 +34,7 @@ internal class TilbakekrevingClientTest {
             "/api/ytelsestype/$encodedStønadstype/fagsak/$eksternFagsakId/kanBehandlingOpprettesManuelt/v1"
         wiremockServerItem.stubFor(
             WireMock.get(WireMock.urlEqualTo(url))
-                .willReturn(WireMock.okJson(jsonResponse))
+                .willReturn(WireMock.okJson(jsonResponse)),
         )
         val kanBehandlingOpprettesManuelt =
             client.kanBehandlingOpprettesManuelt(StønadType.OVERGANGSSTØNAD, eksternFagsakId)


### PR DESCRIPTION
Ønsker å finne åpne behandlinger uten oppgave. 

Løsning: 
Sjekker alle behandlinger som har vært åpne i mer enn to uker. Henter alle "behandle sak oppgaver" (BehandleSak,BehandleUderkjentVedtak,GodkjenneVedtak) og sjekker om det er noen av våre åpne behandlinger som ikke har en tilsvarende eksternid lagret i saksreferanse på en av oppgavene vi har hentet ut.  

Kjøres hver mandag med en ny task. 

Tasken vil feile dersom toggle er skrudd på og vi finner behandling uten oppgave.  