### PR TITLE
Vil at tester skal fungere etter at vi legger til ny G for mai 2023.

### DIFF
--- a/src/test/resources/no/nav/familie/ef/sak/periode2_begynner_samtidig_som_forrige_første_periode.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/periode2_begynner_samtidig_som_forrige_første_periode.feature
@@ -7,8 +7,8 @@ Egenskap: Andelhistorikk: Behandling 2 blir oppdelt i 2 då den overlapper mai (
 
     Gitt følgende vedtak
       | BehandlingId | Fra og med dato | Til og med dato |
-      | 1            | 05.2022         | 04.2025         |
-      | 2            | 02.2022         | 01.2025         |
+      | 1            | 05.2022         | 04.2023         |
+      | 2            | 02.2022         | 01.2023         |
 
     Og følgende inntekter
       | BehandlingId | Fra og med dato | Inntekt |
@@ -20,16 +20,17 @@ Egenskap: Andelhistorikk: Behandling 2 blir oppdelt i 2 då den overlapper mai (
     Så forvent følgende historikk
       | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
       | 2            | 02.2022         | 04.2022         |              |                       |
-      | 1            | 05.2022         | 04.2025         | FJERNET      | 2                     |
-      | 2            | 05.2022         | 01.2025         |              |                       |
+      | 1            | 05.2022         | 04.2023         | FJERNET      | 2                     |
+      | 2            | 05.2022         | 01.2023         |              |                       |
+
 
   Scenario: Behandling 2 sin andre perioder begynner samtidig som behandling 1 sin første periode, med revurdering
 
     Gitt følgende vedtak
       | BehandlingId | Fra og med dato | Til og med dato |
-      | 1            | 05.2022         | 04.2025         |
-      | 2            | 02.2022         | 01.2025         |
-      | 3            | 07.2022         | 04.2025         |
+      | 1            | 05.2022         | 04.2023         |
+      | 2            | 02.2022         | 01.2023         |
+      | 3            | 07.2022         | 04.2023         |
 
     Og følgende inntekter
       | BehandlingId | Fra og med dato | Inntekt |
@@ -42,21 +43,21 @@ Egenskap: Andelhistorikk: Behandling 2 blir oppdelt i 2 då den overlapper mai (
     Så forvent følgende historikk
       | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
       | 2            | 02.2022         | 04.2022         |              |                       |
-      | 1            | 05.2022         | 04.2025         | FJERNET      | 2                     |
+      | 1            | 05.2022         | 04.2023         | FJERNET      | 2                     |
       | 2            | 05.2022         | 06.2022         | SPLITTET     | 3                     |
-      | 2            | 07.2022         | 01.2025         | FJERNET      | 3                     |
-      | 3            | 07.2022         | 04.2025         |              |                       |
+      | 2            | 07.2022         | 01.2023         | FJERNET      | 3                     |
+      | 3            | 07.2022         | 04.2023         |              |                       |
 
   Scenario: Behandling 2 sin andre perioder begynner samtidig som behandling 1 sin første periode, med flere revurderinger
 
     Gitt følgende vedtak
       | BehandlingId | Fra og med dato | Til og med dato |
-      | 1            | 05.2022         | 04.2025         |
-      | 2            | 05.2022         | 04.2025         |
-      | 3            | 02.2022         | 01.2025         |
-      | 4            | 07.2022         | 04.2025         |
-      | 5            | 09.2022         | 01.2025         |
-      | 6            | 10.2022         | 01.2025         |
+      | 1            | 05.2022         | 04.2023         |
+      | 2            | 05.2022         | 04.2023         |
+      | 3            | 02.2022         | 01.2023         |
+      | 4            | 07.2022         | 04.2023         |
+      | 5            | 09.2022         | 01.2023         |
+      | 6            | 10.2022         | 01.2023         |
 
 
     Og følgende inntekter
@@ -74,32 +75,32 @@ Egenskap: Andelhistorikk: Behandling 2 blir oppdelt i 2 då den overlapper mai (
     Så forvent følgende historikk
       | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
       | 3            | 02.2022         | 04.2022         |              |                       |
-      | 1            | 05.2022         | 04.2025         | FJERNET      | 2                     |
-      | 2            | 05.2022         | 04.2025         | FJERNET      | 3                     |
+      | 1            | 05.2022         | 04.2023         | FJERNET      | 2                     |
+      | 2            | 05.2022         | 04.2023         | FJERNET      | 3                     |
       | 3            | 05.2022         | 06.2022         | SPLITTET     | 4                     |
-      | 3            | 07.2022         | 01.2025         | FJERNET      | 4                     |
+      | 3            | 07.2022         | 01.2023         | FJERNET      | 4                     |
       | 4            | 07.2022         | 08.2022         | SPLITTET     | 5                     |
-      | 4            | 09.2022         | 04.2025         | FJERNET      | 5                     |
+      | 4            | 09.2022         | 04.2023         | FJERNET      | 5                     |
       | 5            | 09.2022         | 09.2022         | SPLITTET     | 6                     |
-      | 5            | 10.2022         | 01.2025         | FJERNET      | 6                     |
-      | 6            | 10.2022         | 01.2025         |              |                       |
+      | 5            | 10.2022         | 01.2023         | FJERNET      | 6                     |
+      | 6            | 10.2022         | 01.2023         |              |                       |
 
   Scenario: Behandling 2 sin andre periode overlapper behandling 1 sin første periode, men med ulike stønadsbeløp pga ulik inntekt
 
     Gitt følgende vedtak
       | BehandlingId | Fra og med dato | Til og med dato |
-      | 1            | 05.2022         | 04.2025         |
-      | 2            | 02.2022         | 01.2025         |
+      | 1            | 05.2022         | 04.2023         |
+      | 2            | 02.2022         | 01.2023         |
 
     Og følgende inntekter
       | BehandlingId | Fra og med dato | Inntekt  |
       | 1            | 05.2022         | 0        |
-      | 2            | 02.2022         | 2000000 |
+      | 2            | 02.2022         | 2000000  |
 
     Når beregner ytelse
 
     Så forvent følgende historikk
       | BehandlingId | Fra og med dato | Til og med dato | Endringstype | Endret i behandlingId |
       | 2            | 02.2022         | 04.2022         |              |                       |
-      | 1            | 05.2022         | 04.2025         | FJERNET      | 2                     |
-      | 2            | 05.2022         | 01.2025         |              |                       |
+      | 1            | 05.2022         | 04.2023         | FJERNET      | 2                     |
+      | 2            | 05.2022         | 01.2023         |              |                       |


### PR DESCRIPTION
**Hvorfor:** 
Uten endring feiler testene når vi får nye perioder etter innføring av ny G (mai-23, mai-24).
Vurderte å legge til forventede perioder gitt splitt i 23 og sette april 24 som stopp istedenfor 25.  
Det ville fungert, men det ble veldig fort mange perioder og tester ble vanskeligere å lese/forstå. 
Jeg mener vi fortsatt tester det vi ønsket å teste med april 2023 som "sisteperiode" her. 

Eksempel på stoppdato etter mai 2023: (første test)

<img width="1363" alt="image" src="https://github.com/navikt/familie-ef-sak/assets/53942238/4a708701-fbc9-455b-b155-008b337442e9">

I test 2 som nå har 6 historierader ville vi fått 16 (?)   

Testet lokalt med ny hypotetisk g for mai 23. Testene fungerer fint. 
  