### PR TITLE
Nytt forsøk: Sett sats som mest sannsynligvis vedtas i morgen i ikke gjeldende sats

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -52,8 +52,8 @@ object BeregningBarnetilsynUtil {
     val ikkeGjeldendeSatserForBarnetilsyn: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
-                Datoperiode(LocalDate.of(2022, 1, 1), LocalDate.MAX),
-                maxbeløp = mapOf(1 to 4250, 2 to 5545, 3 to 6284),
+                Datoperiode(LocalDate.of(2023, 7, 1), LocalDate.MAX),
+                maxbeløp = mapOf(1 to 4480, 2 to 5844, 3 to 6623),
             ),
         ) + eldreBarnetilsynsatser.filter { !it.periode.inneholder(LocalDate.of(2022, 1, 1)) }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
@@ -50,7 +50,7 @@ class BarnetilsynSatsendringService(
         logger.info("Antall kandidater til satsendring: ${barnetilsynSatsendringKandidat.size}")
 
         val kandidaterMedSkalRevurderesSatt = barnetilsynSatsendringKandidat.map {
-            val nåværendeAndelerForNesteÅr = it.andelerEtter(YearMonth.of(YearMonth.now().year, 12))
+            val nåværendeAndelerForNesteÅr = it.andelerEtter(YearMonth.of(YearMonth.now().year, 7))
             val nyBeregningMånedsperioder = gjørNyBeregning(nåværendeAndelerForNesteÅr, brukIkkeVedtatteSatser)
             val skalRevurderes: Boolean =
                 finnesStørreBeløpINyBeregning(nyBeregningMånedsperioder, nåværendeAndelerForNesteÅr)

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
@@ -50,7 +50,7 @@ class BarnetilsynSatsendringService(
         logger.info("Antall kandidater til satsendring: ${barnetilsynSatsendringKandidat.size}")
 
         val kandidaterMedSkalRevurderesSatt = barnetilsynSatsendringKandidat.map {
-            val nåværendeAndelerForNesteÅr = it.andelerEtter(YearMonth.of(YearMonth.now().year, 7))
+            val nåværendeAndelerForNesteÅr = it.andelerEtter(YearMonth.of(YearMonth.now().year, 6))
             val nyBeregningMånedsperioder = gjørNyBeregning(nåværendeAndelerForNesteÅr, brukIkkeVedtatteSatser)
             val skalRevurderes: Boolean =
                 finnesStørreBeløpINyBeregning(nyBeregningMånedsperioder, nåværendeAndelerForNesteÅr)

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -404,7 +404,7 @@ class StepDefinitions {
                     saksbehandlinger.values.map { it.first }.toList(),
                     null,
                     behandlingIdsToAktivitetArbeid,
-                    HistorikkKonfigurasjon(brukIkkeVedtatteSatser = true),
+                    HistorikkKonfigurasjon(brukIkkeVedtatteSatser = false),
                 )
             }
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/util/FeatureToggleTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/util/FeatureToggleTestUtil.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 
 fun mockFeatureToggleService(enabled: Boolean = true): FeatureToggleService {
     val mockk = mockk<FeatureToggleService>()
-    every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
     every { mockk.isEnabled(any()) } returns enabled
+    every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
     return mockk
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -20,6 +20,7 @@ class FeatureToggleMock {
         every { mockk.isEnabled(any()) } returns true
         every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE) } returns false
         every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE) } returns false
+        every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
         return mockk
     }
 }


### PR DESCRIPTION
**Hvorfor?**
Slik at beregningen av ny andelshistorikk kan bruke nye satser til å sjekke om det er en diff mot gjeldende beløp. 
Resultatet av kjøringen som var uten denne endringen telte med alle barnetilsynsaker som var aktive i juli og fremover (44 stk) selv om alle var under maks-sats