### PR TITLE
Fjerner felt for tilrettelagtKommunikasjon siden denne ikke er i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -17,7 +17,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Navn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Opphold
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Oppholdsadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.TilrettelagtKommunikasjon
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergemaalEllerFremtidsfullmakt
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
@@ -89,7 +88,6 @@ data class Søker(
     val oppholdsadresse: List<Oppholdsadresse>,
     val sivilstand: List<SivilstandMedNavn>,
     val statsborgerskap: List<Statsborgerskap>,
-    val tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon>,
     val innflyttingTilNorge: List<InnflyttingTilNorge>,
     val utflyttingFraNorge: List<UtflyttingFraNorge>,
     val vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -71,7 +71,6 @@ object GrunnlagsdataMapper {
         opphold = pdlSøker.opphold,
         oppholdsadresse = pdlSøker.oppholdsadresse,
         statsborgerskap = pdlSøker.statsborgerskap,
-        tilrettelagtKommunikasjon = pdlSøker.tilrettelagtKommunikasjon,
         utflyttingFraNorge = pdlSøker.utflyttingFraNorge,
         vergemaalEllerFremtidsfullmakt = mapVergemålEllerFremtidsfullmakt(pdlSøker, andrePersoner),
         folkeregisteridentifikator = mapFolkeregisteridentifikator(pdlSøker.folkeregisteridentifikator),

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -117,7 +117,6 @@ data class PdlSøker(
     val oppholdsadresse: List<Oppholdsadresse>,
     val sivilstand: List<Sivilstand>,
     val statsborgerskap: List<Statsborgerskap>,
-    val tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon>,
     val innflyttingTilNorge: List<InnflyttingTilNorge>,
     val utflyttingFraNorge: List<UtflyttingFraNorge>,
     val vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt>,
@@ -377,11 +376,6 @@ data class Personnavn(
     val etternavn: String,
     val fornavn: String,
     val mellomnavn: String?,
-)
-
-data class TilrettelagtKommunikasjon(
-    @JsonProperty("talespraaktolk") val talespråktolk: Tolk?,
-    @JsonProperty("tegnspraaktolk") val tegnspråktolk: Tolk?,
 )
 
 data class Tolk(@JsonProperty("spraak") val språk: String?)

--- a/src/main/resources/pdl/pdl-api-schema.graphql
+++ b/src/main/resources/pdl/pdl-api-schema.graphql
@@ -457,7 +457,6 @@ type Person {
     sivilstand(historikk: Boolean = false): [Sivilstand!]!
     statsborgerskap(historikk: Boolean = false): [Statsborgerskap!]!
     telefonnummer: [Telefonnummer!]!
-    tilrettelagtKommunikasjon: [TilrettelagtKommunikasjon!]!
     utenlandskIdentifikasjonsnummer(historikk: Boolean = false): [UtenlandskIdentifikasjonsnummer!]!
     utflyttingFraNorge: [UtflyttingFraNorge!]!
     vergemaalEllerFremtidsfullmakt(historikk: Boolean = false): [VergemaalEllerFremtidsfullmakt!]!
@@ -592,12 +591,6 @@ type Telefonnummer {
     metadata: Metadata!
     nummer: String!
     prioritet: Int!
-}
-
-type TilrettelagtKommunikasjon {
-    metadata: Metadata!
-    talespraaktolk: Tolk
-    tegnspraaktolk: Tolk
 }
 
 type Tolk {

--- a/src/main/resources/pdl/søker.graphql
+++ b/src/main/resources/pdl/søker.graphql
@@ -220,14 +220,6 @@ query($ident: ID!){
             gyldigFraOgMed
             gyldigTilOgMed
         }
-        tilrettelagtKommunikasjon {
-            talespraaktolk {
-                spraak
-            }
-            tegnspraaktolk {
-                spraak
-            }
-        }
         innflyttingTilNorge {
             fraflyttingsland
             fraflyttingsstedIUtlandet

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
@@ -35,7 +35,6 @@ fun opprettGrunnlagsdata(
         oppholdsadresse = emptyList(),
         sivilstand = emptyList(),
         statsborgerskap = emptyList(),
-        tilrettelagtKommunikasjon = emptyList(),
         innflyttingTilNorge = innflyttingTilNorge,
         utflyttingFraNorge = utflyttingFraNorge,
         vergemaalEllerFremtidsfullmakt = emptyList(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -196,7 +196,6 @@ class PdlClientConfig {
                 oppholdsadresse = listOf(),
                 sivilstand = sivilstand(),
                 statsborgerskap = statsborgerskap(),
-                tilrettelagtKommunikasjon = listOf(),
                 innflyttingTilNorge = listOf(InnflyttingTilNorge("SWE", "Stockholm", folkeregistermetadata)),
                 utflyttingFraNorge = listOf(
                     UtflyttingFraNorge(

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -141,7 +141,6 @@ object PdlTestdata {
                     ),
                 ),
                 statsborgerskap,
-                listOf(TilrettelagtKommunikasjon(Tolk(""), Tolk(""))),
                 innflyttingTilNorge,
                 utflyttingFraNorge,
                 listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -494,5 +494,4 @@ fun søker(sivilstand: List<SivilstandMedNavn> = emptyList()): Søker =
         listOf(),
         listOf(),
         listOf(),
-        listOf(),
     )

--- a/src/test/kotlin/testutil/PdlTestdataHelper.kt
+++ b/src/test/kotlin/testutil/PdlTestdataHelper.kt
@@ -22,7 +22,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonForeld
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Statsborgerskap
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.TilrettelagtKommunikasjon
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UkjentBosted
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.UtflyttingFraNorge
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.VergemaalEllerFremtidsfullmakt
@@ -64,7 +63,6 @@ object PdlTestdataHelper {
         oppholdsadresse: List<Oppholdsadresse> = emptyList(),
         sivilstand: List<Sivilstand> = emptyList(),
         statsborgerskap: List<Statsborgerskap> = emptyList(),
-        tilrettelagtKommunikasjon: List<TilrettelagtKommunikasjon> = emptyList(),
         innflyttingTilNorge: List<InnflyttingTilNorge> = emptyList(),
         utflyttingFraNorge: List<UtflyttingFraNorge> = emptyList(),
         vergemaalEllerFremtidsfullmakt: List<VergemaalEllerFremtidsfullmakt> = emptyList(),
@@ -86,7 +84,6 @@ object PdlTestdataHelper {
             oppholdsadresse,
             sivilstand,
             statsborgerskap,
-            tilrettelagtKommunikasjon,
             innflyttingTilNorge,
             utflyttingFraNorge,
             vergemaalEllerFremtidsfullmakt,

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -891,37 +891,6 @@
         },
         "nullable" : false
       },
-      "tilrettelagtKommunikasjon" : {
-        "name" : "tilrettelagtKommunikasjon",
-        "type" : "Collection",
-        "fields" : {
-          "talespråktolk" : {
-            "name" : "talespråktolk",
-            "type" : "Object",
-            "fields" : {
-              "språk" : {
-                "name" : "språk",
-                "type" : "String",
-                "nullable" : true
-              }
-            },
-            "nullable" : true
-          },
-          "tegnspråktolk" : {
-            "name" : "tegnspråktolk",
-            "type" : "Object",
-            "fields" : {
-              "språk" : {
-                "name" : "språk",
-                "type" : "String",
-                "nullable" : true
-              }
-            },
-            "nullable" : true
-          }
-        },
-        "nullable" : false
-      },
       "innflyttingTilNorge" : {
         "name" : "innflyttingTilNorge",
         "type" : "Collection",

--- a/src/test/resources/json/søker.json
+++ b/src/test/resources/json/søker.json
@@ -146,7 +146,6 @@
           "gyldigTilOgMed": null
         }
       ],
-      "tilrettelagtKommunikasjon": [],
       "innflyttingTilNorge": [
         {
           "fraflyttingsland": "CYP",


### PR DESCRIPTION
Hvorfor ? 

Feltet tilrettelagtKommunikasjon er ikke i bruk og bør derfor ikke hentes fra pdl. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12517