### PR TITLE
Endret G-omregning tester til å bruke reell grunnbeløp for 2023

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -200,14 +200,14 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
             assertThat(iverksettDto.vedtak.tilkjentYtelse?.andelerTilkjentYtelse?.size).isEqualTo(2) // skal være splittet
             // Sjekk andel etter ny g omregningsdato
             val andelTilkjentYtelseOmregnet = finnAndelEtterNyGDato(iverksettDto)!!
-            assertThat(andelTilkjentYtelseOmregnet.inntekt).isEqualTo(222000)
-            assertThat(andelTilkjentYtelseOmregnet.beløp).isEqualTo(16019)
+            assertThat(andelTilkjentYtelseOmregnet.inntekt).isEqualTo(223000)
+            assertThat(andelTilkjentYtelseOmregnet.beløp).isEqualTo(16103)
             // Sjekk inntektsperiode etter ny G omregning
             val inntektsperiodeEtterGomregning = finnInntektsperiodeEtterNyGDato(iverksettDto.behandling.behandlingId, 2023)
             assertThat(inntektsperiodeEtterGomregning.dagsats?.toInt()).isEqualTo(0)
             assertThat(inntektsperiodeEtterGomregning.månedsinntekt?.toInt()).isEqualTo(0)
-            assertThat(inntektsperiodeEtterGomregning.inntekt.toInt()).isEqualTo(222348)
-            assertThat(inntektsperiodeEtterGomregning.totalinntekt().toInt()).isEqualTo(222348)
+            assertThat(inntektsperiodeEtterGomregning.inntekt.toInt()).isEqualTo(223455)
+            assertThat(inntektsperiodeEtterGomregning.totalinntekt().toInt()).isEqualTo(223455)
         }
     }
 

--- a/src/test/kotlin/testutil/GOmregningsperiodeHelper.kt
+++ b/src/test/kotlin/testutil/GOmregningsperiodeHelper.kt
@@ -41,7 +41,7 @@ fun mockTestMedGrunnbeløpFra2022(test: () -> Unit) {
 fun mockTestMedGrunnbeløpFra2023(test: () -> Unit) {
     val grunnbeløp2023 = Grunnbeløp(
         periode = Månedsperiode(YearMonth.parse("2023-05"), YearMonth.from(LocalDate.MAX)),
-        grunnbeløp = 118_032.toBigDecimal(),
+        grunnbeløp = 118_620.toBigDecimal(),
         perMnd = BigDecimal.ZERO,
         gjennomsnittPerÅr = BigDecimal.ZERO,
     )

--- a/src/test/resources/no/nav/familie/ef/sak/gomregning-av-løpende.feature
+++ b/src/test/resources/no/nav/familie/ef/sak/gomregning-av-løpende.feature
@@ -43,7 +43,7 @@ Egenskap: G-omregning
       | Fra og med dato | Til og med dato | Kildebehandling | Inntekt   | Beløp   |
       | 01.2023         | 12.2023         | 1               | <Inntekt> | <Beløp> |
 
-    Når utfør g-omregning for år 2023 med beløp 118032
+    Når utfør g-omregning for år 2023 med beløp 118620
 
     Så forvent følgende andeler for g-omregnet tilkjent ytelse
       | Fra og med dato | Til og med dato | Inntekt                 | Beløp              |
@@ -52,10 +52,10 @@ Egenskap: G-omregning
 
     Eksempler:
       | Inntekt | Beløp | Indeksjustert inntekt | G omregnet beløp |
-      | 10000   | 20902 | 10000                 | 22131            |
-      | 120000  | 18492 | 127000                | 19582            |
-      | 180000  | 16242 | 190000                | 17219            |
-      | 210000  | 15117 | 222000                | 16019            |
-      | 240000  | 13992 | 254000                | 14819            |
-      | 600000  | 492   | 635000                | 532              |
-      | 700000  | 0     | 741000                | 0                |
+      | 10000   | 20902 | 10000                 | 22241            |
+      | 120000  | 18492 | 127000                | 19703            |
+      | 180000  | 16242 | 191000                | 17303            |
+      | 210000  | 15117 | 223000                | 16103            |
+      | 240000  | 13992 | 255000                | 14903            |
+      | 600000  | 492   | 638000                | 540              |
+      | 700000  | 0     | 744000                | 0                |


### PR DESCRIPTION
Skal bruke cucumber-testen til å sjekke med funksjonelle om de er enige i beregningen