### PR TITLE
Skal sende med behandlingsnummer header ved call til PDL. Datatyper f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230210162649_a258d57-SPRING_BOOT_3</felles.version>
         <prosessering.version>2.20230322091650_fb0187e-SPRING_BOOT_3</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20230428084827_0b6a892-JAKARTA</kontrakter.version>
+        <kontrakter.version>3.0_20230509152247_36d24db</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.11.2</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlClient.kt
@@ -22,6 +22,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlResponse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøkerData
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.familie.kontrakter.felles.Tema
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Service
@@ -161,6 +162,7 @@ class PdlClient(
     private fun httpHeaders(): HttpHeaders {
         return HttpHeaders().apply {
             add("Tema", "ENF")
+            add("behandlingsnummer", Tema.ENF.behandlingsnummer)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -13,7 +13,7 @@ import kotlin.math.sqrt
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
-    open val extensions: PdlExtensions?,
+    val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -13,33 +13,41 @@ import kotlin.math.sqrt
 data class PdlResponse<T>(
     val data: T,
     val errors: List<PdlError>?,
+    open val extensions: PdlExtensions?,
 ) {
 
     fun harFeil(): Boolean {
         return errors != null && errors.isNotEmpty()
     }
-
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
+    }
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
     }
 }
 
-data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?) {
+data class PdlBolkResponse<T>(val data: PersonBolk<T>?, val errors: List<PdlError>?, val extensions: PdlExtensions?) {
 
     fun errorMessages(): String {
         return errors?.joinToString { it -> it.message } ?: ""
+    }
+    fun harAdvarsel(): Boolean {
+        return !extensions?.warnings.isNullOrEmpty()
     }
 }
 
 data class PdlError(
     val message: String,
-    val extensions: PdlExtensions?,
+    val extensions: PdlErrorExtensions?,
 )
 
-data class PdlExtensions(val code: String?) {
+data class PdlErrorExtensions(val code: String?) {
 
     fun notFound() = code == "not_found"
 }
+data class PdlExtensions(val warnings: List<PdlWarning>?)
+data class PdlWarning(val details: Any?, val id: String?, val message: String?, val query: String?)
 
 data class PdlSøkerData(val person: PdlSøker?)
 


### PR DESCRIPTION
…or PdlExtensions og PdlWarning.

Hvorfor ?

PDL gjør endringer mot en mere fingranulert tilgangsstyring, og ønsker at konsumentene skal legge på en header med behandlingsnummer fra enhetskatalogen. Vi ønsker også å logge advarsler fra PDL, og ikke bare feil. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12402