### PR TITLE
Skal ikke bare søke etter oppgaver med behandlingstema skolepenger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.karakterutskrift
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
-import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.prosessering.internal.TaskService
@@ -37,7 +36,6 @@ class AutomatiskBrevInnhentingKarakterutskriftService(
         val opppgaver = oppgaveService.hentOppgaver(
             FinnOppgaveRequest(
                 tema = Tema.ENF,
-                behandlingstema = Behandlingstema.Skolepenger,
                 fristFomDato = oppgaveFrist,
                 fristTomDato = oppgaveFrist,
                 mappeId = mappeId.toLong(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/KarakterutskriftBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/KarakterutskriftBrevTaskTest.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ef.sak.karakterutskrift
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.brev.FrittståendeBrevService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Year
+
+internal class KarakterutskriftBrevTaskTest {
+
+    private val behandlingService = mockk<BehandlingService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val oppgaveService = mockk<OppgaveService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val frittståendeBrevService = mockk<FrittståendeBrevService>()
+
+    private val karakterutskriftBrevTask = KarakterutskriftBrevTask(
+        behandlingService,
+        fagsakService,
+        oppgaveService,
+        personopplysningerService,
+        frittståendeBrevService,
+    )
+
+    @Test
+    internal fun `task skal feile dersom det ikke finnes fagsak for ident på oppgaven`() {
+        val oppgaveId: Long = 123
+
+        every { oppgaveService.hentOppgave(oppgaveId) } returns Oppgave(
+            id = oppgaveId,
+            identer = listOf(OppgaveIdentV2("11111111", IdentGruppe.FOLKEREGISTERIDENT)),
+        )
+        every { fagsakService.finnFagsaker(any()) } returns emptyList()
+
+        val task = KarakterutskriftBrevTask.opprettTask(oppgaveId, KarakterutskriftBrevtype.HOVEDPERIODE, Year.of(2023))
+
+        val feil = assertThrows<Feil> { karakterutskriftBrevTask.doTask(task) }
+        assertThat(feil.frontendFeilmelding?.contains("Fant ikke fagsak"))
+    }
+
+    @Test
+    internal fun `task skal feile dersom det ikke finnes behandling for ident på oppgaven`() {
+        val oppgaveId: Long = 123
+
+        every { oppgaveService.hentOppgave(oppgaveId) } returns Oppgave(
+            id = oppgaveId,
+            identer = listOf(OppgaveIdentV2("11111111", IdentGruppe.FOLKEREGISTERIDENT)),
+        )
+        every { behandlingService.finnesBehandlingForFagsak(any()) } returns false
+        every { fagsakService.finnFagsaker(any()) } returns listOf(fagsak())
+
+        val task = KarakterutskriftBrevTask.opprettTask(oppgaveId, KarakterutskriftBrevtype.HOVEDPERIODE, Year.of(2023))
+
+        val feil = assertThrows<Feil> { karakterutskriftBrevTask.doTask(task) }
+        assertThat(feil.frontendFeilmelding?.contains("Fant ikke behandling"))
+    }
+}


### PR DESCRIPTION
Fortsettelse på [automatisk utsending av brev for innhenting av karakterutskrift](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8258)

**Hvorfor denne endringen?**
Gjorde en dryRun i prod og fant 0 oppgaver i søket vårt 😢 Etter å se sett på oppgavelisten i prod med Mirja fant vi ut at vi ikke skal søke på behandlingstema skolepenger. De fleste oppgavene i mappen hadde tema overgangsstønad, og noen hadde ikke tema. Skal derfor bare søke etter alle oppgaver i mappen med riktig frist. Fjerner derfor også validering av at person har fagsak/ behandling på skolepenger.