### PR TITLE
Skal ikke runde av inntektsverdier som allerede er gomregnet

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
@@ -36,6 +36,22 @@ data class Inntektsperiode(
             (this.dagsats ?: BigDecimal.ZERO).multiply(BeregningUtils.DAGSATS_ANTALL_DAGER) +
             (this.månedsinntekt ?: BigDecimal.ZERO).multiply(BeregningUtils.ANTALL_MÅNEDER_ÅR)
     }
+
+    /**
+     * Dersom den eksisterende årsinntekten er g-omregnet til nærmeste 100,
+     * så skal vi ikke nedjustere denne til nærmeste 1000
+     */
+    fun skalRundeAvTilNærmeste1000(): Boolean {
+        if (this.dagsats != null && this.dagsats > BigDecimal.ZERO) {
+            return true
+        } else if (this.månedsinntekt != null && this.månedsinntekt > BigDecimal.ZERO) {
+            return true
+        } else if (this.inntekt.remainder(BigDecimal(100)) > BigDecimal.ZERO) {
+            return true
+        } else {
+            return false
+        }
+    }
 }
 
 fun List<Inntekt>.tilInntektsperioder() = this.mapIndexed { index, inntektsperiode ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.beregning
 
+import no.nav.familie.ef.sak.felles.util.Utregning
 import no.nav.familie.ef.sak.felles.util.Utregning.rundNedTilNærmeste1000
 import no.nav.familie.ef.sak.felles.util.Utregning.rundNedTilNærmesteKrone
 import no.nav.familie.kontrakter.felles.Månedsperiode
@@ -57,7 +58,9 @@ object BeregningUtils {
 
     private fun beregnTotalinntekt(inntektsperiode: Inntektsperiode, skalRundeNedTotalInntekt: Boolean): BigDecimal {
         val totalInntekt = inntektsperiode.totalinntekt()
-        return if (skalRundeNedTotalInntekt) BigDecimal(rundNedTilNærmeste1000(totalInntekt)) else totalInntekt
+        val skalRundeNedBasertPåInntektsperiodensVerdier = inntektsperiode.skalRundeAvTilNærmeste1000()
+
+        return if (skalRundeNedTotalInntekt && skalRundeNedBasertPåInntektsperiodensVerdier) BigDecimal(rundNedTilNærmeste1000(totalInntekt)) else totalInntekt
     }
 
     private fun beregnAvkortning(grunnbeløp: BigDecimal, inntekt: BigDecimal): BigDecimal {


### PR DESCRIPTION
Vi må gjøre et kvalifisert "gjett" på at dersom det KUN finnes årsinntekt og denne har en hundre-verdi (100, 200, 300 osv) så trenger vi ikke å avrunde ned til nærmeste hundre-verdi.

Det finnes 20 tilfeller i prod hvor denne typen verdier HAR blitt avrundet siden vi gikk live med dag/måned/år-inntektsbeløp. 

Disse vil potensielt få tilbakrekreving på noen kroner. Siden det er under 4xrettsgebyr vil det aldri bli tilbakekrevd, og får vi spørsmål på teams vil den "enkleste" fiksen være å legge til/fjerne én krone på årsinntekten for at det skal bli likt beløp som tidligere.

En liten hack, men heller dette enn å ha en "knapp" per inntektsperiode for å runde av "riktig" for alle mulige perioder.