### PR TITLE
Opprett task som finner fagsaker som er kandidater for satsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository
 import java.util.UUID
 
 @Repository
-interface BarnetilsynSatsendringRepository : RepositoryInterface<BarnetilsynSatsendringKanditat, UUID> {
+interface BarnetilsynSatsendringRepository : RepositoryInterface<BarnetilsynSatsendringKandidat, UUID> {
 
     // language=PostgreSQL
     @Query(
@@ -15,7 +15,7 @@ interface BarnetilsynSatsendringRepository : RepositoryInterface<BarnetilsynSats
         FROM gjeldende_iverksatte_behandlinger gib
          JOIN tilkjent_ytelse ty ON ty.behandling_id = gib.id
          JOIN andel_tilkjent_ytelse aty ON ty.id = aty.tilkjent_ytelse
-        WHERE aty.stonad_tom >= '2023-01-01' AND gib.stonadstype = 'BARNETILSYN'
+        WHERE aty.stonad_tom >= '2023-07-01' AND gib.stonadstype = 'BARNETILSYN'
         """,
     )
     fun finnSatsendringskandidaterForBarnetilsyn(): List<UUID>

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.beregning.barnetilsyn.satsendring
 
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import kotlin.random.Random
 
@@ -9,9 +9,7 @@ import kotlin.random.Random
 @Service
 class BarnetilsynSatsendringScheduler(val barnetilsynSatsendringService: BarnetilsynSatsendringService) {
 
-    private val logger = LoggerFactory.getLogger(javaClass)
-
-    // @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) //Kjører ved oppstart av app
+    @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) // Kjører ved oppstart av app
     fun opprettTask() {
         Thread.sleep(Random.nextLong(5_000)) // YOLO unngå feil med att 2 noder
         barnetilsynSatsendringService.opprettTask()

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
@@ -43,13 +43,13 @@ class BarnetilsynSatsendringService(
         }
     }
 
-    private fun finnFagsakerSomSkalSatsendresMedNySats(brukIkkeVedtatteSatser: Boolean = true): List<BarnetilsynSatsendringKanditat> {
+    private fun finnFagsakerSomSkalSatsendresMedNySats(brukIkkeVedtatteSatser: Boolean = true): List<BarnetilsynSatsendringKandidat> {
         val fagsakIds = barnetilsynSatsendringRepository.finnSatsendringskandidaterForBarnetilsyn()
-        val barnetilsynSatsendringKanditat: List<BarnetilsynSatsendringKanditat> =
-            fagsakIds.map { BarnetilsynSatsendringKanditat(it, vedtakHistorikkService.hentAktivHistorikk(it)) }
-        logger.info("Antall kandidater til satsendring: ${barnetilsynSatsendringKanditat.size}")
+        val barnetilsynSatsendringKandidat: List<BarnetilsynSatsendringKandidat> =
+            fagsakIds.map { BarnetilsynSatsendringKandidat(it, vedtakHistorikkService.hentAktivHistorikk(it)) }
+        logger.info("Antall kandidater til satsendring: ${barnetilsynSatsendringKandidat.size}")
 
-        val kandidaterMedSkalRevurderesSatt = barnetilsynSatsendringKanditat.map {
+        val kandidaterMedSkalRevurderesSatt = barnetilsynSatsendringKandidat.map {
             val nåværendeAndelerForNesteÅr = it.andelerEtter(YearMonth.of(YearMonth.now().year, 12))
             val nyBeregningMånedsperioder = gjørNyBeregning(nåværendeAndelerForNesteÅr, brukIkkeVedtatteSatser)
             val skalRevurderes: Boolean =
@@ -111,7 +111,7 @@ class BarnetilsynSatsendringService(
     }
 }
 
-data class BarnetilsynSatsendringKanditat(
+data class BarnetilsynSatsendringKandidat(
     val fagsakId: UUID,
     val andelshistorikk: List<AndelHistorikkDto>,
     val skalRevurderes: Boolean = false,


### PR DESCRIPTION
**Hvorfor gjøres dette**
Første steg i satsendring er å finne kandidater til manuell satsendring, altså de sakene som har beløp over makssats. 
Ved første sjekk med spørring, ser det ut til at det ikke er noen aktuelle kandidater som gjelder fra 1. juli. Tasken som opprettes med denne endringen vil kunne finne kandidater nøyere enn med nevnte sql. Dersom tasken finner kandidater, vil disse gås gjennom med Mirja når hun er tilbake, og eventuelt satsendres manuelt.

Rutine for satsendring er beskrevet i readme: BarnetilsynSatsendring_README.md