### PR TITLE
Frittstående sanitybrev 💌 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevClient.kt
@@ -29,6 +29,7 @@ class BrevClient(
         operations.optionsForAllow(pingUri)
     }
 
+    @Deprecated("Skal slettes")
     fun genererBrev(
         fritekstBrev: FrittståendeBrevRequestDto,
         saksbehandlerNavn: String,
@@ -75,6 +76,7 @@ class BrevClient(
         )
     }
 
+    @Deprecated("Skal slettes")
     fun genererHtmlFritekstbrev(
         fritekstBrev: FrittståendeBrevRequestDto,
         saksbehandlerNavn: String,
@@ -110,6 +112,7 @@ data class BrevRequestMedSignaturer(
     val datoPlaceholder: String,
 )
 
+@Deprecated("Skal slettes")
 data class FritekstBrevRequestMedSignatur(
     val brevFraSaksbehandler: FrittståendeBrevRequestDto,
     val saksbehandlersignatur: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -90,4 +90,30 @@ class BrevMellomlagerController(
             ),
         )
     }
+
+    @PostMapping("/fagsak/{fagsakId}")
+    fun mellomlagreFrittståendeSanitybrev(
+        @PathVariable fagsakId: UUID,
+        @RequestBody mellomlagreBrev: MellomlagreBrevRequestDto,
+    ): Ressurs<UUID> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return Ressurs.success(
+            mellomlagringBrevService.mellomLagreFrittståendeSanitybrev(
+                fagsakId,
+                mellomlagreBrev.brevverdier,
+                mellomlagreBrev.brevmal,
+            ),
+        )
+    }
+
+    @GetMapping("/fagsak/{fagsakId}")
+    fun hentMellomlagretFrittståendesanitybrev(
+        @PathVariable fagsakId: UUID,
+    ): Ressurs<MellomlagretBrevResponse?> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+
+        return Ressurs.success(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId))
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -45,6 +45,7 @@ class BrevMellomlagerController(
         )
     }
 
+    @Deprecated("Skal slettes")
     @PostMapping("/fritekst")
     fun mellomlagreFritekstbrev(@RequestBody mellomlagretBrev: FritekstBrevDto): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(mellomlagretBrev.behandlingId, AuditLoggerEvent.UPDATE)
@@ -53,6 +54,7 @@ class BrevMellomlagerController(
         return Ressurs.success(mellomlagringBrevService.mellomlagreFritekstbrev(mellomlagretBrev))
     }
 
+    @Deprecated("Skal slettes")
     @PostMapping("/frittstaende")
     fun mellomlagreFrittstaendeBrev(@RequestBody mellomlagretBrev: FrittståendeBrevDto): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(mellomlagretBrev.fagsakId, AuditLoggerEvent.UPDATE)
@@ -61,6 +63,7 @@ class BrevMellomlagerController(
         return Ressurs.success(mellomlagringBrevService.mellomlagreFrittståendeBrev(mellomlagretBrev))
     }
 
+    @Deprecated("Skal slettes")
     @DeleteMapping("/frittstaende/{fagsakId}")
     fun mellomlagreFrittstaendeBrev(@PathVariable fagsakId: UUID): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.DELETE)
@@ -69,6 +72,7 @@ class BrevMellomlagerController(
         return Ressurs.success(fagsakId)
     }
 
+    @Deprecated("Skal slettes")
     @GetMapping("/frittstaende/{fagsakId}")
     fun hentMellomlagretFrittstaendeBrev(@PathVariable fagsakId: UUID): Ressurs<FrittståendeBrevDto?> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
@@ -1,14 +1,18 @@
 package no.nav.familie.ef.sak.brev
 
