### PR TITLE
Må sette callId på task etter task er opprettet for at denne ikke overskrives

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftService.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
-import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.prosessering.internal.TaskService

--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
@@ -21,6 +21,7 @@ import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Task
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -105,7 +106,7 @@ class SendKarakterutskriftBrevTilIverksettTask(
                 setProperty(MDCConstants.MDC_CALL_ID, IdUtils.generateId())
             }
 
-            return Task(TYPE, payload, properties)
+            return Task(TYPE, payload).copy(metadataWrapper = PropertiesWrapper(properties))
         }
 
         const val TYPE = "SendKarakterutskriftBrevTilIverksettTask"

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
@@ -39,6 +39,16 @@ internal class AutomatiskBrevInnhentingKarakterutskriftControllerTest : OppslagS
         assertThat(taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }).isTrue
     }
 
+    @Test
+    internal fun `Tasker skal ha unik callId`() {
+        val respons = opprettTasks(liveRun = true)
+
+        assertThat(respons.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }).isTrue
+        assertThat(taskService.findAll().map { it.callId }).doesNotHaveDuplicates()
+        assertThat(taskService.findAll().size > 1).isTrue
+    }
+
     private fun opprettTasks(
         liveRun: Boolean = true,
         brevtype: FrittståendeBrevType = FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE,


### PR DESCRIPTION
Bugfix relatert til [utsending av karakterutskriftsbrev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8258)

**Hvorfor?**
Uten denne endringen vil alle tasker opprettet gjennom karakterutskriftcontrolleren ha samme callId. callId bør være unik for hver av av SendKarakterutskriftBrevTilIverksettTask'ene våre for å kunne spore en enkelt taskflyt gjennom sak/iverksett. Default oppførsel til Task er at den plukker ut callId fra log4j/mdc, og setter denne på tasken,  uavhengig av hva som sendes inn som properties. Derfor må denne verdien settes etter at tasken er opprettet.