### PR TITLE
Skal sende med brevtittel ved utsending av frittstående brev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230508082643_6b28bd8</felles.version>
         <prosessering.version>2.20230505153212_2bc6a06</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20230614120843_29f0a45</kontrakter.version>
+        <kontrakter.version>3.0_20230615142948_f6dc470</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.12.0</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
@@ -52,6 +52,7 @@ class FrittståendeBrevService(
                 eksternFagsakId = fagsak.eksternId.id,
                 stønadType = fagsak.stønadstype,
                 brevtype = frittståendeBrevDto.brevType.frittståendeBrevType,
+                tittel = frittståendeBrevDto.brevType.frittståendeBrevType.tittel,
                 fil = brev,
                 journalførendeEnhet = journalførendeEnhet,
                 saksbehandlerIdent = saksbehandlerIdent,

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
@@ -129,7 +129,7 @@ internal class FrittståendeBrevServiceTest {
     }
 
     @TestFactory
-    fun `skal sende frittstående brev med riktig brevtype`() =
+    fun `skal sende frittstående brev med riktig brevtype og sette riktig tittel`() =
         brevtyperTestData.map { (input, forventetBrevtype) ->
             DynamicTest.dynamicTest(
                 "Skal sende brev for stønadtype ${input.first} og brevkategori " +
@@ -140,6 +140,7 @@ internal class FrittståendeBrevServiceTest {
                 frittståendeBrevService.sendFrittståendeBrev(frittståendeBrevDto.copy(brevType = input.second))
 
                 assertThat(frittståendeBrevSlot.captured.brevtype).isEqualTo(forventetBrevtype)
+                assertThat(frittståendeBrevSlot.captured.tittel).isEqualTo(forventetBrevtype.tittel)
                 assertThat(frittståendeBrevSlot.captured.mottakere).hasSize(1)
                 assertThat(frittståendeBrevSlot.captured.mottakere!![0].ident).isEqualTo("mottakerIdent")
             }


### PR DESCRIPTION
**Hvorfor?**
[Ved overgangen til frittstående sanitybrev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119) øsnker vi å kunne sende med brevtittel fra sanity, istedenfor å mappe om til en enum/brevtype. Dette gjør at Mirja kan kontrollere hva brevene skal hete i dokumentoversikten.