### PR TITLE
Rekkefølge oppgavebeskrivelse ved sett på vent

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -116,7 +116,7 @@ class BehandlingPåVentService(
         val skalOppdatereBeskrivelse = harEndringer || beskrivelse.isNotBlank()
         val tidligereBeskrivelse =
             if (skalOppdatereBeskrivelse && oppgave.beskrivelse?.isNotBlank() == true) {
-                "\n${oppgave.beskrivelse.orEmpty()}"
+                "\n\n${oppgave.beskrivelse.orEmpty()}"
             } else {
                 oppgave.beskrivelse.orEmpty()
             }
@@ -125,7 +125,7 @@ class BehandlingPåVentService(
 
         val nyBeskrivelse =
             if (skalOppdatereBeskrivelse) {
-                prefix + tilordnetSaksbehandler + prioritet + frist + mappe + beskrivelse + tidligereBeskrivelse
+                prefix + beskrivelse + tilordnetSaksbehandler + prioritet + frist + mappe + tidligereBeskrivelse
             } else {
                 tidligereBeskrivelse
             }
@@ -148,8 +148,8 @@ class BehandlingPåVentService(
     ): String {
         return when {
             settPåVentRequest.beskrivelse.isBlank() -> ""
-            harEndringer -> "\n${settPåVentRequest.beskrivelse}\n"
-            else -> "${settPåVentRequest.beskrivelse}\n"
+            harEndringer -> "${settPåVentRequest.beskrivelse}\n\n"
+            else -> "${settPåVentRequest.beskrivelse}\n\n"
         }
     }
 

--- a/src/test/resources/no/nav/familie/ef/sak/settPåVent/sett_behanlding_på_vent.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/settPåVent/sett_behanlding_på_vent.feature
@@ -29,12 +29,13 @@ Egenskap: Sett behandling på vent og oppdater oppgave
     Så forventer vi følgende beskrivelse på oppgaven
     """
  --- 25.10.2020 13:34 System (VL) ---
+  Tekst fra saksbehandler
+
   Oppgave flyttet fra saksbehandler Ola til Kari
   Oppgave endret fra prioritet NORM til HOY
   Oppgave endret frist fra 2023-03-18 til 2023-03-24
   Oppgave flyttet fra mappe søknad til venter på dokumentasjon
 
-  Tekst fra saksbehandler
 
   Gammel beskrivelse
     """
@@ -71,6 +72,7 @@ Egenskap: Sett behandling på vent og oppdater oppgave
     """
     --- 25.10.2020 13:34 System (VL) ---
   Oppgave flyttet fra saksbehandler Ola til Kari
+
 
   Gammel beskrivelse
     """
@@ -179,11 +181,11 @@ Egenskap: Sett behandling på vent og oppdater oppgave
     Så forventer vi følgende beskrivelse på oppgaven
     """
     --- 25.10.2020 13:34 System (VL) ---
-  Oppgave flyttet fra saksbehandler Ola til <ingen>
-
   Har lagt inn en ny beskrivelse.
 
   Den kan også være formatert
+
+  Oppgave flyttet fra saksbehandler Ola til <ingen>
     """
 
     Så forventer vi at oppgaven er oppdatert med
@@ -216,9 +218,9 @@ Egenskap: Sett behandling på vent og oppdater oppgave
     Så forventer vi følgende beskrivelse på oppgaven
     """
     --- 25.10.2020 13:34 System (VL) ---
-  Oppgave flyttet fra saksbehandler Ola til Rita
-
   Sendt til Rita
+
+  Oppgave flyttet fra saksbehandler Ola til Rita
     """
 
     Så forventer vi at oppgaven er oppdatert med
@@ -249,9 +251,9 @@ Egenskap: Sett behandling på vent og oppdater oppgave
     Så forventer vi følgende beskrivelse på oppgaven
     """
 --- 25.10.2020 13:34 System (VL) ---
-Oppgave endret frist fra 2023-03-18 til 2023-03-19
-
 Venter på bruker
+
+Oppgave endret frist fra 2023-03-18 til 2023-03-19
     """
 
     Så forventer vi at oppgaven er oppdatert med


### PR DESCRIPTION
Når oppgave oppdateres via Sett på vent i EF Sak, må tekstbeskrivelsen legge seg før endringsinnslag i beskrivelseshistorikken. Til nå har endringsinnslagene kommet før saksbehandler beskrivelse

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12404)