+import com.fasterxml.jackson.databind.JsonNode
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevDto
+import no.nav.familie.ef.sak.brev.dto.FrittståendeSanitybrevDto
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/frittstaende-brev"])
@@ -29,5 +33,26 @@ class FrittståendeBrevController(
         tilgangService.validerTilgangTilFagsak(brevInnhold.fagsakId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(frittståendeBrevService.sendFrittståendeBrev(brevInnhold))
+    }
+
+    @PostMapping("/{fagsakId}/{brevMal}")
+    fun forhåndsvisFrittsåendeSanitybrev(
+        @PathVariable fagsakId: UUID,
+        @PathVariable brevMal: String,
+        @RequestBody brevRequest: JsonNode,
+    ): Ressurs<ByteArray> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return Ressurs.success(frittståendeBrevService.lagFrittståendeSanitybrev(fagsakId, brevMal, brevRequest))
+    }
+
+    @PostMapping("/send/{fagsakId}")
+    fun sendFrittsåendeSanitybrev(
+        @PathVariable fagsakId: UUID,
+        @RequestBody sendBrevRequest: FrittståendeSanitybrevDto,
+    ): Ressurs<Unit> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return Ressurs.success(frittståendeBrevService.sendFrittståendeSanitybrev(fagsakId, sendBrevRequest))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
@@ -22,12 +22,14 @@ class FrittståendeBrevController(
     private val tilgangService: TilgangService,
 ) {
 
+    @Deprecated("Skal slettes")
     @PostMapping("")
     fun forhåndsvisFrittståendeBrev(@RequestBody brevInnhold: FrittståendeBrevDto): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilFagsak(brevInnhold.fagsakId, AuditLoggerEvent.UPDATE)
         return Ressurs.success(frittståendeBrevService.forhåndsvisFrittståendeBrev(brevInnhold))
     }
 
