### PR TITLE
Oppretter task med nyeste grunnbeløpsmåned i payload for å sikre ulikhet på tasks ved ny g-omregning.

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskTest.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ef.sak.behandling.grunnbelop
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
+import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -39,6 +41,18 @@ internal class GOmregningTaskTest {
         gOmregningTask.opprettTask(UUID.randomUUID())
 
         assertThat(taskSlot.captured.callId).isNotEqualTo(callId)
+    }
+
+
+    @Test
+    internal fun `skal opprette task med grunnbeløpsmåned i payload`() {
+        val fagsakId = UUID.randomUUID()
+        val payload = objectMapper.writeValueAsString(GOmregningPayload(fagsakId, nyesteGrunnbeløpGyldigFraOgMed))
+        every { taskService.finnTaskMedPayloadOgType(any(), any()) } returns null
+
+        gOmregningTask.opprettTask(fagsakId)
+
+        assertThat(taskSlot.captured.payload).isEqualTo(payload)
     }
 
     @Test


### PR DESCRIPTION
✨ **Hvorfor gjøres dette?** ✨ 
I teorien kan det være en g-omregning task som har blitt gjort for en fagsak rett før ny g-beregning. Siden fullførte tasks lever i tre mnd i db før de slettes, så kan det allerede finnes en task med samme fagsak i payload, og det vil dermed ikke g-omregnes fordi tasken allerede finnes. I denne PR'n legges nyeste grunnbeløpsmåned til i payload for at task blir ulik mellom hver g-omregning.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12360)