### PR TITLE
Skal lage historikkinnslag for å logge når utredning av behandling starter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingshistorikk/domain/Behandlingshistorikk.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingshistorikk/domain/Behandlingshistorikk.kt
@@ -98,6 +98,7 @@ fun JsonWrapper?.tilJson(): Map<String, Any>? {
 }
 
 enum class StegUtfall {
+    UTREDNING_PÅBEGYNT,
     BESLUTTE_VEDTAK_GODKJENT,
     BESLUTTE_VEDTAK_UNDERKJENT,
     HENLAGT,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
+import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
+import no.nav.familie.ef.sak.behandlingshistorikk.domain.StegUtfall
 import no.nav.familie.ef.sak.blankett.BlankettRepository
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
@@ -32,6 +34,7 @@ class VurderingStegService(
     private val stegService: StegService,
     private val taskService: TaskService,
     private val blankettRepository: BlankettRepository,
+    private val behandlingshistorikkService: BehandlingshistorikkService,
 ) {
 
     @Transactional
@@ -105,6 +108,7 @@ class VurderingStegService(
             stegService.resetSteg(saksbehandling.id, StegType.VILKÅR)
         } else if (saksbehandling.harStatusOpprettet) {
             behandlingService.oppdaterStatusPåBehandling(saksbehandling.id, BehandlingStatus.UTREDES)
+            behandlingshistorikkService.opprettHistorikkInnslag(behandlingId = saksbehandling.id, stegtype = StegType.VILKÅR, utfall = StegUtfall.UTREDNING_PÅBEGYNT, metadata = null)
             opprettBehandlingsstatistikkTask(saksbehandling)
         }
     }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 

Hilde ønsker at vi skal finne en måte å måle saksbehandlingstiden i ef-sak, og for å klare dette må vi vite når en behandling starter og slutter. I første omgang skal det ses på tiden fra SB "plukker" oppgaven, til den sendes til beslutter. Ettersom plukking av oppgaver ikke er så lett å måle har vi etter mye diskusjoner valgt "første vilkårsvurdering" som start og "sendt til beslutter" som slutt. 

OBS: dette er ikke målinger, bare data som skal samles inn for å kunne lage målinger.

### Utdypende forklaring 🤓 
Behandlingshistorikk inneholder nesten informasjonen som trengs, men mangler definisjonen av start for førstegangsbehandlinger fordi vi har kun informasjon om når behandlingen ble opprettet og når SB er ferdig med vilkårsvurderingen. Det er derfor lagt til et historikkinnslag for å få med tiden SB bruker på vilkårsvurderingen:  

- Førstegangsbehandlinger: Legges inn et historikkinnslag på steg `VILKÅR` med utfall `UTREDNING_PÅBEGYNT` når behandlingstatus går fra `opprettet` til `utredes`.
- Revurderinger: Her brukes eksisterende historikkinnslag på steg `ÅRSAK_REVURDERING` som start. 

Sluttidspunkt vil være første innslag av `SEND_TIL_BESLUTTER` etter siste innslag av `ANGRE_SEND_TIL_BESLUTTER`.