### PR TITLE
Skolepenger makssats2023

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløp.kt
@@ -15,6 +15,7 @@ import java.time.Year
 object SkolepengerMaksbeløp {
 
     private val høgskoleUniversitet = mapOf<Year, Int>(
+        Year.of(2023) to 74_366,
         Year.of(2022) to 69_500,
         Year.of(2021) to 68_136,
         Year.of(2020) to 66_604,
@@ -22,6 +23,7 @@ object SkolepengerMaksbeløp {
     )
 
     private val videregående = mapOf<Year, Int>(
+        Year.of(2023) to 31_033,
         Year.of(2022) to 29_002,
         Year.of(2021) to 28_433,
         Year.of(2020) to 27_794,

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
@@ -42,6 +42,16 @@ internal class SkolepengerMaksbeløpTest {
             .withFailMessage("Finner ikke maksbeløp for studietype=VIDEREGÅENDE skoleår=18/19")
     }
 
+    @Test
+    internal fun `maksbeløp for universitet 2023 skal returnere riktig beløp`() {
+        assertThat(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, Year.of(2023))).isEqualTo(74_366)
+    }
+
+    @Test
+    internal fun `maksbeløp for videregående 2023 skal returnere riktig beløp`() {
+        assertThat(maksbeløpForÅr(VIDEREGÅENDE, Year.of(2023))).isEqualTo(31_033)
+    }
+
     /**
      * Disse testene må oppdateres med år når man legger inn nytt maksbeløp for neste år
      * * [ÅR_OM_2_ÅR] må oppdateres
@@ -51,16 +61,6 @@ internal class SkolepengerMaksbeløpTest {
     inner class MaksBeløpEtÅrFremITiden {
 
         private val ÅR_OM_2_ÅR = Year.now().plusYears(2)
-
-        @Test
-        internal fun `maksbeløp for universitet et år frem i tiden skal returnere forrige år sitt verdi`() {
-            assertThat(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, Year.of(2023))).isEqualTo(74_366)
-        }
-
-        @Test
-        internal fun `maksbeløp for videregående et år frem i tiden skal returnere forrige år sitt verdi`() {
-            assertThat(maksbeløpForÅr(VIDEREGÅENDE, Year.of(2023))).isEqualTo(31_033)
-        }
 
         @Test
         internal fun `maksbeløp for skoleår 2 år frem i tiden kaster exception`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
@@ -50,16 +50,16 @@ internal class SkolepengerMaksbeløpTest {
     @Nested
     inner class MaksBeløpEtÅrFremITiden {
 
-        private val ÅR_OM_2_ÅR = Year.of(2024)
+        private val ÅR_OM_2_ÅR = Year.now().plusYears(2)
 
         @Test
         internal fun `maksbeløp for universitet et år frem i tiden skal returnere forrige år sitt verdi`() {
-            assertThat(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, Year.of(2023))).isEqualTo(69_500)
+            assertThat(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, Year.of(2023))).isEqualTo(74_366)
         }
 
         @Test
         internal fun `maksbeløp for videregående et år frem i tiden skal returnere forrige år sitt verdi`() {
-            assertThat(maksbeløpForÅr(VIDEREGÅENDE, Year.of(2023))).isEqualTo(29_002)
+            assertThat(maksbeløpForÅr(VIDEREGÅENDE, Year.of(2023))).isEqualTo(31_033)
         }
 
         @Test


### PR DESCRIPTION
Hvorfor? 

Nye maks-satser for skolepenger 23/24: 
<img width="850" alt="image" src="https://github.com/navikt/familie-ef-sak/assets/53942238/b862f11b-006d-4496-b91d-5d861a95fd58">

Beløp må verifiseres av fag før vi prodsetter. 