### PR TITLE
Inntektsjustering ved g-omregning…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
@@ -99,7 +99,6 @@ object BeregningUtils {
                 val justertInntekt = inntekt.multiply(faktor).rundNedTilNærmesteKrone()
                 val justertDagsatsInntekt = dagsats?.multiply(faktor)?.rundNedTilNærmesteKrone()
                 val justertMånedinntekt = månedsinntekt?.multiply(faktor)?.rundNedTilNærmesteKrone()
-                // avrunding gjøres i beregning
                 Inntektsperiode(
                     periode = grunnbeløp.periode,
                     dagsats = justertDagsatsInntekt,

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/util/Utregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/util/Utregning.kt
@@ -14,4 +14,8 @@ object Utregning {
         val beløpSomHeltal = beløp.setScale(0, RoundingMode.FLOOR).toLong()
         return (beløpSomHeltal / 1000L) * 1000L
     }
+
+    fun BigDecimal.rundNedTilNærmesteKrone(): BigDecimal {
+        return this.setScale(0, RoundingMode.FLOOR)
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtilsTest.kt
@@ -234,7 +234,7 @@ internal class BeregningUtilsTest {
 
             assertThat(indeksjusterInntekt.first()).isEqualTo(inntektsperioder.first())
             assertThat(indeksjusterInntekt[1].periode).isEqualTo(inntektsperioder[1].periode)
-            assertThat(indeksjusterInntekt[1].inntekt).isEqualTo(209_900.toBigDecimal())
+            assertThat(indeksjusterInntekt[1].inntekt).isEqualTo(209_961.toBigDecimal()) // runder ikke av inntektsgrunnlag
             assertThat(indeksjusterInntekt[1].samordningsfradrag).isEqualTo(inntektsperioder[1].samordningsfradrag)
         }
 
@@ -272,7 +272,7 @@ internal class BeregningUtilsTest {
             assertThat(indeksjusterInntekt[1].samordningsfradrag).isEqualTo(inntektsperioder[1].samordningsfradrag)
             assertThat(indeksjusterInntekt[2].periode.fomDato).isEqualTo(LocalDate.of(2021, 5, 1))
             assertThat(indeksjusterInntekt[2].periode.tom).isEqualTo(inntektsperioder[1].periode.tom)
-            assertThat(indeksjusterInntekt[2].inntekt).isEqualTo(209_900.toBigDecimal())
+            assertThat(indeksjusterInntekt[2].inntekt).isEqualTo(209_961.toBigDecimal())
             assertThat(indeksjusterInntekt[2].samordningsfradrag).isEqualTo(inntektsperioder[1].samordningsfradrag)
         }
 
@@ -304,7 +304,7 @@ internal class BeregningUtilsTest {
             )
 
             assertThat(indeksjusterInntekt.first().periode).isEqualTo(inntektsperioder.first().periode)
-            assertThat(indeksjusterInntekt.first().inntekt).isEqualTo(202_900.toBigDecimal())
+            assertThat(indeksjusterInntekt.first().inntekt).isEqualTo(202_990.toBigDecimal())
             assertThat(indeksjusterInntekt.first().samordningsfradrag).isEqualTo(inntektsperioder.first().samordningsfradrag)
             assertThat(indeksjusterInntekt[1].periode).isEqualTo(inntektsperioder[1].periode)
             assertThat(indeksjusterInntekt[1].inntekt).isEqualTo(213_100.toBigDecimal())

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -295,6 +295,7 @@ fun tilkjentYtelse(
     grunnbeløpsmåned: YearMonth = YearMonth.of(stønadsår - 1, 5),
     samordningsfradrag: Int = 0,
     beløp: Int = 11554,
+    inntekt: Int = 277100,
 ): TilkjentYtelse {
     val andeler = listOf(
         AndelTilkjentYtelse(
@@ -303,7 +304,7 @@ fun tilkjentYtelse(
             stønadTom = LocalDate.of(stønadsår, 12, 31),
             personIdent = personIdent,
             inntektsreduksjon = 8396,
-            inntekt = 277100,
+            inntekt = inntekt,
             samordningsfradrag = samordningsfradrag,
             kildeBehandlingId = behandlingId,
         ),
@@ -380,8 +381,10 @@ fun inntektsperiode(
     sluttDato: LocalDate = LocalDate.of(år, 12, 1),
     inntekt: BigDecimal = BigDecimal.valueOf(100000),
     samordningsfradrag: BigDecimal = BigDecimal.valueOf(500),
+    dagsats: BigDecimal? = null,
+    månedsinntekt: BigDecimal? = null,
 ) =
-    Inntektsperiode(periode = Månedsperiode(startDato, sluttDato), inntekt = inntekt, samordningsfradrag = samordningsfradrag)
+    Inntektsperiode(periode = Månedsperiode(startDato, sluttDato), dagsats = dagsats, månedsinntekt = månedsinntekt, inntekt = inntekt, samordningsfradrag = samordningsfradrag)
 
 fun vedtaksperiode(
     år: Int = 2021,


### PR DESCRIPTION
**Hvorfor** 

Vi har siden forrige G-omregning endret litt på hvordan vi lagrer inntekt (grunnlag) og hvordan vi beregner. 

Nå lagrer vi grunnlag i dagsats, månedsinntekt og inntekt (år). Disse summene skal ikke rundes ned når de legges inn. Dette gjøres automatisk når vi beregner.  

Tidligere rundet vi indeks-justert inntekt ned til nærmeste 100 før vi beregnet. Det trenger vi ikke lenger gjøre da inntekt blir rundet av til nærmeste 1000 når vi beregner. 

Dersom vi skal runde av til nærmeste 100 må dette gjøres i beregning. Dette har jeg ikke tatt stilling til dette i denne pull-requesten. Avklaring rundt avrunding til nærmeste 100/1000 er ikke klar ennå, men bør ikke påvirke dette. 

Del 1 av: 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12303

Funksjonell verifisering av tall brukt i tester planlegger vi gjøre asap. REF tall brukt i testen: 
`Verifiser riktig beløp og intekstjustering`

Vurderer også lage en cucumber-test for enklere kunne lage en matrise av før-etter-g-omregnings beløp og for lettere kunne dele dette med funksjonelle for verifisering. (Det blir i så fall en annen PR)  

------ 

* Vil ikke runde av indeksjustert inntekt til nærmeste 100. Her lagres kun grunnlag (runder derfor av til nærmeste krone).

* Vil indeksjustere dag- og månedsinntekt på samme måte.

* Hvis vi skal runde av inntekt til nærmeste 100 ved g-omregning må vi gjøre det når vi beregner (på samme måte som vanlige behandlinger).