### PR TITLE
Skal feile dersom saksbehandler prøver å sende til beslutter rett ett…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
@@ -72,6 +73,13 @@ class SendTilBeslutterSteg(
         validerOmregningService.validerHarGammelGOgKanLagres(saksbehandling)
 
         årsakRevurderingService.validerHarGyldigRevurderingsinformasjon(saksbehandling)
+        validerAtDetFinnesOppgave(saksbehandling)
+    }
+
+    private fun validerAtDetFinnesOppgave(saksbehandling: Saksbehandling) {
+        feilHvis(oppgaveService.hentBehandleSakOppgaveSomIkkeErFerdigstilt(saksbehandling.id) == null) {
+            "Oppgaven for behandlingen er ikke tilgjengelig. Vennligst vent og prøv igjen om litt."
+        }
     }
 
     private fun validerRiktigTilstandVedInvilgelse(saksbehandling: Saksbehandling) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -167,6 +167,13 @@ class OppgaveService(
         return oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(saksbehandling.id, oppgavetype)
     }
 
+    fun hentBehandleSakOppgaveSomIkkeErFerdigstilt(behandlingId: UUID): EfOppgave? {
+        return oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
+            behandlingId,
+            setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak),
+        )
+    }
+
     fun hentOppgave(gsakOppgaveId: Long): Oppgave {
         return oppgaveClient.finnOppgaveMedId(gsakOppgaveId)
     }
@@ -220,10 +227,7 @@ class OppgaveService(
     }
 
     fun hentIkkeFerdigstiltOppgaveForBehandling(behandlingId: UUID): Oppgave? {
-        return oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
-            behandlingId,
-            setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak),
-        )
+        return hentBehandleSakOppgaveSomIkkeErFerdigstilt(behandlingId)
             ?.let { oppgaveClient.finnOppgaveMedId(it.gsakOppgaveId) }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.api.gui.VedtakControllerTest.Saksbehandler.BESLUTTE
 import no.nav.familie.ef.sak.api.gui.VedtakControllerTest.Saksbehandler.SAKSBEHANDLER
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
@@ -19,6 +20,8 @@ import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.oppgave.Oppgave
+import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -90,6 +93,9 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var grunnlagsdataService: GrunnlagsdataService
+
+    @Autowired
+    private lateinit var oppgaveRepository: OppgaveRepository
 
     @Autowired
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
@@ -414,7 +420,17 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
             "1",
         )
         grunnlagsdataService.opprettGrunnlagsdata(lagretBehandling.id)
+        opprettOppgave(lagretBehandling.id)
         return lagretBehandling.id
+    }
+
+    private fun opprettOppgave(behandlingId: UUID) {
+        val oppgave = Oppgave(
+            gsakOppgaveId = 12345L,
+            behandlingId = behandlingId,
+            type = Oppgavetype.BehandleSak,
+        )
+        oppgaveRepository.insert(oppgave)
     }
 
     private fun opprettOppgave(

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.api.gui.VedtakControllerTest.Saksbehandler.BESLUTTE
 import no.nav.familie.ef.sak.api.gui.VedtakControllerTest.Saksbehandler.SAKSBEHANDLER
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType


### PR DESCRIPTION
…er at man har tatt tilbake en sak fra beslutter. Dette fordi  oppdatering av oppgaver blir gjort asynkront og dermed forsøker vi å opprette og ferdigstille uten Ãat oppgavene foreligger. Løsningen blir følgelig at vi sjekke at det faktisk finnes en behandlesak-oppgave før vi sender til beslutter.

[Løser denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12535)

Siden vi har en "jobb" hver mandag som sjekker at vi ikke har "løse" behandlinger, så bør det ikke finnes behandlinger som ikke har oppgave. Usikker på hva vi gjør dersom vi treffer på et slikt tilfelle, for da får man ikke sendt til beslutter i det hele tatt 😬 