### PR TITLE
Skal kunne lagre og hente brevmottakere for frittstående brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereController.kt
@@ -37,4 +37,22 @@ class BrevmottakereController(
 
         return Ressurs.success(brevmottakereService.lagreBrevmottakere(behandlingId, brevmottakere))
     }
+
+    @GetMapping("fagsak/{fagsakId}")
+    fun hentBrevmottakereForFagsak(@PathVariable fagsakId: UUID): Ressurs<BrevmottakereDto?> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+
+        return Ressurs.success(brevmottakereService.hentBrevnottakereForFagsak(fagsakId))
+    }
+
+    @PostMapping("fagsak/{fagsakId}")
+    fun velgBrevmottakereForFagsak(
+        @PathVariable fagsakId: UUID,
+        @RequestBody brevmottakere: BrevmottakereDto,
+    ): Ressurs<UUID> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
+
+        return Ressurs.success(brevmottakereService.lagreBrevmottakereForFagsak(fagsakId, brevmottakere))
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
@@ -2,15 +2,20 @@ package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.brev.BrevmottakerUtil.validerUnikeBrevmottakere
 import no.nav.familie.ef.sak.brev.domain.Brevmottakere
+import no.nav.familie.ef.sak.brev.domain.BrevmottakereFrittståendeBrev
 import no.nav.familie.ef.sak.brev.domain.OrganisasjonerWrapper
 import no.nav.familie.ef.sak.brev.domain.PersonerWrapper
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.UUID
 
 @Service
