### PR TITLE
Controllertest av utsending av karakterutskriftsbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftController.kt
@@ -38,7 +38,7 @@ class AutomatiskBrevInnhentingKarakterutskriftController(
     }
 
     private fun validerBrevtype(brevtype: FrittståendeBrevType) {
-        feilHvisIkke(
+        feilHvis(
             brevtype != FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE &&
                 brevtype != FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_UTVIDET_PERIODE,
         ) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
@@ -73,6 +73,11 @@ class OppgaveClientMock {
                             enhetsnr = "4489",
                         ),
                         MappeDto(
+                            id = 106,
+                            navn = "64 Utdanning",
+                            enhetsnr = "4489",
+                        ),
+                        MappeDto(
                             id = 102,
                             navn = "70 Godkjennevedtak",
                             enhetsnr = "4489",

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.ef.sak.karakterutskrift
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+
+internal class AutomatiskBrevInnhentingKarakterutskriftControllerTest : OppslagSpringRunnerTest() {
+
+    @Autowired lateinit var taskService: TaskService
+
+    @BeforeEach
+    fun setUp() {
+        headers.setBearerAuth(lokalTestToken)
+    }
+
+    @Test
+    internal fun `Skal ikke opprette tasks når liveRun er false`() {
+        val respons = opprettTasks(liveRun = false)
+
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(taskService.findAll().none { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }).isTrue
+    }
+
+    @Test
+    internal fun `Skal opprette tasks når liveRun er true`() {
+        val respons = opprettTasks(liveRun = true)
+
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }).isTrue
+    }
+
+    private fun opprettTasks(
+        liveRun: Boolean = true,
+        brevtype: FrittståendeBrevType = FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE,
+    ): ResponseEntity<Ressurs<Unit>> {
+        return restTemplate.exchange(
+            localhost("/api/automatisk-brev-innhenting-karakterutskrift/opprett-tasks"),
+            HttpMethod.POST,
+            HttpEntity(KarakterutskriftRequest(liveRun = liveRun, frittståendeBrevType = brevtype), headers),
+        )
+    }
+}


### PR DESCRIPTION
**Hvorfor?**
Legger til tester relatert til [automatisk utsending av karakterutskriftsbrev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8258).
Vil verifisere at tasks for utsending av karakterutskriftsbrev ikke blir opprettet når `liveRun = false`.

Fordi mapper/oppgaver er mocket gir det ikke så mye verdi å se på innholdet i de forskjellige taskene. Dette er hovedsaklig en ekstra sikkerthet mtp. liveRun/dryRun-logikk.

Oppdaget også en liten bug i validering av brevtype som fikses.

Kommer flere tester på service-nivå etter hvert 🤠 