### PR TITLE
Forsøk på å fikse test som feiler av og til

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -173,7 +173,9 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         val sivilstandVilkårForRevurdering = vilkårRevurdering.first { it.type == VilkårType.SIVILSTAND }
         val aleneomsorgVilkårForBehandling = vilkårBehandling.first { it.type == VilkårType.ALENEOMSORG }
         val aleneomsorgVilkårForRevurdering = vilkårRevurdering.first { it.type == VilkårType.ALENEOMSORG }
-        val barnPåBehandling = barnRepository.findByBehandlingId(revurdering.id).first()
+        val barnPåBehandling = barnRepository.findByBehandlingId(revurdering.id).first {
+            it.navn.equals("Barn Barnesen")
+        }
 
         assertThat(vilkårRevurdering).hasSize(vilkårBehandling.size)
 


### PR DESCRIPTION
Ser i PR at test feilet uten at relevant kode er endret: https://github.com/navikt/familie-ef-sak/pull/2187

Det kan se ut til at db noen ganger returnerer barn nr 2 som første element i lista noen ganger. Lager en fix som filtrerer på hvilket barn som hentes ut.

