### PR TITLE
identen til vår fagressurs skal kunne migrere saker sju år tilbake i tid

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -223,11 +223,7 @@ class InfotrygdPeriodeValideringService(
             )
         }
 
-        val årBakoverTillattVedMigrering: Long =
-            when (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE)) {
-                true -> 5
-                false -> 3
-            }
+        val årBakoverTillattVedMigrering = utledÅrBakoverTillattVedMigrering()
 
         if (dato.isBefore(LocalDate.now().minusYears(årBakoverTillattVedMigrering))) {
             throw MigreringException(
@@ -285,6 +281,16 @@ class InfotrygdPeriodeValideringService(
                     MigreringExceptionType.ÅPEN_SAK,
                 )
             }
+    }
+
+    private fun utledÅrBakoverTillattVedMigrering(): Long {
+        if (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE)) {
+            return 7
+        }
+        else if (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE)){
+            return 5
+        }
+        return 3
     }
 
     private fun lagSakFeilinfo(sak: InfotrygdSak): String {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -41,6 +41,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     VURDER_KONSEKVENS_OPPGAVER_LOKALKONTOR("familie.ef.sak.automatiske-oppgaver-lokalkontor"),
     KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-pa-apen-behandling"),
     TILLAT_MIGRERING_5_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-5-ar-tilbake", "Permission"),
+    TILLAT_MIGRERING_7_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-7-ar-tilbake", "Permission"),
     AUTOMATISKE_OPPGAVER_FREMLEGGSOPPGAVE("familie.ef.sak.automatiske-oppgaver.fremleggsoppgave"),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT("familie.ef.sak.automatiske-brev-innhenting-karakterutskrift"),
     ;

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -19,6 +19,7 @@ class FeatureToggleMock {
         val mockk = mockk<FeatureToggleService>()
         every { mockk.isEnabled(any()) } returns true
         every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE) } returns false
+        every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE) } returns false
         return mockk
     }
 }


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12828)

Identen til Mirja har behov for å få tilgang til å migrere en sak sju år tilbake i tid. 

```Saksbehandler har en sak fra 2017 som skal migreres. Vi har diskutert tidligere at vi ikke utvider tilgangen for alle ennå, men at Mirja migrerer de sakene.```

Lenke til ny feature toggle: 
https://unleash.nais.io/#/features/strategies/familie.ef.sak.tillat-migrering-7-ar-tilbake