### PR TITLE
Ved opprettelse av fremleggsoppgaver skal det bare sjekkes om det fin…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgaveforopprettelse/OppgaverForOpprettelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgaveforopprettelse/OppgaverForOpprettelseService.kt
@@ -1,9 +1,5 @@
 package no.nav.familie.ef.sak.behandling.oppgaveforopprettelse
 
-import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.domain.Behandling
-import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
-import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
@@ -17,7 +13,6 @@ import java.util.UUID
 @Service
 class OppgaverForOpprettelseService(
     private val oppgaverForOpprettelseRepository: OppgaverForOpprettelseRepository,
-    private val behandlingService: BehandlingService,
     private val tilkjentYtelseService: TilkjentYtelseService,
 ) {
 
@@ -42,9 +37,8 @@ class OppgaverForOpprettelseService(
     }
 
     fun hentOppgavetyperSomKanOpprettes(behandlingId: UUID): List<OppgaveForOpprettelseType> {
-        val behandling = behandlingService.hentBehandling(behandlingId)
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandlingEllerNull(behandlingId)
-        val kanOppretteInntektskontroll = kanOppretteOppgaveForInntektskontrollFremITid(behandling, tilkjentYtelse)
+        val kanOppretteInntektskontroll = kanOppretteOppgaveForInntektskontrollFremITid(tilkjentYtelse)
 
         return if (kanOppretteInntektskontroll) listOf(OppgaveForOpprettelseType.INNTEKTSKONTROLL_1_ÅR_FREM_I_TID) else emptyList()
     }
@@ -52,7 +46,6 @@ class OppgaverForOpprettelseService(
     fun initialVerdierForOppgaverSomSkalOpprettes(behandlingId: UUID) = hentOppgavetyperSomKanOpprettes(behandlingId)
 
     private fun kanOppretteOppgaveForInntektskontrollFremITid(
-        behandling: Behandling,
         tilkjentYtelse: TilkjentYtelse?,
     ): Boolean {
         if (tilkjentYtelse == null) return false
@@ -61,17 +54,7 @@ class OppgaverForOpprettelseService(
             .filter { it.stønadTom > LocalDate.now().plusYears(1) }
             .any { it.beløp > 0 }
 
-        return harUtbetalingEtterDetNesteÅret &&
-            (behandlingErFørstegangs(behandling) || forrigeErFørstegangsOgAvslåttEllerHenlagt(behandling))
-    }
-
-    private fun behandlingErFørstegangs(behandling: Behandling) =
-        behandling.type == BehandlingType.FØRSTEGANGSBEHANDLING
-
-    private fun forrigeErFørstegangsOgAvslåttEllerHenlagt(behandling: Behandling): Boolean {
-        val forrigeBehandling = behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it) }
-        return forrigeBehandling?.type == BehandlingType.FØRSTEGANGSBEHANDLING &&
-            (forrigeBehandling.resultat == BehandlingResultat.AVSLÅTT || forrigeBehandling.resultat == BehandlingResultat.HENLAGT)
+        return harUtbetalingEtterDetNesteÅret
     }
 
     fun slettOppgaverForOpprettelse(behandlingId: UUID) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgaveforopprettelse/OppgaverForOpprettelseService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgaveforopprettelse/OppgaverForOpprettelseService.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ef.sak.behandling.oppgaveforopprettelse
 
+import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForOpprettelseType
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,6 +15,7 @@ import java.util.UUID
 @Service
 class OppgaverForOpprettelseService(
     private val oppgaverForOpprettelseRepository: OppgaverForOpprettelseRepository,
+    private val behandlingService: BehandlingService,
     private val tilkjentYtelseService: TilkjentYtelseService,
 ) {
 
@@ -37,6 +40,10 @@ class OppgaverForOpprettelseService(
     }
 
     fun hentOppgavetyperSomKanOpprettes(behandlingId: UUID): List<OppgaveForOpprettelseType> {
+        val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
+        if (saksbehandling.stønadstype != StønadType.OVERGANGSSTØNAD) {
+            return emptyList()
+        }
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandlingEllerNull(behandlingId)
         val kanOppretteInntektskontroll = kanOppretteOppgaveForInntektskontrollFremITid(tilkjentYtelse)
 


### PR DESCRIPTION
…nes andeler ett år frem i tid

Hvorfor :
Ved opprettelse av fremleggsoppgaver, så var det tidligere enighet om å gjøre dette for førstegangsbehandlinger og noen revurderinger :[#2212](https://github.com/navikt/familie-ef-sak/pull/2212)

Nå satser vi på å gjøre dette for både førstegangsbehandlinger og revurderinger (alle). Derfor sjekker vi bare om det finnes andeler ett år frem i tid, og i så fall, så kan fremleggsoppgave opprettes.

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12474