### PR TITLE
Vil legge til rette for migrering hvor siste periode i infotrygd er mer enn 3 år siden.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleConfig.kt
@@ -79,9 +79,6 @@ class FeatureToggleConfig(
                 if (unleash.environment == "local") {
                     return true
                 }
-                if (toggle == Toggle.SETT_PÅ_VENT_MED_OPPGAVESTYRING) {
-                    return false
-                }
                 return defaultValue
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -38,7 +38,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),
     VURDER_KONSEKVENS_OPPGAVER_LOKALKONTOR("familie.ef.sak.automatiske-oppgaver-lokalkontor"),
     KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-pa-apen-behandling"),
-    TILLAT_MIGRERING_5_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-5-ar-tilbake"),
+    TILLAT_MIGRERING_5_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-5-ar-tilbake", "Permission"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -20,7 +20,10 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
 
     SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS("familie.ef.sak.bruk-nye-maxsatser"),
 
-    OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST("familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost", "Permission"),
+    OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST(
+        "familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost",
+        "Permission",
+    ),
     BEHANDLING_KORRIGERING("familie.ef.sak.behandling-korrigering", "Permission"),
 
     VILKÅR_GJENBRUK("familie.ef.sak.vilkaar-gjenruk"),
@@ -35,6 +38,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     PERSONOPPLYSNINGER_ENDRINGER("familie.ef.sak.frontend.personopplysninger-endringer"),
     VURDER_KONSEKVENS_OPPGAVER_LOKALKONTOR("familie.ef.sak.automatiske-oppgaver-lokalkontor"),
     KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-pa-apen-behandling"),
