### PR TITLE
Skal ikke validere G ved iverksetting av opphør

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -123,7 +123,7 @@ class IverksettingDtoMapper(
         val tilkjentYtelse =
             if (vedtak.resultatType != ResultatType.AVSLÅ) tilkjentYtelseService.hentForBehandling(saksbehandling.id) else null
 
-        if (tilkjentYtelse != null) validerGrunnbeløpsmåned(tilkjentYtelse)
+        if (tilkjentYtelse != null && vedtak.resultatType != ResultatType.OPPHØRT) validerGrunnbeløpsmåned(tilkjentYtelse)
         val vilkårsvurderinger = vilkårsvurderingRepository.findByBehandlingId(saksbehandling.id)
 
         val behandlingsdetaljer = mapBehandlingsdetaljer(saksbehandling, vilkårsvurderinger)
@@ -189,7 +189,7 @@ class IverksettingDtoMapper(
     private fun validerGrunnbeløpsmåned(tilkjentYtelse: TilkjentYtelse) {
         val gMånedTilkjentYtelse = tilkjentYtelse.grunnbeløpsmåned
         val feilmelding =
-            "Kan ikke iverksette med utdatert grunnbeløp gyldig fra $gMånedTilkjentYtelse. Denne behandlingen må beregnes og simmuleres på nytt"
+            "Kan ikke iverksette med utdatert grunnbeløp gyldig fra $gMånedTilkjentYtelse. Denne behandlingen må beregnes og simuleres på nytt"
 
         val nyttGrunnbeløpForInneværendeÅrRegistrertIEF = nyesteGrunnbeløpGyldigFraOgMed.year == DatoUtil.inneværendeÅr()
         val fristGOmregning = LocalDate.of(DatoUtil.inneværendeÅr(), Month.JUNE, 15)


### PR DESCRIPTION
**Hvorfor gjør vi dette?**
Det er meldt inn en feil på teams der saksbehandler ikke fikk besluttet/iverksatt en behandling pga. utdatert G-måned. Behandlingen var et opphør og TilkjentYtelse var derfor ikke oppdatert med den nyeste G-måned. G-Måned/grunnbeløp brukes ikke til noen ting ved opphør, og det gir derfor ikke mening å oppdatere G-måned. Derfor velger vi å ikke validere G-måned dersom vedtaksresultatet er OPPHØRT.