+    @Deprecated("Skal slettes")
     @PostMapping("/send")
     fun sendFrittståendeBrev(@RequestBody brevInnhold: FrittståendeBrevDto): Ressurs<Unit> {
         tilgangService.validerTilgangTilFagsak(brevInnhold.fagsakId, AuditLoggerEvent.CREATE)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
@@ -38,6 +38,7 @@ class FrittståendeBrevService(
     private val familieDokumentClient: FamilieDokumentClient,
 ) {
 
+    @Deprecated("Skal slettes")
     fun forhåndsvisFrittståendeBrev(frittståendeBrevDto: FrittståendeBrevDto): ByteArray {
         return lagFrittståendeBrevMedSignatur(frittståendeBrevDto)
     }
@@ -82,6 +83,7 @@ class FrittståendeBrevService(
         mellomlagringBrevService.slettMellomlagretFrittståendeBrev(fagsakId, saksbehandlerIdent)
     }
 
+    @Deprecated("Skal slettes")
     fun sendFrittståendeBrev(frittståendeBrevDto: FrittståendeBrevDto) {
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
         val mottakere = validerOgMapBrevmottakere(frittståendeBrevDto.mottakere)
@@ -125,6 +127,7 @@ class FrittståendeBrevService(
         return personer + organisasjoner
     }
 
+    @Deprecated("Skal slettes")
     private fun lagFrittståendeBrevRequest(
         frittståendeBrevDto: FrittståendeBrevDto,
         ident: String,
@@ -138,11 +141,13 @@ class FrittståendeBrevService(
         )
     }
 
+    @Deprecated("Skal slettes")
     private fun lagFrittståendeBrevMedSignatur(frittståendeBrevDto: FrittståendeBrevDto): ByteArray {
         val fagsak = fagsakService.hentFagsak(frittståendeBrevDto.fagsakId)
         return lagFrittståendeBrevMedSignatur(frittståendeBrevDto, fagsak)
     }
 
+    @Deprecated("Skal slettes")
     private fun lagFrittståendeBrevMedSignatur(frittståendeBrevDto: FrittståendeBrevDto, fagsak: Fagsak): ByteArray {
         val request = lagFrittståendeBrevRequest(frittståendeBrevDto, fagsak.hentAktivIdent())
         val signatur = brevsignaturService.lagSignaturMedEnhet(fagsak)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFritekstbrevRepository.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.repository.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 @Repository
 interface MellomlagerFritekstbrevRepository :
     RepositoryInterface<MellomlagretFritekstbrev, UUID>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeBrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeBrevRepository.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.repository.RepositoryInterface
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 @Repository
 interface MellomlagerFrittståendeBrevRepository :
     RepositoryInterface<MellomlagretFrittståendeBrev, UUID>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepository.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ef.sak.brev
+
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
+import no.nav.familie.ef.sak.repository.InsertUpdateRepository
+import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface MellomlagerFrittståendeSanitybrevRepository :
+    RepositoryInterface<MellomlagretFrittståendeSanitybrev, UUID>,
+    InsertUpdateRepository<MellomlagretFrittståendeSanitybrev> {
+
+    fun findByFagsakIdAndSaksbehandlerIdent(fagsakId: UUID, saksehandlerIdent: String): MellomlagretFrittståendeSanitybrev?
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -52,6 +52,7 @@ class MellomlagringBrevService(
         return mellomlagerFrittståendeSanitybrevRepository.insert(mellomlagretBrev).fagsakId
     }
 
+    @Deprecated("Skal slettes")
     fun mellomlagreFritekstbrev(mellomlagretBrev: FritekstBrevDto): UUID {
         slettMellomlagringHvisFinnes(mellomlagretBrev.behandlingId)
         val mellomlagretFritekstbrev = MellomlagretFritekstbrev(
@@ -66,6 +67,7 @@ class MellomlagringBrevService(
         return mellomlagerFritekstbrevRepository.insert(mellomlagretFritekstbrev).behandlingId
     }
 
+    @Deprecated("Skal slettes")
     fun mellomlagreFrittståendeBrev(mellomlagretBrev: FrittståendeBrevDto): UUID {
         mellomlagretBrev.mottakere?.let { validerUnikeBrevmottakere(it) }
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
@@ -85,6 +87,7 @@ class MellomlagringBrevService(
         return mellomlagerFrittståendeBrevRepository.insert(mellomlagretFrittståendeBrev).fagsakId
     }
 
+    @Deprecated("Skal slettes")
     fun hentMellomlagretFrittståendeBrev(fagsakId: UUID): FrittståendeBrevDto? {
         val saksbehandlerIdent = SikkerhetContext.hentSaksbehandler()
         return mellomlagerFrittståendeBrevRepository.findByFagsakIdAndSaksbehandlerIdent(fagsakId, saksbehandlerIdent)?.let {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFritekstbrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFritekstbrev.kt
@@ -4,4 +4,5 @@ import no.nav.familie.ef.sak.brev.dto.FritekstBrevKategori
 import org.springframework.data.annotation.Id
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 data class MellomlagretFritekstbrev(@Id val behandlingId: UUID, val brev: Fritekstbrev, val brevType: FritekstBrevKategori)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeBrev.kt
@@ -6,6 +6,7 @@ import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 @Table("mellomlagret_frittstaende_brev")
 data class MellomlagretFrittståendeBrev(
     @Id
@@ -18,6 +19,7 @@ data class MellomlagretFrittståendeBrev(
     val mottakere: FrittståendeBrevmottakere?,
 )
 
+@Deprecated("Skal slettes")
 data class FrittståendeBrevmottakere(
     val personer: List<BrevmottakerPerson>,
     val organisasjoner: List<BrevmottakerOrganisasjon>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeSanitybrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeSanitybrev.kt
@@ -1,0 +1,18 @@
+package no.nav.familie.ef.sak.brev.domain
+
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Table("mellomlagret_frittstaende_sanitybrev")
+data class MellomlagretFrittståendeSanitybrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val fagsakId: UUID,
+    val brevverdier: String,
+    val brevmal: String,
+    val opprettetTid: LocalDateTime = LocalDateTime.now(),
+    val saksbehandlerIdent: String = SikkerhetContext.hentSaksbehandler(),
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FritekstBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FritekstBrevDto.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.brev.dto
 
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 data class FritekstBrevDto(
     val overskrift: String,
     val avsnitt: List<FrittståendeBrevAvsnitt>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FritekstBrevKategori.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FritekstBrevKategori.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.brev.dto
 
+@Deprecated("Skal slettes")
 enum class FritekstBrevKategori {
     SANKSJON,
     VEDTAK_INVILGELSE,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevDto.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.brev.dto
 import no.nav.familie.ef.sak.brev.BrevmottakereDto
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 data class FrittståendeBrevDto(
     val overskrift: String,
     val avsnitt: List<FrittståendeBrevAvsnitt>,
@@ -11,4 +12,5 @@ data class FrittståendeBrevDto(
     val mottakere: BrevmottakereDto?,
 )
 
+@Deprecated("Skal slettes")
 data class FrittståendeBrevAvsnitt(val deloverskrift: String, val innhold: String, val skalSkjulesIBrevbygger: Boolean? = false)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevKategori.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevKategori.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.brev.dto
 
 import no.nav.familie.kontrakter.ef.felles.FrittståendeBrevType
 
+@Deprecated("Skal slettes")
 enum class FrittståendeBrevKategori(val frittståendeBrevType: FrittståendeBrevType) {
     INFORMASJONSBREV(frittståendeBrevType = FrittståendeBrevType.INFORMASJONSBREV),
     INNHENTING_AV_OPPLYSNINGER(frittståendeBrevType = (FrittståendeBrevType.INNHENTING_AV_OPPLYSNINGER)),

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeBrevRequestDto.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.brev.dto
 
+@Deprecated("Skal slettes")
 data class FrittståendeBrevRequestDto(
     val overskrift: String,
     val avsnitt: List<FrittståendeBrevAvsnitt>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeSanitybrevDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/FrittståendeSanitybrevDto.kt
@@ -1,0 +1,9 @@
+package no.nav.familie.ef.sak.brev.dto
+
+import no.nav.familie.ef.sak.brev.BrevmottakereDto
+
+data class FrittståendeSanitybrevDto(
+    val pdf: ByteArray,
+    val mottakere: BrevmottakereDto,
+    val tittel: String,
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/MellomlagretBrevResponse.kt
@@ -7,6 +7,7 @@ sealed class MellomlagretBrevResponse
 data class MellomlagretBrevSanity(val brevtype: Brevtype = Brevtype.SANITYBREV, val brevmal: String, val brevverdier: String?) :
     MellomlagretBrevResponse()
 
+@Deprecated("Skal slettes")
 data class MellomlagretBrevFritekst(
     val brevtype: Brevtype = Brevtype.FRITEKSTBREV,
     val brev: Fritekstbrev,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/VedtaksbrevFritekstDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/dto/VedtaksbrevFritekstDto.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.brev.dto
 
 import java.util.UUID
 
+@Deprecated("Skal slettes")
 data class VedtaksbrevFritekstDto(
     val overskrift: String,
     val avsnitt: List<FrittståendeBrevAvsnitt>,

--- a/src/main/resources/db/migration/V136__mellomlagring_frittstående_sanitybrev.sql
+++ b/src/main/resources/db/migration/V136__mellomlagring_frittstående_sanitybrev.sql
@@ -1,0 +1,10 @@
+CREATE TABLE mellomlagret_frittstaende_sanitybrev
+(
+    id                  UUID PRIMARY KEY            NOT NULL,
+    fagsak_id           UUID REFERENCES fagsak (id) NOT NULL,
+    brevverdier         VARCHAR                     NOT NULL,
+    brevmal             VARCHAR                     NOT NULL,
+    saksbehandler_ident VARCHAR                     NOT NULL,
+    opprettet_tid       TIMESTAMP(3)                NOT NULL,
+    UNIQUE (fagsak_id, saksbehandler_ident)
+);

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ef.sak.brev.domain.Brevmottakere
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeBrev
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.brev.domain.Vedtaksbrev
 import no.nav.familie.ef.sak.database.DbContainerInitializer
 import no.nav.familie.ef.sak.fagsak.domain.FagsakDomain
@@ -151,6 +152,7 @@ abstract class OppslagSpringRunnerTest {
             MellomlagretBrev::class,
             MellomlagretFritekstbrev::class,
             MellomlagretFrittståendeBrev::class,
+            MellomlagretFrittståendeSanitybrev::class,
             Behandlingsjournalpost::class,
             Grunnlagsdata::class,
             Tilbakekreving::class,

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepositoryTest.kt
@@ -1,0 +1,56 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.brev
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.brev.MellomlagerFrittståendeSanitybrevRepository
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
+import no.nav.familie.ef.sak.repository.fagsak
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.temporal.ChronoUnit
+
+internal class MellomlagerFrittståendeSanitybrevRepositoryTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var mellomlagerFrittståendeSanitybrevRepository: MellomlagerFrittståendeSanitybrevRepository
+
+    @Test
+    internal fun `skal lagre mellomlagret brev`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val mellomlagretBrev = MellomlagretFrittståendeSanitybrev(
+            fagsakId = fagsak.id,
+            brevverdier = "{}",
+            brevmal = "",
+            saksbehandlerIdent = "saksbehandler123",
+        )
+
+        mellomlagerFrittståendeSanitybrevRepository.insert(mellomlagretBrev)
+
+        val mellomlagretBrevFraDb = mellomlagerFrittståendeSanitybrevRepository.findById(mellomlagretBrev.id)
+        Assertions.assertThat(mellomlagretBrevFraDb)
+            .get().usingRecursiveComparison().ignoringFields("opprettetTid").isEqualTo(mellomlagretBrev)
+        Assertions.assertThat(mellomlagretBrevFraDb.get().opprettetTid)
+            .isCloseTo(mellomlagretBrev.opprettetTid, within(1, ChronoUnit.SECONDS))
+    }
+
+    @Test
+    internal fun `skal finne igjen mellomlagret brev fra fagsakId og saksbehandlers ident`() {
+        val saksbehandlerIdent = "12345678910"
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val mellomlagretBrev = MellomlagretFrittståendeSanitybrev(
+            fagsakId = fagsak.id,
+            brevverdier = "{}",
+            brevmal = "",
+            saksbehandlerIdent = saksbehandlerIdent,
+        )
+
+        mellomlagerFrittståendeSanitybrevRepository.insert(mellomlagretBrev)
+        val mellomlagretBrevFraDb =
+            mellomlagerFrittståendeSanitybrevRepository.findByFagsakIdAndSaksbehandlerIdent(fagsak.id, saksbehandlerIdent)
+        Assertions.assertThat(mellomlagretBrevFraDb)
+            .usingRecursiveComparison()
+            .ignoringFields("opprettetTid")
+            .isEqualTo(mellomlagretBrev)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/MellomlagringBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/MellomlagringBrevServiceTest.kt
@@ -7,12 +7,14 @@ import io.mockk.unmockkObject
 import no.nav.familie.ef.sak.brev.MellomlagerBrevRepository
 import no.nav.familie.ef.sak.brev.MellomlagerFritekstbrevRepository
 import no.nav.familie.ef.sak.brev.MellomlagerFrittståendeBrevRepository
+import no.nav.familie.ef.sak.brev.MellomlagerFrittståendeSanitybrevRepository
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerOrganisasjon
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerPerson
 import no.nav.familie.ef.sak.brev.domain.Fritekstbrev
 import no.nav.familie.ef.sak.brev.domain.FrittståendeBrevmottakere
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeBrev
+import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.brev.domain.MottakerRolle
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevAvsnitt
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevKategori
@@ -33,10 +35,12 @@ internal class MellomlagringBrevServiceTest {
     private val mellomlagerBrevRepository = mockk<MellomlagerBrevRepository>()
     private val mellomlagerFritekstbrevRepository = mockk<MellomlagerFritekstbrevRepository>()
     private val mellomlagerFrittståendeBrevRepository = mockk<MellomlagerFrittståendeBrevRepository>()
+    private val mellomlagerFrittståendeSanitybrevRepository = mockk<MellomlagerFrittståendeSanitybrevRepository>()
     private val mellomlagringBrevService = no.nav.familie.ef.sak.brev.MellomlagringBrevService(
         mellomlagerBrevRepository,
         mellomlagerFritekstbrevRepository,
         mellomlagerFrittståendeBrevRepository,
+        mellomlagerFrittståendeSanitybrevRepository,
     )
 
     @BeforeAll
@@ -108,6 +112,26 @@ internal class MellomlagringBrevServiceTest {
         assertThat(dto.brevType).isEqualTo(brev.brevType)
         assertThat(dto.mottakere!!.organisasjoner).isEqualTo(brev.mottakere!!.organisasjoner)
         assertThat(dto.mottakere!!.personer).isEqualTo(brev.mottakere!!.personer)
+    }
+
+    @Test
+    fun `hentMellomlagretFrittståendeSanityBrev skal returnere mellomlagret frittstående brev`() {
+        val fagsakId = UUID.randomUUID()
+
+        val brev = MellomlagretFrittståendeSanitybrev(
+            fagsakId = fagsakId,
+            brevverdier = mellomlagretBrev.brevverdier,
+            brevmal = mellomlagretBrev.brevmal,
+        )
+
+        every { mellomlagerFrittståendeSanitybrevRepository.findByFagsakIdAndSaksbehandlerIdent(fagsakId, any()) } returns brev
+
+        assertThat(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId)).isEqualTo(
+            MellomlagretBrevSanity(
+                brevmal = mellomlagretBrev.brevmal,
+                brevverdier = mellomlagretBrev.brevverdier,
+            ),
+        )
     }
 
     private fun brevmottakerOrganisasjon() = BrevmottakerOrganisasjon("456", "Power", MottakerRolle.FULLMAKT)


### PR DESCRIPTION
**Hvorfor?**
[Vi skal gå over til å bruke sanity for våre frittstående brev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119). Denne branchen legger til støtte for generering/forhåndvisning , utsending og mellomlagring av denne type brev.

PR på frontend kommer snart ⚡ 


**Hva gjenstår?**
- https://github.com/navikt/familie-ef-iverksett/pull/774 Må merges
- Endepunkter for lagring/henting av brevmottakere. Disse sendes  pr. np med ved utsending, men mellomlagres ikke.
- Slette gammel fritekst/frittstående-kode

