### PR TITLE
Refaktorering. Skal trekke ut grunnbeløp i eget objekt for å kunne mocke i tester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTask.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.ef.sak.behandling.grunnbelop
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.OmregningService
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
@@ -42,7 +42,7 @@ class GOmregningTask(
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun opprettTask(fagsakId: UUID) {
-        val payload = objectMapper.writeValueAsString(GOmregningPayload(fagsakId, nyesteGrunnbeløpGyldigFraOgMed))
+        val payload = objectMapper.writeValueAsString(GOmregningPayload(fagsakId, Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed))
         val eksisterendeTask = taskService.finnTaskMedPayloadOgType(payload, TYPE)
 
         if (eksisterendeTask != null) {
@@ -51,7 +51,7 @@ class GOmregningTask(
 
         val properties = Properties().apply {
             setProperty("fagsakId", fagsakId.toString())
-            setProperty("grunnbeløpsdato", nyesteGrunnbeløpGyldigFraOgMed.toString())
+            setProperty("grunnbeløpsdato", Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.toString())
             setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskService.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.behandling.grunnbelop
 
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -34,7 +34,7 @@ class GOmregningTaskService(
 
     fun opprettGOmregningTaskForBehandlingerMedUtdatertG(): Int {
         logger.info("Starter opprettelse av tasker for G-omregning.")
-        val fagsakIder = fagsakRepository.finnFerdigstilteFagsakerMedUtdatertGBelop(nyesteGrunnbeløpGyldigFraOgMed.atDay(1))
+        val fagsakIder = fagsakRepository.finnFerdigstilteFagsakerMedUtdatertGBelop(Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.atDay(1))
         try {
             fagsakIder.forEach {
                 gOmregningTask.opprettTask(it)

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
@@ -38,497 +38,501 @@ data class Grunnbeløp(
     val gjennomsnittPerÅr: BigDecimal? = null,
 )
 
-fun finnGrunnbeløpsPerioder(periode: Månedsperiode): List<Beløpsperiode> {
-    return grunnbeløpsperioder
-        .filter { it.periode.overlapper(periode) }
-        .map {
-            Beløpsperiode(
-                periode = Månedsperiode(
-                    fom = maxOf(it.periode.fom, periode.fom),
-                    tom = minOf(it.periode.tom, periode.tom),
-                ),
-                beløp = it.grunnbeløp,
-                beløpFørSamordning = it.grunnbeløp,
-            )
-        }
-        .sortedBy { it.periode }
-}
+object Grunnbeløpsperioder {
 
-fun finnGrunnbeløp(måned: YearMonth) = grunnbeløpsperioder.find {
-    it.periode.inneholder(måned)
-} ?: error("Grunnbeløp finnes ikke for dato $måned")
+    fun finnGrunnbeløpsPerioder(periode: Månedsperiode): List<Beløpsperiode> {
+        return grunnbeløpsperioder
+            .filter { it.periode.overlapper(periode) }
+            .map {
+                Beløpsperiode(
+                    periode = Månedsperiode(
+                        fom = maxOf(it.periode.fom, periode.fom),
+                        tom = minOf(it.periode.tom, periode.tom),
+                    ),
+                    beløp = it.grunnbeløp,
+                    beløpFørSamordning = it.grunnbeløp,
+                )
+            }
+            .sortedBy { it.periode }
+    }
 
-// TODO: Kopiert inn fra https://github.com/navikt/g - kan kanskje kalle tjenesten på sikt hvis den er tenkt å være oppdatert?
+    fun finnGrunnbeløp(måned: YearMonth) = grunnbeløpsperioder.find {
+        it.periode.inneholder(måned)
+    } ?: error("Grunnbeløp finnes ikke for dato $måned")
+
+    // TODO: Kopiert inn fra https://github.com/navikt/g - kan kanskje kalle tjenesten på sikt hvis den er tenkt å være oppdatert?
 // TODO: tilDato må være siste dag i måneden
-val grunnbeløpsperioder: List<Grunnbeløp> =
-    listOf(
-        Grunnbeløp(
-            periode = Månedsperiode(YearMonth.parse("2022-05"), YearMonth.from(LocalDate.MAX)),
-            grunnbeløp = 111_477.toBigDecimal(),
-            perMnd = 9_290.toBigDecimal(),
-            gjennomsnittPerÅr = 109_784.toBigDecimal(),
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2021-05" to "2022-04"),
-            grunnbeløp = 106_399.toBigDecimal(),
-            perMnd = 8_867.toBigDecimal(),
-            gjennomsnittPerÅr = 104_716.toBigDecimal(),
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2020-05" to "2021-04"),
-            grunnbeløp = 101_351.toBigDecimal(),
-            perMnd = 8_446.toBigDecimal(),
-            gjennomsnittPerÅr = 100_853.toBigDecimal(),
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2019-05" to "2020-04"),
-            grunnbeløp = 99_858.toBigDecimal(),
-            perMnd = 8_322.toBigDecimal(),
-            gjennomsnittPerÅr = 98_866.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2018-05" to "2019-04"),
-            grunnbeløp = 96_883.toBigDecimal(),
-            perMnd = 8_074.toBigDecimal(),
-            gjennomsnittPerÅr = 95_800.toBigDecimal(),
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2017-05" to "2018-04"),
-            grunnbeløp = 93_634.toBigDecimal(),
-            perMnd = 7_803.toBigDecimal(),
-            gjennomsnittPerÅr = 93_281.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2016-05" to "2017-04"),
-            grunnbeløp = 92_576.toBigDecimal(),
-            perMnd = 7_715.toBigDecimal(),
-            gjennomsnittPerÅr = 91_740.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2015-05" to "2016-04"),
-            grunnbeløp = 90_068.toBigDecimal(),
-            perMnd = 7_506.toBigDecimal(),
-            gjennomsnittPerÅr = 89_502.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2014-05" to "2015-04"),
-            grunnbeløp = 88_370.toBigDecimal(),
-            perMnd = 7_364.toBigDecimal(),
-            gjennomsnittPerÅr = 87_328.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2013-05" to "2014-04"),
-            grunnbeløp = 85_245.toBigDecimal(),
-            perMnd = 7_104.toBigDecimal(),
-            gjennomsnittPerÅr = 84_204.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2012-05" to "2013-04"),
-            grunnbeløp = 82_122.toBigDecimal(),
-            perMnd = 6_844.toBigDecimal(),
-            gjennomsnittPerÅr = 81_153.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2011-05" to "2012-04"),
-            grunnbeløp = 79_216.toBigDecimal(),
-            perMnd = 6_601.toBigDecimal(),
-            gjennomsnittPerÅr = 78_024.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2010-05" to "2011-04"),
-            grunnbeløp = 75_641.toBigDecimal(),
-            perMnd = 6_303.toBigDecimal(),
-            gjennomsnittPerÅr = 74_721.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2009-05" to "2010-04"),
-            grunnbeløp = 72_881.toBigDecimal(),
-            perMnd = 6_073.toBigDecimal(),
-            gjennomsnittPerÅr = 72_006.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2008-05" to "2009-04"),
-            grunnbeløp = 70_256.toBigDecimal(),
-            perMnd = 5_855.toBigDecimal(),
-            gjennomsnittPerÅr = 69_108.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2007-05" to "2008-04"),
-            grunnbeløp = 66_812.toBigDecimal(),
-            perMnd = 5_568.toBigDecimal(),
-            gjennomsnittPerÅr = 65_505.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2006-05" to "2007-04"),
-            grunnbeløp = 62_892.toBigDecimal(),
-            perMnd = 5_241.toBigDecimal(),
-            gjennomsnittPerÅr = 62_161.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2005-05" to "2006-04"),
-            grunnbeløp = 60_699.toBigDecimal(),
-            perMnd = 5_058.toBigDecimal(),
-            gjennomsnittPerÅr = 60_059.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2004-05" to "2005-04"),
-            grunnbeløp = 58_778.toBigDecimal(),
-            perMnd = 4_898.toBigDecimal(),
-            gjennomsnittPerÅr = 58_139.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2003-05" to "2004-04"),
-            grunnbeløp = 56_861.toBigDecimal(),
-            perMnd = 4_738.toBigDecimal(),
-            gjennomsnittPerÅr = 55_964.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2002-05" to "2003-04"),
-            grunnbeløp = 54_170.toBigDecimal(),
-            perMnd = 4_514.toBigDecimal(),
-            gjennomsnittPerÅr = 53_233.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2001-05" to "2002-04"),
-            grunnbeløp = 51_360.toBigDecimal(),
-            perMnd = 4_280.toBigDecimal(),
-            gjennomsnittPerÅr = 50_603.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("2000-05" to "2001-04"),
-            grunnbeløp = 49_090.toBigDecimal(),
-            perMnd = 4_091.toBigDecimal(),
-            gjennomsnittPerÅr = 48_377.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1999-05" to "2000-04"),
-            grunnbeløp = 46_950.toBigDecimal(),
-            perMnd = 3_913.toBigDecimal(),
-            gjennomsnittPerÅr = 46_423.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1998-05" to "1999-04"),
-            grunnbeløp = 45_370.toBigDecimal(),
-            perMnd = 3_781.toBigDecimal(),
-            gjennomsnittPerÅr = 44_413.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1997-05" to "1998-04"),
-            grunnbeløp = 42_500.toBigDecimal(),
-            perMnd = 3_542.toBigDecimal(),
-            gjennomsnittPerÅr = 42_000.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1996-05" to "1997-04"),
-            grunnbeløp = 41_000.toBigDecimal(),
-            perMnd = 3_417.toBigDecimal(),
-            gjennomsnittPerÅr = 40_410.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1995-05" to "1996-04"),
-            grunnbeløp = 39_230.toBigDecimal(),
-            perMnd = 3_269.toBigDecimal(),
-            gjennomsnittPerÅr = 38_847.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1994-05" to "1995-04"),
-            grunnbeløp = 38_080.toBigDecimal(),
-            perMnd = 3_173.toBigDecimal(),
-            gjennomsnittPerÅr = 37_820.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1993-05" to "1994-04"),
-            grunnbeløp = 37_300.toBigDecimal(),
-            perMnd = 3_108.toBigDecimal(),
-            gjennomsnittPerÅr = 37_033.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1992-05" to "1993-04"),
-            grunnbeløp = 36_500.toBigDecimal(),
-            perMnd = 3_042.toBigDecimal(),
-            gjennomsnittPerÅr = 36_167.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1991-05" to "1992-04"),
-            grunnbeløp = 35_500.toBigDecimal(),
-            perMnd = 2_958.toBigDecimal(),
-            gjennomsnittPerÅr = 35_033.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1990-12" to "1991-04"),
-            grunnbeløp = 34_100.toBigDecimal(),
-            perMnd = 2_842.toBigDecimal(),
-            gjennomsnittPerÅr = 33_575.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1990-05" to "1990-11"),
-            grunnbeløp = 34_000.toBigDecimal(),
-            perMnd = 2_833.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1989-04" to "1990-04"),
-            grunnbeløp = 32_700.toBigDecimal(),
-            perMnd = 2_725.toBigDecimal(),
-            gjennomsnittPerÅr = 32_275.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1988-04" to "1989-03"),
-            grunnbeløp = 31_000.toBigDecimal(),
-            perMnd = 2_583.toBigDecimal(),
-            gjennomsnittPerÅr = 30_850.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1988-01" to "1988-03"),
-            grunnbeløp = 30_400.toBigDecimal(),
-            perMnd = 2_533.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1987-05" to "1987-12"),
-            grunnbeløp = 29_900.toBigDecimal(),
-            perMnd = 2_492.toBigDecimal(),
-            gjennomsnittPerÅr = 29_267.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1986-05" to "1987-04"),
-            grunnbeløp = 28_000.toBigDecimal(),
-            perMnd = 2_333.toBigDecimal(),
-            gjennomsnittPerÅr = 27_433.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1986-01" to "1986-04"),
-            grunnbeløp = 26_300.toBigDecimal(),
-            perMnd = 2_192.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1985-05" to "1985-12"),
-            grunnbeløp = 25_900.toBigDecimal(),
-            perMnd = 2_158.toBigDecimal(),
-            gjennomsnittPerÅr = 25_333.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1984-05" to "1985-04"),
-            grunnbeløp = 24_200.toBigDecimal(),
-            perMnd = 2_017.toBigDecimal(),
-            gjennomsnittPerÅr = 23_667.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1983-05" to "1984-04"),
-            grunnbeløp = 22_600.toBigDecimal(),
-            perMnd = 1_883.toBigDecimal(),
-            gjennomsnittPerÅr = 22_333.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1983-01" to "1983-04"),
-            grunnbeløp = 21_800.toBigDecimal(),
-            perMnd = 1_817.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1982-05" to "1982-12"),
-            grunnbeløp = 21_200.toBigDecimal(),
-            perMnd = 1_767.toBigDecimal(),
-            gjennomsnittPerÅr = 20_667.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1981-10" to "1982-04"),
-            grunnbeløp = 19_600.toBigDecimal(),
-            perMnd = 1_633.toBigDecimal(),
-            gjennomsnittPerÅr = 18_658.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1981-05" to "1981-09"),
-            grunnbeløp = 19_100.toBigDecimal(),
-            perMnd = 1_592.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1981-01" to "1981-04"),
-            grunnbeløp = 17_400.toBigDecimal(),
-            perMnd = 1_450.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1980-05" to "1980-12"),
-            grunnbeløp = 16_900.toBigDecimal(),
-            perMnd = 1_408.toBigDecimal(),
-            gjennomsnittPerÅr = 16_633.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1980-01" to "1980-04"),
-            grunnbeløp = 16_100.toBigDecimal(),
-            perMnd = 1_342.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1979-01" to "1979-12"),
-            grunnbeløp = 15_200.toBigDecimal(),
-            perMnd = 1_267.toBigDecimal(),
-            gjennomsnittPerÅr = 15_200.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1978-07" to "1978-12"),
-            grunnbeløp = 14_700.toBigDecimal(),
-            perMnd = 1_225.toBigDecimal(),
-            gjennomsnittPerÅr = 14_550.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1977-12" to "1978-06"),
-            grunnbeløp = 14_400.toBigDecimal(),
-            perMnd = 1_200.toBigDecimal(),
-            gjennomsnittPerÅr = 13_383.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1977-05" to "1977-11"),
-            grunnbeløp = 13_400.toBigDecimal(),
-            perMnd = 1_117.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1977-01" to "1977-04"),
-            grunnbeløp = 13_100.toBigDecimal(),
-            perMnd = 1_092.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1976-05" to "1976-12"),
-            grunnbeløp = 12_100.toBigDecimal(),
-            perMnd = 1_008.toBigDecimal(),
-            gjennomsnittPerÅr = 12_000.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1976-01" to "1976-04"),
-            grunnbeløp = 11_800.toBigDecimal(),
-            perMnd = 983.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1975-05" to "1975-12"),
-            grunnbeløp = 11_000.toBigDecimal(),
-            perMnd = 917.toBigDecimal(),
-            gjennomsnittPerÅr = 10_800.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1975-01" to "1975-04"),
-            grunnbeløp = 10_400.toBigDecimal(),
-            perMnd = 867.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1974-05" to "1974-12"),
-            grunnbeløp = 9_700.toBigDecimal(),
-            perMnd = 808.toBigDecimal(),
-            gjennomsnittPerÅr = 9_533.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1974-01" to "1974-04"),
-            grunnbeløp = 9_200.toBigDecimal(),
-            perMnd = 767.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1973-01" to "1973-12"),
-            grunnbeløp = 8_500.toBigDecimal(),
-            perMnd = 708.toBigDecimal(),
-            gjennomsnittPerÅr = 8_500.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1972-01" to "1972-12"),
-            grunnbeløp = 7_900.toBigDecimal(),
-            perMnd = 658.toBigDecimal(),
-            gjennomsnittPerÅr = 7_900.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1971-05" to "1971-12"),
-            grunnbeløp = 7_500.toBigDecimal(),
-            perMnd = 625.toBigDecimal(),
-            gjennomsnittPerÅr = 7_400.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1971-01" to "1971-04"),
-            grunnbeløp = 7_200.toBigDecimal(),
-            perMnd = 600.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1970-01" to "1970-12"),
-            grunnbeløp = 6_800.toBigDecimal(),
-            perMnd = 567.toBigDecimal(),
-            gjennomsnittPerÅr = 6_800.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1969-01" to "1969-12"),
-            grunnbeløp = 6_400.toBigDecimal(),
-            perMnd = 533.toBigDecimal(),
-            gjennomsnittPerÅr = 6_400.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1968-01" to "1968-12"),
-            grunnbeløp = 5_900.toBigDecimal(),
-            perMnd = 492.toBigDecimal(),
-            gjennomsnittPerÅr = 5_900.toBigDecimal(),
-
-        ),
-        Grunnbeløp(
-            periode = Månedsperiode("1967-01" to "1967-12"),
-            grunnbeløp = 5_400.toBigDecimal(),
-            perMnd = 450.toBigDecimal(),
-            gjennomsnittPerÅr = 5_400.toBigDecimal(),
-        ),
-    )
-
-val nyesteGrunnbeløp = grunnbeløpsperioder.maxBy { it.periode }
-val forrigeGrunnbeløp = grunnbeløpsperioder.sortedBy { it.periode }[1]
-val nyesteGrunnbeløpGyldigFraOgMed = nyesteGrunnbeløp.periode.fom
+    val grunnbeløpsperioder: List<Grunnbeløp> =
+        listOf(
+            Grunnbeløp(
+                periode = Månedsperiode(YearMonth.parse("2022-05"), YearMonth.from(LocalDate.MAX)),
+                grunnbeløp = 111_477.toBigDecimal(),
+                perMnd = 9_290.toBigDecimal(),
+                gjennomsnittPerÅr = 109_784.toBigDecimal(),
+            ),
+            Grunnbeløp(
+                periode = Månedsperiode("2021-05" to "2022-04"),
+                grunnbeløp = 106_399.toBigDecimal(),
+                perMnd = 8_867.toBigDecimal(),
+                gjennomsnittPerÅr = 104_716.toBigDecimal(),
+            ),
+            Grunnbeløp(
+                periode = Månedsperiode("2020-05" to "2021-04"),
+                grunnbeløp = 101_351.toBigDecimal(),
+                perMnd = 8_446.toBigDecimal(),
+                gjennomsnittPerÅr = 100_853.toBigDecimal(),
+            ),
+            Grunnbeløp(
+                periode = Månedsperiode("2019-05" to "2020-04"),
+                grunnbeløp = 99_858.toBigDecimal(),
+                perMnd = 8_322.toBigDecimal(),
+                gjennomsnittPerÅr = 98_866.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2018-05" to "2019-04"),
+                grunnbeløp = 96_883.toBigDecimal(),
+                perMnd = 8_074.toBigDecimal(),
+                gjennomsnittPerÅr = 95_800.toBigDecimal(),
+            ),
+            Grunnbeløp(
+                periode = Månedsperiode("2017-05" to "2018-04"),
+                grunnbeløp = 93_634.toBigDecimal(),
+                perMnd = 7_803.toBigDecimal(),
+                gjennomsnittPerÅr = 93_281.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2016-05" to "2017-04"),
+                grunnbeløp = 92_576.toBigDecimal(),
+                perMnd = 7_715.toBigDecimal(),
+                gjennomsnittPerÅr = 91_740.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2015-05" to "2016-04"),
+                grunnbeløp = 90_068.toBigDecimal(),
+                perMnd = 7_506.toBigDecimal(),
+                gjennomsnittPerÅr = 89_502.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2014-05" to "2015-04"),
+                grunnbeløp = 88_370.toBigDecimal(),
+                perMnd = 7_364.toBigDecimal(),
+                gjennomsnittPerÅr = 87_328.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2013-05" to "2014-04"),
+                grunnbeløp = 85_245.toBigDecimal(),
+                perMnd = 7_104.toBigDecimal(),
+                gjennomsnittPerÅr = 84_204.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2012-05" to "2013-04"),
+                grunnbeløp = 82_122.toBigDecimal(),
+                perMnd = 6_844.toBigDecimal(),
+                gjennomsnittPerÅr = 81_153.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2011-05" to "2012-04"),
+                grunnbeløp = 79_216.toBigDecimal(),
+                perMnd = 6_601.toBigDecimal(),
+                gjennomsnittPerÅr = 78_024.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2010-05" to "2011-04"),
+                grunnbeløp = 75_641.toBigDecimal(),
+                perMnd = 6_303.toBigDecimal(),
+                gjennomsnittPerÅr = 74_721.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2009-05" to "2010-04"),
+                grunnbeløp = 72_881.toBigDecimal(),
+                perMnd = 6_073.toBigDecimal(),
+                gjennomsnittPerÅr = 72_006.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2008-05" to "2009-04"),
+                grunnbeløp = 70_256.toBigDecimal(),
+                perMnd = 5_855.toBigDecimal(),
+                gjennomsnittPerÅr = 69_108.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2007-05" to "2008-04"),
+                grunnbeløp = 66_812.toBigDecimal(),
+                perMnd = 5_568.toBigDecimal(),
+                gjennomsnittPerÅr = 65_505.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2006-05" to "2007-04"),
+                grunnbeløp = 62_892.toBigDecimal(),
+                perMnd = 5_241.toBigDecimal(),
+                gjennomsnittPerÅr = 62_161.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2005-05" to "2006-04"),
+                grunnbeløp = 60_699.toBigDecimal(),
+                perMnd = 5_058.toBigDecimal(),
+                gjennomsnittPerÅr = 60_059.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2004-05" to "2005-04"),
+                grunnbeløp = 58_778.toBigDecimal(),
+                perMnd = 4_898.toBigDecimal(),
+                gjennomsnittPerÅr = 58_139.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2003-05" to "2004-04"),
+                grunnbeløp = 56_861.toBigDecimal(),
+                perMnd = 4_738.toBigDecimal(),
+                gjennomsnittPerÅr = 55_964.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2002-05" to "2003-04"),
+                grunnbeløp = 54_170.toBigDecimal(),
+                perMnd = 4_514.toBigDecimal(),
+                gjennomsnittPerÅr = 53_233.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2001-05" to "2002-04"),
+                grunnbeløp = 51_360.toBigDecimal(),
+                perMnd = 4_280.toBigDecimal(),
+                gjennomsnittPerÅr = 50_603.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("2000-05" to "2001-04"),
+                grunnbeløp = 49_090.toBigDecimal(),
+                perMnd = 4_091.toBigDecimal(),
+                gjennomsnittPerÅr = 48_377.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1999-05" to "2000-04"),
+                grunnbeløp = 46_950.toBigDecimal(),
+                perMnd = 3_913.toBigDecimal(),
+                gjennomsnittPerÅr = 46_423.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1998-05" to "1999-04"),
+                grunnbeløp = 45_370.toBigDecimal(),
+                perMnd = 3_781.toBigDecimal(),
+                gjennomsnittPerÅr = 44_413.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1997-05" to "1998-04"),
+                grunnbeløp = 42_500.toBigDecimal(),
+                perMnd = 3_542.toBigDecimal(),
+                gjennomsnittPerÅr = 42_000.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1996-05" to "1997-04"),
+                grunnbeløp = 41_000.toBigDecimal(),
+                perMnd = 3_417.toBigDecimal(),
+                gjennomsnittPerÅr = 40_410.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1995-05" to "1996-04"),
+                grunnbeløp = 39_230.toBigDecimal(),
+                perMnd = 3_269.toBigDecimal(),
+                gjennomsnittPerÅr = 38_847.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1994-05" to "1995-04"),
+                grunnbeløp = 38_080.toBigDecimal(),
+                perMnd = 3_173.toBigDecimal(),
+                gjennomsnittPerÅr = 37_820.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1993-05" to "1994-04"),
+                grunnbeløp = 37_300.toBigDecimal(),
+                perMnd = 3_108.toBigDecimal(),
+                gjennomsnittPerÅr = 37_033.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1992-05" to "1993-04"),
+                grunnbeløp = 36_500.toBigDecimal(),
+                perMnd = 3_042.toBigDecimal(),
+                gjennomsnittPerÅr = 36_167.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1991-05" to "1992-04"),
+                grunnbeløp = 35_500.toBigDecimal(),
+                perMnd = 2_958.toBigDecimal(),
+                gjennomsnittPerÅr = 35_033.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1990-12" to "1991-04"),
+                grunnbeløp = 34_100.toBigDecimal(),
+                perMnd = 2_842.toBigDecimal(),
+                gjennomsnittPerÅr = 33_575.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1990-05" to "1990-11"),
+                grunnbeløp = 34_000.toBigDecimal(),
+                perMnd = 2_833.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1989-04" to "1990-04"),
+                grunnbeløp = 32_700.toBigDecimal(),
+                perMnd = 2_725.toBigDecimal(),
+                gjennomsnittPerÅr = 32_275.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1988-04" to "1989-03"),
+                grunnbeløp = 31_000.toBigDecimal(),
+                perMnd = 2_583.toBigDecimal(),
+                gjennomsnittPerÅr = 30_850.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1988-01" to "1988-03"),
+                grunnbeløp = 30_400.toBigDecimal(),
+                perMnd = 2_533.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1987-05" to "1987-12"),
+                grunnbeløp = 29_900.toBigDecimal(),
+                perMnd = 2_492.toBigDecimal(),
+                gjennomsnittPerÅr = 29_267.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1986-05" to "1987-04"),
+                grunnbeløp = 28_000.toBigDecimal(),
+                perMnd = 2_333.toBigDecimal(),
+                gjennomsnittPerÅr = 27_433.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1986-01" to "1986-04"),
+                grunnbeløp = 26_300.toBigDecimal(),
+                perMnd = 2_192.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1985-05" to "1985-12"),
+                grunnbeløp = 25_900.toBigDecimal(),
+                perMnd = 2_158.toBigDecimal(),
+                gjennomsnittPerÅr = 25_333.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1984-05" to "1985-04"),
+                grunnbeløp = 24_200.toBigDecimal(),
+                perMnd = 2_017.toBigDecimal(),
+                gjennomsnittPerÅr = 23_667.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1983-05" to "1984-04"),
+                grunnbeløp = 22_600.toBigDecimal(),
+                perMnd = 1_883.toBigDecimal(),
+                gjennomsnittPerÅr = 22_333.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1983-01" to "1983-04"),
+                grunnbeløp = 21_800.toBigDecimal(),
+                perMnd = 1_817.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1982-05" to "1982-12"),
+                grunnbeløp = 21_200.toBigDecimal(),
+                perMnd = 1_767.toBigDecimal(),
+                gjennomsnittPerÅr = 20_667.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1981-10" to "1982-04"),
+                grunnbeløp = 19_600.toBigDecimal(),
+                perMnd = 1_633.toBigDecimal(),
+                gjennomsnittPerÅr = 18_658.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1981-05" to "1981-09"),
+                grunnbeløp = 19_100.toBigDecimal(),
+                perMnd = 1_592.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1981-01" to "1981-04"),
+                grunnbeløp = 17_400.toBigDecimal(),
+                perMnd = 1_450.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1980-05" to "1980-12"),
+                grunnbeløp = 16_900.toBigDecimal(),
+                perMnd = 1_408.toBigDecimal(),
+                gjennomsnittPerÅr = 16_633.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1980-01" to "1980-04"),
+                grunnbeløp = 16_100.toBigDecimal(),
+                perMnd = 1_342.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1979-01" to "1979-12"),
+                grunnbeløp = 15_200.toBigDecimal(),
+                perMnd = 1_267.toBigDecimal(),
+                gjennomsnittPerÅr = 15_200.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1978-07" to "1978-12"),
+                grunnbeløp = 14_700.toBigDecimal(),
+                perMnd = 1_225.toBigDecimal(),
+                gjennomsnittPerÅr = 14_550.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1977-12" to "1978-06"),
+                grunnbeløp = 14_400.toBigDecimal(),
+                perMnd = 1_200.toBigDecimal(),
+                gjennomsnittPerÅr = 13_383.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1977-05" to "1977-11"),
+                grunnbeløp = 13_400.toBigDecimal(),
+                perMnd = 1_117.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1977-01" to "1977-04"),
+                grunnbeløp = 13_100.toBigDecimal(),
+                perMnd = 1_092.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1976-05" to "1976-12"),
+                grunnbeløp = 12_100.toBigDecimal(),
+                perMnd = 1_008.toBigDecimal(),
+                gjennomsnittPerÅr = 12_000.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1976-01" to "1976-04"),
+                grunnbeløp = 11_800.toBigDecimal(),
+                perMnd = 983.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1975-05" to "1975-12"),
+                grunnbeløp = 11_000.toBigDecimal(),
+                perMnd = 917.toBigDecimal(),
+                gjennomsnittPerÅr = 10_800.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1975-01" to "1975-04"),
+                grunnbeløp = 10_400.toBigDecimal(),
+                perMnd = 867.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1974-05" to "1974-12"),
+                grunnbeløp = 9_700.toBigDecimal(),
+                perMnd = 808.toBigDecimal(),
+                gjennomsnittPerÅr = 9_533.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1974-01" to "1974-04"),
+                grunnbeløp = 9_200.toBigDecimal(),
+                perMnd = 767.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1973-01" to "1973-12"),
+                grunnbeløp = 8_500.toBigDecimal(),
+                perMnd = 708.toBigDecimal(),
+                gjennomsnittPerÅr = 8_500.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1972-01" to "1972-12"),
+                grunnbeløp = 7_900.toBigDecimal(),
+                perMnd = 658.toBigDecimal(),
+                gjennomsnittPerÅr = 7_900.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1971-05" to "1971-12"),
+                grunnbeløp = 7_500.toBigDecimal(),
+                perMnd = 625.toBigDecimal(),
+                gjennomsnittPerÅr = 7_400.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1971-01" to "1971-04"),
+                grunnbeløp = 7_200.toBigDecimal(),
+                perMnd = 600.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1970-01" to "1970-12"),
+                grunnbeløp = 6_800.toBigDecimal(),
+                perMnd = 567.toBigDecimal(),
+                gjennomsnittPerÅr = 6_800.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1969-01" to "1969-12"),
+                grunnbeløp = 6_400.toBigDecimal(),
+                perMnd = 533.toBigDecimal(),
+                gjennomsnittPerÅr = 6_400.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1968-01" to "1968-12"),
+                grunnbeløp = 5_900.toBigDecimal(),
+                perMnd = 492.toBigDecimal(),
+                gjennomsnittPerÅr = 5_900.toBigDecimal(),
+
+                ),
+            Grunnbeløp(
+                periode = Månedsperiode("1967-01" to "1967-12"),
+                grunnbeløp = 5_400.toBigDecimal(),
+                perMnd = 450.toBigDecimal(),
+                gjennomsnittPerÅr = 5_400.toBigDecimal(),
+            ),
+        )
+
+    val nyesteGrunnbeløp = grunnbeløpsperioder.maxBy { it.periode }
+    val forrigeGrunnbeløp = grunnbeløpsperioder.sortedByDescending { it.periode }[1]
+    val nyesteGrunnbeløpGyldigFraOgMed = nyesteGrunnbeløp.periode.fom
+
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
@@ -88,7 +88,7 @@ object Grunnbeløpsperioder {
                 perMnd = 8_322.toBigDecimal(),
                 gjennomsnittPerÅr = 98_866.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2018-05" to "2019-04"),
                 grunnbeløp = 96_883.toBigDecimal(),
@@ -101,428 +101,428 @@ object Grunnbeløpsperioder {
                 perMnd = 7_803.toBigDecimal(),
                 gjennomsnittPerÅr = 93_281.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2016-05" to "2017-04"),
                 grunnbeløp = 92_576.toBigDecimal(),
                 perMnd = 7_715.toBigDecimal(),
                 gjennomsnittPerÅr = 91_740.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2015-05" to "2016-04"),
                 grunnbeløp = 90_068.toBigDecimal(),
                 perMnd = 7_506.toBigDecimal(),
                 gjennomsnittPerÅr = 89_502.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2014-05" to "2015-04"),
                 grunnbeløp = 88_370.toBigDecimal(),
                 perMnd = 7_364.toBigDecimal(),
                 gjennomsnittPerÅr = 87_328.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2013-05" to "2014-04"),
                 grunnbeløp = 85_245.toBigDecimal(),
                 perMnd = 7_104.toBigDecimal(),
                 gjennomsnittPerÅr = 84_204.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2012-05" to "2013-04"),
                 grunnbeløp = 82_122.toBigDecimal(),
                 perMnd = 6_844.toBigDecimal(),
                 gjennomsnittPerÅr = 81_153.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2011-05" to "2012-04"),
                 grunnbeløp = 79_216.toBigDecimal(),
                 perMnd = 6_601.toBigDecimal(),
                 gjennomsnittPerÅr = 78_024.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2010-05" to "2011-04"),
                 grunnbeløp = 75_641.toBigDecimal(),
                 perMnd = 6_303.toBigDecimal(),
                 gjennomsnittPerÅr = 74_721.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2009-05" to "2010-04"),
                 grunnbeløp = 72_881.toBigDecimal(),
                 perMnd = 6_073.toBigDecimal(),
                 gjennomsnittPerÅr = 72_006.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2008-05" to "2009-04"),
                 grunnbeløp = 70_256.toBigDecimal(),
                 perMnd = 5_855.toBigDecimal(),
                 gjennomsnittPerÅr = 69_108.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2007-05" to "2008-04"),
                 grunnbeløp = 66_812.toBigDecimal(),
                 perMnd = 5_568.toBigDecimal(),
                 gjennomsnittPerÅr = 65_505.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2006-05" to "2007-04"),
                 grunnbeløp = 62_892.toBigDecimal(),
                 perMnd = 5_241.toBigDecimal(),
                 gjennomsnittPerÅr = 62_161.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2005-05" to "2006-04"),
                 grunnbeløp = 60_699.toBigDecimal(),
                 perMnd = 5_058.toBigDecimal(),
                 gjennomsnittPerÅr = 60_059.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2004-05" to "2005-04"),
                 grunnbeløp = 58_778.toBigDecimal(),
                 perMnd = 4_898.toBigDecimal(),
                 gjennomsnittPerÅr = 58_139.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2003-05" to "2004-04"),
                 grunnbeløp = 56_861.toBigDecimal(),
                 perMnd = 4_738.toBigDecimal(),
                 gjennomsnittPerÅr = 55_964.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2002-05" to "2003-04"),
                 grunnbeløp = 54_170.toBigDecimal(),
                 perMnd = 4_514.toBigDecimal(),
                 gjennomsnittPerÅr = 53_233.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2001-05" to "2002-04"),
                 grunnbeløp = 51_360.toBigDecimal(),
                 perMnd = 4_280.toBigDecimal(),
                 gjennomsnittPerÅr = 50_603.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("2000-05" to "2001-04"),
                 grunnbeløp = 49_090.toBigDecimal(),
                 perMnd = 4_091.toBigDecimal(),
                 gjennomsnittPerÅr = 48_377.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1999-05" to "2000-04"),
                 grunnbeløp = 46_950.toBigDecimal(),
                 perMnd = 3_913.toBigDecimal(),
                 gjennomsnittPerÅr = 46_423.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1998-05" to "1999-04"),
                 grunnbeløp = 45_370.toBigDecimal(),
                 perMnd = 3_781.toBigDecimal(),
                 gjennomsnittPerÅr = 44_413.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1997-05" to "1998-04"),
                 grunnbeløp = 42_500.toBigDecimal(),
                 perMnd = 3_542.toBigDecimal(),
                 gjennomsnittPerÅr = 42_000.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1996-05" to "1997-04"),
                 grunnbeløp = 41_000.toBigDecimal(),
                 perMnd = 3_417.toBigDecimal(),
                 gjennomsnittPerÅr = 40_410.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1995-05" to "1996-04"),
                 grunnbeløp = 39_230.toBigDecimal(),
                 perMnd = 3_269.toBigDecimal(),
                 gjennomsnittPerÅr = 38_847.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1994-05" to "1995-04"),
                 grunnbeløp = 38_080.toBigDecimal(),
                 perMnd = 3_173.toBigDecimal(),
                 gjennomsnittPerÅr = 37_820.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1993-05" to "1994-04"),
                 grunnbeløp = 37_300.toBigDecimal(),
                 perMnd = 3_108.toBigDecimal(),
                 gjennomsnittPerÅr = 37_033.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1992-05" to "1993-04"),
                 grunnbeløp = 36_500.toBigDecimal(),
                 perMnd = 3_042.toBigDecimal(),
                 gjennomsnittPerÅr = 36_167.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1991-05" to "1992-04"),
                 grunnbeløp = 35_500.toBigDecimal(),
                 perMnd = 2_958.toBigDecimal(),
                 gjennomsnittPerÅr = 35_033.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1990-12" to "1991-04"),
                 grunnbeløp = 34_100.toBigDecimal(),
                 perMnd = 2_842.toBigDecimal(),
                 gjennomsnittPerÅr = 33_575.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1990-05" to "1990-11"),
                 grunnbeløp = 34_000.toBigDecimal(),
                 perMnd = 2_833.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1989-04" to "1990-04"),
                 grunnbeløp = 32_700.toBigDecimal(),
                 perMnd = 2_725.toBigDecimal(),
                 gjennomsnittPerÅr = 32_275.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1988-04" to "1989-03"),
                 grunnbeløp = 31_000.toBigDecimal(),
                 perMnd = 2_583.toBigDecimal(),
                 gjennomsnittPerÅr = 30_850.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1988-01" to "1988-03"),
                 grunnbeløp = 30_400.toBigDecimal(),
                 perMnd = 2_533.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1987-05" to "1987-12"),
                 grunnbeløp = 29_900.toBigDecimal(),
                 perMnd = 2_492.toBigDecimal(),
                 gjennomsnittPerÅr = 29_267.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1986-05" to "1987-04"),
                 grunnbeløp = 28_000.toBigDecimal(),
                 perMnd = 2_333.toBigDecimal(),
                 gjennomsnittPerÅr = 27_433.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1986-01" to "1986-04"),
                 grunnbeløp = 26_300.toBigDecimal(),
                 perMnd = 2_192.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1985-05" to "1985-12"),
                 grunnbeløp = 25_900.toBigDecimal(),
                 perMnd = 2_158.toBigDecimal(),
                 gjennomsnittPerÅr = 25_333.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1984-05" to "1985-04"),
                 grunnbeløp = 24_200.toBigDecimal(),
                 perMnd = 2_017.toBigDecimal(),
                 gjennomsnittPerÅr = 23_667.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1983-05" to "1984-04"),
                 grunnbeløp = 22_600.toBigDecimal(),
                 perMnd = 1_883.toBigDecimal(),
                 gjennomsnittPerÅr = 22_333.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1983-01" to "1983-04"),
                 grunnbeløp = 21_800.toBigDecimal(),
                 perMnd = 1_817.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1982-05" to "1982-12"),
                 grunnbeløp = 21_200.toBigDecimal(),
                 perMnd = 1_767.toBigDecimal(),
                 gjennomsnittPerÅr = 20_667.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1981-10" to "1982-04"),
                 grunnbeløp = 19_600.toBigDecimal(),
                 perMnd = 1_633.toBigDecimal(),
                 gjennomsnittPerÅr = 18_658.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1981-05" to "1981-09"),
                 grunnbeløp = 19_100.toBigDecimal(),
                 perMnd = 1_592.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1981-01" to "1981-04"),
                 grunnbeløp = 17_400.toBigDecimal(),
                 perMnd = 1_450.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1980-05" to "1980-12"),
                 grunnbeløp = 16_900.toBigDecimal(),
                 perMnd = 1_408.toBigDecimal(),
                 gjennomsnittPerÅr = 16_633.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1980-01" to "1980-04"),
                 grunnbeløp = 16_100.toBigDecimal(),
                 perMnd = 1_342.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1979-01" to "1979-12"),
                 grunnbeløp = 15_200.toBigDecimal(),
                 perMnd = 1_267.toBigDecimal(),
                 gjennomsnittPerÅr = 15_200.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1978-07" to "1978-12"),
                 grunnbeløp = 14_700.toBigDecimal(),
                 perMnd = 1_225.toBigDecimal(),
                 gjennomsnittPerÅr = 14_550.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1977-12" to "1978-06"),
                 grunnbeløp = 14_400.toBigDecimal(),
                 perMnd = 1_200.toBigDecimal(),
                 gjennomsnittPerÅr = 13_383.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1977-05" to "1977-11"),
                 grunnbeløp = 13_400.toBigDecimal(),
                 perMnd = 1_117.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1977-01" to "1977-04"),
                 grunnbeløp = 13_100.toBigDecimal(),
                 perMnd = 1_092.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1976-05" to "1976-12"),
                 grunnbeløp = 12_100.toBigDecimal(),
                 perMnd = 1_008.toBigDecimal(),
                 gjennomsnittPerÅr = 12_000.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1976-01" to "1976-04"),
                 grunnbeløp = 11_800.toBigDecimal(),
                 perMnd = 983.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1975-05" to "1975-12"),
                 grunnbeløp = 11_000.toBigDecimal(),
                 perMnd = 917.toBigDecimal(),
                 gjennomsnittPerÅr = 10_800.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1975-01" to "1975-04"),
                 grunnbeløp = 10_400.toBigDecimal(),
                 perMnd = 867.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1974-05" to "1974-12"),
                 grunnbeløp = 9_700.toBigDecimal(),
                 perMnd = 808.toBigDecimal(),
                 gjennomsnittPerÅr = 9_533.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1974-01" to "1974-04"),
                 grunnbeløp = 9_200.toBigDecimal(),
                 perMnd = 767.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1973-01" to "1973-12"),
                 grunnbeløp = 8_500.toBigDecimal(),
                 perMnd = 708.toBigDecimal(),
                 gjennomsnittPerÅr = 8_500.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1972-01" to "1972-12"),
                 grunnbeløp = 7_900.toBigDecimal(),
                 perMnd = 658.toBigDecimal(),
                 gjennomsnittPerÅr = 7_900.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1971-05" to "1971-12"),
                 grunnbeløp = 7_500.toBigDecimal(),
                 perMnd = 625.toBigDecimal(),
                 gjennomsnittPerÅr = 7_400.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1971-01" to "1971-04"),
                 grunnbeløp = 7_200.toBigDecimal(),
                 perMnd = 600.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1970-01" to "1970-12"),
                 grunnbeløp = 6_800.toBigDecimal(),
                 perMnd = 567.toBigDecimal(),
                 gjennomsnittPerÅr = 6_800.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1969-01" to "1969-12"),
                 grunnbeløp = 6_400.toBigDecimal(),
                 perMnd = 533.toBigDecimal(),
                 gjennomsnittPerÅr = 6_400.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1968-01" to "1968-12"),
                 grunnbeløp = 5_900.toBigDecimal(),
                 perMnd = 492.toBigDecimal(),
                 gjennomsnittPerÅr = 5_900.toBigDecimal(),
 
-                ),
+            ),
             Grunnbeløp(
                 periode = Månedsperiode("1967-01" to "1967-12"),
                 grunnbeløp = 5_400.toBigDecimal(),
@@ -534,5 +534,4 @@ object Grunnbeløpsperioder {
     val nyesteGrunnbeløp = grunnbeløpsperioder.maxBy { it.periode }
     val forrigeGrunnbeløp = grunnbeløpsperioder.sortedByDescending { it.periode }[1]
     val nyesteGrunnbeløpGyldigFraOgMed = nyesteGrunnbeløp.periode.fom
-
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
@@ -21,7 +21,7 @@ object BeregningUtils {
         val periode = inntektsperiode.periode
         val samordningsfradrag = inntektsperiode.samordningsfradrag
         val totalInntekt = beregnTotalinntekt(inntektsperiode, skalRundeNedTotalInntekt)
-        return finnGrunnbeløpsPerioder(periode).map {
+        return Grunnbeløpsperioder.finnGrunnbeløpsPerioder(periode).map {
             val avkortningPerMåned = beregnAvkortning(it.beløp, totalInntekt).divide(ANTALL_MÅNEDER_ÅR)
                 .setScale(0, RoundingMode.HALF_DOWN)
 
@@ -72,8 +72,8 @@ object BeregningUtils {
         sisteBrukteGrunnbeløpsdato: YearMonth,
         inntekter: List<Inntektsperiode> = emptyList(),
     ): List<Inntektsperiode> {
-        val sistBrukteGrunnbeløp = finnGrunnbeløp(sisteBrukteGrunnbeløpsdato)
-        if (nyesteGrunnbeløp == sistBrukteGrunnbeløp) {
+        val sistBrukteGrunnbeløp = Grunnbeløpsperioder.finnGrunnbeløp(sisteBrukteGrunnbeløpsdato)
+        if (Grunnbeløpsperioder.nyesteGrunnbeløp == sistBrukteGrunnbeløp) {
             return inntekter
         }
 
@@ -90,7 +90,8 @@ object BeregningUtils {
 
         val samordningsfradrag = inntektsperiode.samordningsfradrag
 
-        return finnGrunnbeløpsPerioder(inntektsperiode.periode).map { grunnbeløp ->
+        return Grunnbeløpsperioder.finnGrunnbeløpsPerioder(inntektsperiode.periode).map { grunnbeløp ->
+
             if (grunnbeløp.periode.fom > sistBrukteGrunnbeløp.periode.fom &&
                 grunnbeløp.beløp != sistBrukteGrunnbeløp.grunnbeløp
             ) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
@@ -61,7 +61,7 @@ class OmregningService(
         val innvilgelseOvergangsstønad =
             vedtakHistorikkService.hentVedtakForOvergangsstønadFraDato(
                 fagsakId,
-                YearMonth.from(nyesteGrunnbeløpGyldigFraOgMed),
+                YearMonth.from(Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed),
             )
         if (innvilgelseOvergangsstønad.perioder.any { it.periodeType == VedtaksperiodeType.SANKSJON }) {
             logger.warn(
@@ -91,7 +91,7 @@ class OmregningService(
 
         val forrigeTilkjentYtelse = ytelseService.hentForBehandling(sisteBehandling.id)
 
-        feilHvis(forrigeTilkjentYtelse.grunnbeløpsmåned == nyesteGrunnbeløpGyldigFraOgMed) {
+        feilHvis(forrigeTilkjentYtelse.grunnbeløpsmåned == Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed) {
             "Skal ikke utføre g-omregning når forrige tilkjent ytelse allerede har nyeste grunnbeløpsdato"
         }
         return forrigeTilkjentYtelse

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningService.kt
@@ -51,7 +51,7 @@ class ValiderOmregningService(
         tidligerePerioder: Map<YearMonth, VedtaksperiodeDto>,
     ) {
         brukerfeilHvis(tidligerePerioder.isEmpty()) {
-            "Denne skal ikke g-omregnes då den ikke har noen tidligere perioder som er etter $nyesteGrunnbeløpGyldigFraOgMed"
+            "Denne skal ikke g-omregnes då den ikke har noen tidligere perioder som er etter ${Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed}"
         }
         brukerfeilHvis(data.perioder.size != tidligerePerioder.size) {
             val tidligereDatoer = tidligerePerioder.values.joinToString(", ") { "${it.periode}" }
@@ -84,7 +84,7 @@ class ValiderOmregningService(
     private fun hentVedtakshistorikkFraNyesteGrunnbeløp(saksbehandling: Saksbehandling) =
         vedtakHistorikkService.hentVedtakForOvergangsstønadFraDato(
             saksbehandling.fagsakId,
-            YearMonth.from(nyesteGrunnbeløpGyldigFraOgMed),
+            YearMonth.from(Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed),
         )
             .perioder
             .filter { it.periodeType != VedtaksperiodeType.SANKSJON }
@@ -95,13 +95,13 @@ class ValiderOmregningService(
         if (vedtakService.hentVedtak(saksbehandling.id).resultatType != ResultatType.INNVILGE) return
         if (saksbehandling.forrigeBehandlingId == null) return
         val forrigeTilkjentYtelse = tilkjentYtelseRepository.findByBehandlingId(saksbehandling.forrigeBehandlingId) ?: return
-        if (forrigeTilkjentYtelse.grunnbeløpsmåned >= nyesteGrunnbeløpGyldigFraOgMed) return
+        if (forrigeTilkjentYtelse.grunnbeløpsmåned >= Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed) return
 
         val tilkjentYtelse = tilkjentYtelseRepository.findByBehandlingId(saksbehandling.id) ?: return
-        if (tilkjentYtelse.grunnbeløpsmåned < nyesteGrunnbeløpGyldigFraOgMed) return
+        if (tilkjentYtelse.grunnbeløpsmåned < Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed) return
 
         tilkjentYtelse.andelerTilkjentYtelse
-            .filter { it.stønadTom > nyesteGrunnbeløpGyldigFraOgMed.atDay(1) }
+            .filter { it.stønadTom > Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.atDay(1) }
             .forEach { andel ->
                 val inntektsperiodeForAndel = Inntektsperiode(
                     periode = andel.periode,
@@ -117,5 +117,5 @@ class ValiderOmregningService(
 
     private fun feilmeldingForFeilGBeløp(andel: AndelTilkjentYtelse) =
         "Kan ikke fullføre behandling: Det må revurderes fra " +
-            "${maxOf(andel.periode.fom, nyesteGrunnbeløpGyldigFraOgMed)} for at beregning av ny G blir riktig"
+            "${maxOf(andel.periode.fom, Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed)} for at beregning av ny G blir riktig"
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -7,8 +7,7 @@ import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprett
 import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingsRepository
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
-import no.nav.familie.ef.sak.beregning.forrigeGrunnbeløp
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.skolepenger.SkolepengerMaksbeløp
 import no.nav.familie.ef.sak.brev.BrevmottakereRepository
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerOrganisasjon
@@ -196,7 +195,7 @@ class IverksettingDtoMapper(
         val feilmelding =
             "Kan ikke iverksette med utdatert grunnbeløp gyldig fra $gMånedTilkjentYtelse. Denne behandlingen må beregnes og simuleres på nytt"
 
-        val nyttGrunnbeløpForInneværendeÅrRegistrertIEF = nyesteGrunnbeløpGyldigFraOgMed.year == DatoUtil.inneværendeÅr()
+        val nyttGrunnbeløpForInneværendeÅrRegistrertIEF = Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.year == DatoUtil.inneværendeÅr()
         val fristGOmregning = LocalDate.of(DatoUtil.inneværendeÅr(), Month.JUNE, 15)
 
         if (nyttGrunnbeløpForInneværendeÅrRegistrertIEF && DatoUtil.dagensDato() < fristGOmregning) {
@@ -207,14 +206,14 @@ class IverksettingDtoMapper(
     }
 
     private fun validerBehandlingBrukerNyesteG(gMånedTilkjentYtelse: YearMonth, feilmelding: String) {
-        brukerfeilHvis(gMånedTilkjentYtelse != nyesteGrunnbeløpGyldigFraOgMed) { feilmelding }
+        brukerfeilHvis(gMånedTilkjentYtelse != Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed) { feilmelding }
     }
 
     private fun validerBehandlingBrukerÅretsEllerFjoråretsG(
         gMånedTilkjentYtelse: YearMonth,
         feilmelding: String,
     ) {
-        brukerfeilHvis(gMånedTilkjentYtelse != nyesteGrunnbeløpGyldigFraOgMed && gMånedTilkjentYtelse != forrigeGrunnbeløp.periode.fom) {
+        brukerfeilHvis(gMånedTilkjentYtelse != Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed && gMånedTilkjentYtelse != Grunnbeløpsperioder.forrigeGrunnbeløp.periode.fom) {
             feilmelding
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilkjentytelse/domain/TilkjentYtelse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilkjentytelse/domain/TilkjentYtelse.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.tilkjentytelse.domain
 
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløp
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.felles.domain.Sporbar
 import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
 import org.springframework.data.annotation.Id
@@ -36,7 +36,7 @@ data class TilkjentYtelse(
     val samordningsfradragType: SamordningsfradragType? = null,
     val startdato: LocalDate,
     @Column("grunnbelopsdato")
-    val grunnbeløpsmåned: YearMonth = nyesteGrunnbeløp.periode.fom,
+    val grunnbeløpsmåned: YearMonth = Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_EMPTY)
     val sporbar: Sporbar = Sporbar(),
 ) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.sak.behandling.grunnbelop
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.Task
@@ -46,7 +46,7 @@ internal class GOmregningTaskTest {
     @Test
     internal fun `skal opprette task med grunnbeløpsmåned i payload`() {
         val fagsakId = UUID.randomUUID()
-        val payload = objectMapper.writeValueAsString(GOmregningPayload(fagsakId, nyesteGrunnbeløpGyldigFraOgMed))
+        val payload = objectMapper.writeValueAsString(GOmregningPayload(fagsakId, Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed))
         every { taskService.finnTaskMedPayloadOgType(any(), any()) } returns null
 
         gOmregningTask.opprettTask(fagsakId)

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningTest.kt
@@ -43,7 +43,7 @@ internal class BeregningTest {
                         "med forventet svar: $fasit",
                 ) {
                     assertThat(
-                        finnGrunnbeløpsPerioder(
+                        Grunnbeløpsperioder.finnGrunnbeløpsPerioder(
                             Månedsperiode(
                                 LocalDate.parse(periode.first),
                                 LocalDate.parse(periode.second),

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtilsTest.kt
@@ -198,7 +198,7 @@ internal class BeregningUtilsTest {
                 )
 
             val indeksjusterInntekt = BeregningUtils.indeksjusterInntekt(
-                nyesteGrunnbeløp.periode.fom,
+                Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom,
                 inntektsperioder,
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpsperioderTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpsperioderTest.kt
@@ -1,0 +1,19 @@
+package no.nav.familie.ef.sak.beregning
+
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+import kotlin.test.assertTrue
+
+internal class GrunnbeløpsperioderTest {
+
+
+    @Test
+    fun nyesteGrunnbeløp() {
+        assertTrue {   Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom > YearMonth.of(2021, 5)}
+    }
+
+    @Test
+    fun forrigeGrunnbeløp() {
+        assertTrue {   Grunnbeløpsperioder.forrigeGrunnbeløp.periode.fom < Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom}
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpsperioderTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpsperioderTest.kt
@@ -6,14 +6,13 @@ import kotlin.test.assertTrue
 
 internal class GrunnbeløpsperioderTest {
 
-
     @Test
     fun nyesteGrunnbeløp() {
-        assertTrue {   Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom > YearMonth.of(2021, 5)}
+        assertTrue { Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom > YearMonth.of(2021, 5) }
     }
 
     @Test
     fun forrigeGrunnbeløp() {
-        assertTrue {   Grunnbeløpsperioder.forrigeGrunnbeløp.periode.fom < Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom}
+        assertTrue { Grunnbeløpsperioder.forrigeGrunnbeløp.periode.fom < Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpstestTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/GrunnbeløpstestTest.kt
@@ -9,7 +9,7 @@ internal class GrunnbeløpstestTest {
 
     @Test
     internal fun `skal sette riktig startdato og sluttdato når beløpsperioder går over flere grunnbeløpsperioder`() {
-        val perioder = finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2001, 1, 1), LocalDate.of(2021, 8, 31)))
+        val perioder = Grunnbeløpsperioder.finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2001, 1, 1), LocalDate.of(2021, 8, 31)))
         assertThat(perioder.size).isEqualTo(22)
         perioder.forEachIndexed { index, beløpsperiode ->
             if (perioder.size > index + 1) {
@@ -20,7 +20,7 @@ internal class GrunnbeløpstestTest {
 
     @Test
     internal fun `skal sette riktig startdato og sluttdato når beløpsperioder stanser på en g-endringsperiode`() {
-        val perioder = finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 5, 1)))
+        val perioder = Grunnbeløpsperioder.finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 1, 1), LocalDate.of(2021, 5, 1)))
         assertThat(perioder.size).isEqualTo(2)
         assertThat(perioder.first().periode.tomDato).isEqualTo(LocalDate.of(2021, 4, 30))
         assertThat(perioder.last().periode.fomDato).isEqualTo(LocalDate.of(2021, 5, 1))
@@ -29,7 +29,7 @@ internal class GrunnbeløpstestTest {
 
     @Test
     internal fun `skal sette riktig startdato og sluttdato når beløpsperioder starter på en g-endringsperiode`() {
-        val perioder = finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 5, 1), LocalDate.of(2021, 8, 31)))
+        val perioder = Grunnbeløpsperioder.finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 5, 1), LocalDate.of(2021, 8, 31)))
         assertThat(perioder.size).isEqualTo(1)
         assertThat(perioder.first().periode.fomDato).isEqualTo(LocalDate.of(2021, 5, 1))
         assertThat(perioder.first().periode.tomDato).isEqualTo(LocalDate.of(2021, 8, 31))
@@ -37,7 +37,7 @@ internal class GrunnbeløpstestTest {
 
     @Test
     internal fun `skal sette riktig startdato og sluttdato når beløpsperioder starter dagen før en en g-endringsperiode`() {
-        val perioder = finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 4, 30), LocalDate.of(2021, 8, 1)))
+        val perioder = Grunnbeløpsperioder.finnGrunnbeløpsPerioder(Månedsperiode(LocalDate.of(2021, 4, 30), LocalDate.of(2021, 8, 1)))
         assertThat(perioder.size).isEqualTo(2)
         assertThat(perioder.first().periode.fomDato).isEqualTo(LocalDate.of(2021, 4, 1))
         assertThat(perioder.first().periode.tomDato).isEqualTo(LocalDate.of(2021, 4, 30))

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -96,7 +96,7 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
     lateinit var søknadService: SøknadService
 
     val personService = mockk<PersonService>()
-    val år = nyesteGrunnbeløpGyldigFraOgMed.year
+    val år = Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.year
 
     @BeforeEach
     fun setup() {
@@ -423,7 +423,7 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
             ObjectMapperProvider.objectMapper.readValue(readFile("expectedIverksettDto.json"))
 
         val andelerTilkjentYtelse = expectedIverksettDto.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.map {
-            if (it.periode.fomDato >= nyesteGrunnbeløpGyldigFraOgMed.atDay(1)) {
+            if (it.periode.fomDato >= Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.atDay(1)) {
                 it.copy(kildeBehandlingId = forrigeBehandling.id)
             } else {
                 it.copy(kildeBehandlingId = behandling.id)

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -503,5 +503,4 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
         )
         return inntektPeriode
     }
-
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
@@ -4,8 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.beregning.BeregningService
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.ValiderOmregningService
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløpGyldigFraOgMed
 import no.nav.familie.ef.sak.felles.util.mockFeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
@@ -91,7 +91,7 @@ class ValiderOmregningServiceTest {
     @Nested
     inner class ValiderHarSammePerioderSomTidligereVedtak {
 
-        private val år = nyesteGrunnbeløpGyldigFraOgMed.year
+        private val år = Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.year
 
         @BeforeEach
         internal fun setUp() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/økonomi/ØkonomiUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/økonomi/ØkonomiUtil.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.økonomi
 
-import no.nav.familie.ef.sak.beregning.nyesteGrunnbeløp
+import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelseType
@@ -16,7 +16,7 @@ fun lagTilkjentYtelse(
     personident: String = "123",
     type: TilkjentYtelseType = TilkjentYtelseType.FØRSTEGANGSBEHANDLING,
     startdato: LocalDate = andelerTilkjentYtelse.minOfOrNull { it.stønadFom } ?: LocalDate.now(),
-    grunnbeløpsmåned: YearMonth = nyesteGrunnbeløp.periode.fom,
+    grunnbeløpsmåned: YearMonth = Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fom,
 ) =
     TilkjentYtelse(
         id = id,


### PR DESCRIPTION
**Hvorfor?**
Noen av testene våre vil feile når vi legger inn nytt grunnbeløp. Vi ønsker derfor å kunne mocke gjeldende/nyeste grunnbeløp i noen av testene våre. Med denne endringen kan vi gjøre:
```
mockObject(Grunnbeløpsperioder)
every {Grunnbeløpsperioder.nyesteGrunnbeløp } returns GrunnbeløpFor2021 // Kjør test
unmockObject(Grunnbeløpsperioder)
```