-class BrevmottakereService(val brevmottakereRepository: BrevmottakereRepository) {
+class BrevmottakereService(
+    val brevmottakereRepository: BrevmottakereRepository,
+    val frittståendeBrevmottakereRepository: FrittståendeBrevmottakereRepository,
+) {
 
     fun lagreBrevmottakere(behandlingId: UUID, brevmottakereDto: BrevmottakereDto): UUID {
         validerAntallBrevmottakere(brevmottakereDto)
@@ -35,6 +40,54 @@ class BrevmottakereService(val brevmottakereRepository: BrevmottakereRepository)
             BrevmottakereDto(personer = it.personer.personer, organisasjoner = it.organisasjoner.organisasjoner)
         }
     }
+
+    fun hentBrevnottakereForFagsak(fagsakId: UUID): BrevmottakereDto? {
+        return frittståendeBrevmottakereRepository.findByFagsakIdAndSaksbehandlerIdent(
+            fagsakId,
+            SikkerhetContext.hentSaksbehandler(),
+        )?.let { BrevmottakereDto(personer = it.personer.personer, organisasjoner = it.organisasjoner.organisasjoner) }
+    }
+
+    fun lagreBrevmottakereForFagsak(fagsakId: UUID, brevmottakereDto: BrevmottakereDto): UUID {
+        validerAntallBrevmottakere(brevmottakereDto)
+        validerUnikeBrevmottakere(brevmottakereDto)
+
+        val eksistrendeBrevmottakere =
+            frittståendeBrevmottakereRepository.findByFagsakIdAndSaksbehandlerIdent(
+                fagsakId,
+                SikkerhetContext.hentSaksbehandler(),
+            )
+
+        return if ((eksistrendeBrevmottakere != null)) {
+            oppdaterBrevmottakere(eksistrendeBrevmottakere, fagsakId, brevmottakereDto)
+        } else {
+            opprettBrevmottakere(fagsakId, brevmottakereDto)
+        }.fagsakId
+    }
+
+    private fun opprettBrevmottakere(
+        fagsakId: UUID,
+        brevmottakereDto: BrevmottakereDto,
+    ) = frittståendeBrevmottakereRepository.insert(
+        BrevmottakereFrittståendeBrev(
+            fagsakId = fagsakId,
+            personer = PersonerWrapper(brevmottakereDto.personer),
+            organisasjoner = OrganisasjonerWrapper(brevmottakereDto.organisasjoner),
+        ),
+    )
+
+    private fun oppdaterBrevmottakere(
+        eksistrendeBrevmottakere: BrevmottakereFrittståendeBrev,
+        fagsakId: UUID,
+        brevmottakereDto: BrevmottakereDto,
+    ) = frittståendeBrevmottakereRepository.update(
+        BrevmottakereFrittståendeBrev(
+            id = eksistrendeBrevmottakere.id,
+            fagsakId = fagsakId,
+            personer = PersonerWrapper(brevmottakereDto.personer),
+            organisasjoner = OrganisasjonerWrapper(brevmottakereDto.organisasjoner),
+        ),
+    )
 
     private fun validerAntallBrevmottakere(brevmottakere: BrevmottakereDto) {
         val antallPersonmottakere = brevmottakere.personer.size

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
@@ -30,6 +30,7 @@ class BrevmottakereService(
         return when (brevmottakereRepository.existsById(behandlingId)) {
             true ->
                 brevmottakereRepository.update(brevmottakere)
+
             false ->
                 brevmottakereRepository.insert(brevmottakere)
         }.behandlingId
@@ -64,6 +65,11 @@ class BrevmottakereService(
             opprettBrevmottakere(fagsakId, brevmottakereDto)
         }.fagsakId
     }
+
+    fun slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(fagsakId: UUID, saksbehandlerIdent: String) =
+        frittståendeBrevmottakereRepository.findByFagsakIdAndSaksbehandlerIdent(fagsakId, saksbehandlerIdent)?.let {
+            frittståendeBrevmottakereRepository.deleteById(it.id)
+        }
 
     private fun opprettBrevmottakere(
         fagsakId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevService.kt
@@ -36,6 +36,7 @@ class FrittståendeBrevService(
     private val brevsignaturService: BrevsignaturService,
     private val mellomlagringBrevService: MellomlagringBrevService,
     private val familieDokumentClient: FamilieDokumentClient,
+    private val brevmottakereService: BrevmottakereService,
 ) {
 
     @Deprecated("Skal slettes")
@@ -81,6 +82,7 @@ class FrittståendeBrevService(
             ),
         )
         mellomlagringBrevService.slettMellomlagretFrittståendeBrev(fagsakId, saksbehandlerIdent)
+        brevmottakereService.slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(fagsakId, saksbehandlerIdent)
     }
 
     @Deprecated("Skal slettes")

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepository.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.ef.sak.brev
+
+import no.nav.familie.ef.sak.brev.domain.BrevmottakereFrittståendeBrev
+import no.nav.familie.ef.sak.repository.InsertUpdateRepository
+import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface FrittståendeBrevmottakereRepository :
+    RepositoryInterface<BrevmottakereFrittståendeBrev, UUID>,
+    InsertUpdateRepository<BrevmottakereFrittståendeBrev> {
+
+    fun findByFagsakIdAndSaksbehandlerIdent(fagsakId: UUID, saksbehandlerIdent: String): BrevmottakereFrittståendeBrev?
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeBrev.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/MellomlagretFrittståendeBrev.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.brev.domain
 
 import no.nav.familie.ef.sak.brev.dto.FrittståendeBrevKategori
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDateTime
@@ -23,4 +24,15 @@ data class MellomlagretFrittståendeBrev(
 data class FrittståendeBrevmottakere(
     val personer: List<BrevmottakerPerson>,
     val organisasjoner: List<BrevmottakerOrganisasjon>,
+)
+
+@Table("brevmottakere_frittstaende_brev")
+data class BrevmottakereFrittståendeBrev(
+    @Id
+    val id: UUID = UUID.randomUUID(),
+    val fagsakId: UUID,
+    val saksbehandlerIdent: String = SikkerhetContext.hentSaksbehandler(),
+    val tidspunktOpprettet: LocalDateTime = LocalDateTime.now(),
+    val personer: PersonerWrapper,
+    val organisasjoner: OrganisasjonerWrapper,
 )

--- a/src/main/resources/db/migration/V137__brevmottakere_frittstående_brev.sql
+++ b/src/main/resources/db/migration/V137__brevmottakere_frittstående_brev.sql
@@ -1,0 +1,9 @@
+CREATE TABLE brevmottakere_frittstaende_brev
+(
+    id                  UUID PRIMARY KEY,
+    fagsak_id           UUID         NOT NULL REFERENCES fagsak (id),
+    saksbehandler_ident VARCHAR      NOT NULL,
+    tidspunkt_opprettet TIMESTAMP(3) NOT NULL,
+    personer            JSON         NOT NULL,
+    organisasjoner      JSON         NOT NULL
+);

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprett
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk
 import no.nav.familie.ef.sak.blankett.Blankett
 import no.nav.familie.ef.sak.brev.domain.Brevmottakere
+import no.nav.familie.ef.sak.brev.domain.BrevmottakereFrittståendeBrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFritekstbrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeBrev
@@ -153,6 +154,7 @@ abstract class OppslagSpringRunnerTest {
             MellomlagretFritekstbrev::class,
             MellomlagretFrittståendeBrev::class,
             MellomlagretFrittståendeSanitybrev::class,
+            BrevmottakereFrittståendeBrev::class,
             Behandlingsjournalpost::class,
             Grunnlagsdata::class,
             Tilbakekreving::class,

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
@@ -16,7 +16,8 @@ import org.springframework.data.repository.findByIdOrNull
 internal class BrevmottakereServiceTest {
 
     val brevmottakereRepository = mockk<BrevmottakereRepository>()
-    val brevmottakereService = BrevmottakereService(brevmottakereRepository)
+    val frittståendeBrevmottakereRepository = mockk<FrittståendeBrevmottakereRepository>()
+    val brevmottakereService = BrevmottakereService(brevmottakereRepository, frittståendeBrevmottakereRepository)
     val behandling = behandling()
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import io.mockk.verifyOrder
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerOrganisasjon
@@ -47,6 +48,7 @@ internal class FrittståendeBrevServiceTest {
     private val brevsignaturService = mockk<BrevsignaturService>()
     private val mellomlagringBrevService = mockk<MellomlagringBrevService>()
     private val familieDokumentClient = mockk<FamilieDokumentClient>()
+    private val brevmottakereService = mockk<BrevmottakereService>()
 
     private val frittståendeBrevService =
         FrittståendeBrevService(
@@ -58,6 +60,7 @@ internal class FrittståendeBrevServiceTest {
             brevsignaturService,
             mellomlagringBrevService,
             familieDokumentClient,
+            brevmottakereService,
         )
     private val fagsak = fagsak(fagsakpersoner(identer = setOf("01010172272")))
     private val frittståendeBrevDto = FrittståendeBrevDto(
@@ -231,6 +234,7 @@ internal class FrittståendeBrevServiceTest {
             assertThat(mottakere[0].ident).isEqualTo(person.personIdent)
             assertThat(mottakere[0].navn).isEqualTo(person.navn)
             assertThat(mottakere[0].mottakerRolle).isEqualTo(person.mottakerRolle.tilIverksettDto())
+            verify { brevmottakereService.slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(fagsak.id, any()) }
         }
 
         @Test
@@ -256,6 +260,7 @@ internal class FrittståendeBrevServiceTest {
             assertThat(mottakere[0].ident).isEqualTo(organisasjon.organisasjonsnummer)
             assertThat(mottakere[0].navn).isEqualTo(organisasjon.navnHosOrganisasjon)
             assertThat(mottakere[0].mottakerRolle).isEqualTo(organisasjon.mottakerRolle.tilIverksettDto())
+            verify { brevmottakereService.slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(fagsak.id, any()) }
         }
 
         @Test
@@ -291,6 +296,7 @@ internal class FrittståendeBrevServiceTest {
             assertThat(mottakere[1].ident).isEqualTo(organisasjon.organisasjonsnummer)
             assertThat(mottakere[1].navn).isEqualTo(organisasjon.navnHosOrganisasjon)
             assertThat(mottakere[1].mottakerRolle).isEqualTo(organisasjon.mottakerRolle.tilIverksettDto())
+            verify { brevmottakereService.slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(fagsak.id, any()) }
         }
     }
 
@@ -310,6 +316,7 @@ internal class FrittståendeBrevServiceTest {
         )
         justRun { iverksettClient.sendFrittståendeBrev(capture(frittståendeBrevSlot)) }
         justRun { mellomlagringBrevService.slettMellomlagretFrittståendeBrev(any(), any()) }
+        justRun { brevmottakereService.slettBrevmottakereForFagsakOgSaksbehandlerHvisFinnes(any(), any()) }
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepositoryTest.kt
@@ -1,0 +1,76 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.brev
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.brev.FrittståendeBrevmottakereRepository
+import no.nav.familie.ef.sak.brev.domain.BrevmottakerOrganisasjon
+import no.nav.familie.ef.sak.brev.domain.BrevmottakerPerson
+import no.nav.familie.ef.sak.brev.domain.BrevmottakereFrittståendeBrev
+import no.nav.familie.ef.sak.brev.domain.MottakerRolle
+import no.nav.familie.ef.sak.brev.domain.OrganisasjonerWrapper
+import no.nav.familie.ef.sak.brev.domain.PersonerWrapper
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.repository.fagsak
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.temporal.ChronoUnit
+
+internal class FrittståendeBrevmottakereRepositoryTest : OppslagSpringRunnerTest() {
+
+    @Autowired
+    private lateinit var frittståendeBrevmottakereRepository: FrittståendeBrevmottakereRepository
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.hentSaksbehandler() } returns "bob"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(SikkerhetContext)
+    }
+
+    @Test
+    internal fun `skal lagre brevmottaker for fagsak`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val brevmottakere = BrevmottakereFrittståendeBrev(
+            fagsakId = fagsak.id,
+            personer = PersonerWrapper(
+                listOf(
+                    BrevmottakerPerson(
+                        personIdent = "12345678910",
+                        navn = "Verge",
+                        mottakerRolle = MottakerRolle.VERGE,
+                    ),
+                ),
+            ),
+            organisasjoner = OrganisasjonerWrapper(
+                listOf(
+                    BrevmottakerOrganisasjon(
+                        organisasjonsnummer = "12345678",
+                        navnHosOrganisasjon = "Advokat",
+                        MottakerRolle.FULLMAKT,
+                    ),
+                ),
+            ),
+        )
+
+        frittståendeBrevmottakereRepository.insert(brevmottakere)
+
+        val brevmottakereFraDb =
+            frittståendeBrevmottakereRepository.findByFagsakIdAndSaksbehandlerIdent(
+                fagsak.id,
+                SikkerhetContext.hentSaksbehandler(),
+            )
+
+        assertThat(brevmottakereFraDb).usingRecursiveComparison().ignoringFields("tidspunktOpprettet").isEqualTo(brevmottakere)
+        assertThat(brevmottakereFraDb!!.tidspunktOpprettet).isCloseTo(brevmottakere.tidspunktOpprettet, within(1, ChronoUnit.SECONDS))
+    }
+}


### PR DESCRIPTION
### Hvorfor?
Hvis saksbehandler velger brevmottakere skal dette lagres, og ligge der også neste gang de åpner brevfanen. Dette var tidligere håndtert som en del av mellomlagringen av frittstående brev, men nå som vi går over til sanitybrev trenger vi egen funksjonalitet for dette.