+    TILLAT_MIGRERING_5_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-5-ar-tilbake"),
     ;
 
     companion object {

--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -30,6 +30,7 @@ fun main(args: Array<String>) {
             "mock-klage",
             "mock-sigrun",
             "mock-historiskpensjon",
+            "mock-featuretoggle",
         )
         .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -34,6 +34,7 @@ fun main(args: Array<String>) {
             "mock-klage",
             "mock-sigrun",
             "mock-historiskpensjon",
+            "mock-featuretoggle",
         )
         .properties(properties)
         .run(*args)

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -74,6 +74,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
     "mock-sigrun",
     "mock-dokument",
     "mock-historiskpensjon",
+    "mock-featuretoggle",
 )
 @EnableMockOAuth2Server
 abstract class OppslagSpringRunnerTest {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSak
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResultat
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakType
-import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.ef.StønadType.BARNETILSYN
 import no.nav.familie.kontrakter.felles.ef.StønadType.OVERGANGSSTØNAD
 import org.assertj.core.api.Assertions.assertThat
@@ -52,22 +51,22 @@ internal class InfotrygdPeriodeValideringServiceTest {
         internal fun `skal kunne journalføre når personen ikke har noen saker i infotrygd`() {
             every { infotrygdService.hentDtoPerioder(personIdent) } returns infotrygdPerioderDto(emptyList())
 
-            service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(personIdent, StønadType.OVERGANGSSTØNAD)
+            service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(personIdent, OVERGANGSSTØNAD)
         }
 
         @Test
         internal fun `skal kunne journalføre når det ikke trengs migrering - når personen har perioder langt bak i tiden`() {
             val dato = YearMonth.now().minusYears(4)
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(
-                        listOf(
-                            lagInfotrygdPeriode(
-                                personIdent = "1",
-                                stønadFom = dato.atDay(1),
-                                stønadTom = dato.atEndOfMonth(),
-                            ),
+                infotrygdPerioderDto(
+                    listOf(
+                        lagInfotrygdPeriode(
+                            personIdent = "1",
+                            stønadFom = dato.atDay(1),
+                            stønadTom = dato.atEndOfMonth(),
                         ),
-                    )
+                    ),
+                )
             service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(personIdent, OVERGANGSSTØNAD)
         }
 
@@ -75,28 +74,28 @@ internal class InfotrygdPeriodeValideringServiceTest {
         internal fun `kan journalføre hvis det kun finnes perioder bak i tiden med 0-beløp`() {
             val dato = YearMonth.now().minusYears(1)
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(
-                        listOf(
-                            lagInfotrygdPeriode(
-                                personIdent = "1",
-                                stønadFom = dato.atDay(1),
-                                stønadTom = dato.atEndOfMonth(),
-                                beløp = 0,
-                            ),
+                infotrygdPerioderDto(
+                    listOf(
+                        lagInfotrygdPeriode(
+                            personIdent = "1",
+                            stønadFom = dato.atDay(1),
+                            stønadTom = dato.atEndOfMonth(),
+                            beløp = 0,
                         ),
-                    )
+                    ),
+                )
             service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(personIdent, OVERGANGSSTØNAD)
         }
 
         @Test
         internal fun `kan ikke journalføre når personen har periode`() {
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(listOf(lagInfotrygdPeriode()))
+                infotrygdPerioderDto(listOf(lagInfotrygdPeriode()))
 
             assertThatThrownBy {
                 service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(
                     personIdent,
-                    StønadType.OVERGANGSSTØNAD,
+                    OVERGANGSSTØNAD,
                 )
             }
                 .isInstanceOf(ApiFeil::class.java)
@@ -105,17 +104,17 @@ internal class InfotrygdPeriodeValideringServiceTest {
         @Test
         internal fun `kan ikke journalføre når det finnes flere identer på perioder i infotrygd`() {
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(
-                        listOf(
-                            lagInfotrygdPeriode(personIdent = "1", vedtakId = 1),
-                            lagInfotrygdPeriode(personIdent = "2", vedtakId = 2),
-                        ),
-                    )
+                infotrygdPerioderDto(
+                    listOf(
+                        lagInfotrygdPeriode(personIdent = "1", vedtakId = 1),
+                        lagInfotrygdPeriode(personIdent = "2", vedtakId = 2),
+                    ),
+                )
 
             assertThatThrownBy {
                 service.validerKanOppretteBehandlingUtenÅMigrereOvergangsstønad(
                     personIdent,
-                    StønadType.OVERGANGSSTØNAD,
+                    OVERGANGSSTØNAD,
                 )
             }
                 .isInstanceOf(ApiFeil::class.java)
@@ -128,20 +127,20 @@ internal class InfotrygdPeriodeValideringServiceTest {
         internal fun `Skal kaste feil hvis perioder er mer enn tre år tilbake i tid`() {
             val dato = YearMonth.now().minusYears(4)
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(
-                        listOf(
-                            lagInfotrygdPeriode(
-                                personIdent = "1",
-                                stønadFom = dato.atDay(1),
-                                stønadTom = dato.atEndOfMonth(),
-                            ),
+                infotrygdPerioderDto(
+                    listOf(
+                        lagInfotrygdPeriode(
+                            personIdent = "1",
+                            stønadFom = dato.atDay(1),
+                            stønadTom = dato.atEndOfMonth(),
                         ),
-                    )
+                    ),
+                )
             val message =
                 assertThrows<MigreringException> {
                     service.hentPeriodeForMigrering(
                         personIdent,
-                        OVERGANGSSTØNAD
+                        OVERGANGSSTØNAD,
                     )
                 }.message
             assertThat(message).contains("Kan ikke migrere når forrige utbetaling i infotrygd er mer enn 3 år tilbake i tid")
@@ -152,22 +151,23 @@ internal class InfotrygdPeriodeValideringServiceTest {
             val dato = YearMonth.now().minusYears(4)
             every { featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE) } returns true
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
-                    infotrygdPerioderDto(
-                        listOf(
-                            lagInfotrygdPeriode(
-                                personIdent = "1",
-                                stønadFom = dato.atDay(1),
-                                stønadTom = dato.atEndOfMonth(),
-                            ),
+                infotrygdPerioderDto(
+                    listOf(
+                        lagInfotrygdPeriode(
+                            personIdent = "1",
+                            stønadFom = dato.atDay(1),
+                            stønadTom = dato.atEndOfMonth(),
                         ),
-                    )
+                    ),
+                )
 
-            assertThat(service.hentPeriodeForMigrering(
-                personIdent,
-                OVERGANGSSTØNAD
-            )).isNotNull
+            assertThat(
+                service.hentPeriodeForMigrering(
+                    personIdent,
+                    OVERGANGSSTØNAD,
+                ),
+            ).isNotNull
         }
-
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -1,0 +1,24 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+class FeatureToggleMock {
+
+    @Profile("mock-featuretoggle")
+    @Bean
+    @Primary
+    fun featureToggleService(): FeatureToggleService {
+        val mockk = mockk<FeatureToggleService>()
+        every { mockk.isEnabled(any()) } returns true
+        every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE) } returns false
+        return mockk
+    }
+}


### PR DESCRIPTION
**Hvorfor?** 
Vi har en sak i prod som saksbehandlere ønsker å revurdere (opphøre) hvor siste periode er mer enn 3 år gammel. Vi antar også at det kan komme flere slike med eøs. 

Vi ønsker derfor å åpne for at saksbehandlere på "toggle-liste" kan migrere slike 
https://unleash.nais.io/#/features/strategies/familie.ef.sak.tillat-migrering-5-ar-tilbake
Nå kun M. på denne lista.

Setter til 5 år etter diskusjon mer funksjonelle. 

Vil legge til rette for migrering av saker der infotrygd-periode mer enn 3 år bak i tid. Vil med denne endringen tillate opp til 5 år hvis saksbehandler i liste (toggle) hvor dette er tillatt.

Favro:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12461