### PR TITLE
Skal sjekke om task allerede er opprettet for utsending av karakterutskriftsbrev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
@@ -102,13 +102,7 @@ class SendKarakterutskriftBrevTilIverksettTask(
     companion object {
 
         fun opprettTask(oppgaveId: Long, brevType: FrittståendeBrevType, gjeldendeÅr: Year): Task {
-            val payload = objectMapper.writeValueAsString(
-                AutomatiskBrevKarakterutskriftPayload(
-                    oppgaveId,
-                    brevType,
-                    gjeldendeÅr,
-                ),
-            )
+            val payload = opprettTaskPayload(oppgaveId, brevType, gjeldendeÅr)
 
             val properties = Properties().apply {
                 setProperty("oppgaveId", oppgaveId.toString())
@@ -117,6 +111,11 @@ class SendKarakterutskriftBrevTilIverksettTask(
 
             return Task(TYPE, payload).copy(metadataWrapper = PropertiesWrapper(properties))
         }
+
+        fun opprettTaskPayload(oppgaveId: Long, brevType: FrittståendeBrevType, gjeldendeÅr: Year): String =
+            objectMapper.writeValueAsString(
+                AutomatiskBrevKarakterutskriftPayload(oppgaveId, brevType, gjeldendeÅr),
+            )
 
         const val TYPE = "SendKarakterutskriftBrevTilIverksettTask"
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
@@ -51,10 +51,10 @@ internal class AutomatiskBrevInnhentingKarakterutskriftControllerTest : OppslagS
 
     @Test
     internal fun `Skal ikke opprette tasker for oppgaver det allerede er opprettet for`() {
-        val førsteRespons = opprettTasks(liveRun = true)
+        val førsteRespons = opprettTasks(liveRun = true, taskLimit = 10)
         val antallTaskerEtterFørsteKjøring = taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }
 
-        val andreRespons = opprettTasks(liveRun = true)
+        val andreRespons = opprettTasks(liveRun = true, taskLimit = 10)
 
         val antallTaskerEtterAndreKjøring = taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftControllerTest.kt
@@ -49,6 +49,20 @@ internal class AutomatiskBrevInnhentingKarakterutskriftControllerTest : OppslagS
         assertThat(taskService.findAll().size > 1).isTrue
     }
 
+    @Test
+    internal fun `Skal ikke opprette tasker for oppgaver det allerede er opprettet for`() {
+        val førsteRespons = opprettTasks(liveRun = true)
+        val antallTaskerEtterFørsteKjøring = taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }
+
+        val andreRespons = opprettTasks(liveRun = true)
+
+        val antallTaskerEtterAndreKjøring = taskService.findAll().any { it.type == SendKarakterutskriftBrevTilIverksettTask.TYPE }
+
+        assertThat(førsteRespons.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(andreRespons.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(antallTaskerEtterFørsteKjøring).isEqualTo(antallTaskerEtterAndreKjøring)
+    }
+
     private fun opprettTasks(
         liveRun: Boolean = true,
         brevtype: FrittståendeBrevType = FrittståendeBrevType.INNHENTING_AV_KARAKTERUTSKRIFT_HOVEDPERIODE,

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/AutomatiskBrevInnhentingKarakterutskriftServiceTest.kt
@@ -38,6 +38,7 @@ internal class AutomatiskBrevInnhentingKarakterutskriftServiceTest {
 
         val oppgaver = listOf(oppgave(), oppgave(), oppgave(), oppgave(), oppgave())
 
+        every { taskService.finnTaskMedPayloadOgType(any(), SendKarakterutskriftBrevTilIverksettTask.TYPE) } returns null
         every { taskService.save(capture(taskSlots)) } returns mockk()
         every { oppgaveService.hentOppgaver(any()) } returns FinnOppgaveResponseDto(
             antallTreffTotalt = oppgaver.size.toLong(),


### PR DESCRIPTION
**Hvorfor?**
Vi har en unikhetsconstraint i task-tabellen på feltene ´oppgaveId´, ´brevtype´ og `gjeldendeÅr`. Derfor vil opprettelse av task feile dersom vi tidligere har opprettet for samme oppgave. Dette kan f.eks. skje dersom noen har verge, eller noe annet feiler i utsendelsflyten. Derfor vil vi sjekke om task er opprettet tidligere, sånn at den kan fortsette å opprette for de resterende oppgavene uten å feile først.