### PR TITLE
Skolepenge maks-sats tester

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløp.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløp.kt
@@ -47,4 +47,12 @@ object SkolepengerMaksbeløp {
         }
         return maksbeløp
     }
+
+    fun hentSisteÅrRegistrertMaksbeløpHøyskole(): Year {
+        return this.høgskoleUniversitet.keys.max()
+    }
+
+    fun hentSisteÅrRegistrertMaksbeløpVideregående(): Year {
+        return this.videregående.keys.max()
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
@@ -52,6 +52,20 @@ internal class SkolepengerMaksbeløpTest {
         assertThat(maksbeløpForÅr(VIDEREGÅENDE, Year.of(2023))).isEqualTo(31_033)
     }
 
+    @Test
+    internal fun `Siste registrerte maksbeløp-år skal være samme for høyskole og videregående`() {
+        val årHøyskole = SkolepengerMaksbeløp.hentSisteÅrRegistrertMaksbeløpHøyskole()
+        val årVideregående = SkolepengerMaksbeløp.hentSisteÅrRegistrertMaksbeløpVideregående()
+        assertThat(årHøyskole).isEqualTo(årVideregående)
+    }
+
+    @Test
+    internal fun `Må holde maksbeløp skolepenger oppdatert, men tåler ett år forsinkelse`() {
+        val sisteRegistrerteÅr = SkolepengerMaksbeløp.hentSisteÅrRegistrertMaksbeløpHøyskole()
+        val ifjor = Year.now().minusYears(1)
+        assertThat(sisteRegistrerteÅr).isGreaterThanOrEqualTo(ifjor)
+    }
+
     /**
      * Disse testene må oppdateres med år når man legger inn nytt maksbeløp for neste år
      * * [ÅR_OM_2_ÅR] må oppdateres
@@ -61,6 +75,20 @@ internal class SkolepengerMaksbeløpTest {
     inner class MaksBeløpEtÅrFremITiden {
 
         private val ÅR_OM_2_ÅR = Year.now().plusYears(2)
+
+        @Test
+        internal fun `Skolepenger skal returnere maksbeløp for siste høyskole år når man ber om året etter`() {
+            val år = SkolepengerMaksbeløp.hentSisteÅrRegistrertMaksbeløpHøyskole()
+            val åretEtterSiste = år.plusYears(1)
+            assertThat(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, år)).isEqualTo(maksbeløpForÅr(HØGSKOLE_UNIVERSITET, åretEtterSiste))
+        }
+
+        @Test
+        internal fun `Skolepenger skal returnere maksbeløp for siste videregående år når man ber om året etter`() {
+            val år = SkolepengerMaksbeløp.hentSisteÅrRegistrertMaksbeløpVideregående()
+            val åretEtterSiste = år.plusYears(1)
+            assertThat(maksbeløpForÅr(VIDEREGÅENDE, år)).isEqualTo(maksbeløpForÅr(VIDEREGÅENDE, åretEtterSiste))
+        }
 
         @Test
         internal fun `maksbeløp for skoleår 2 år frem i tiden kaster exception`() {
@@ -77,3 +105,5 @@ internal class SkolepengerMaksbeløpTest {
         return maksbeløp(studietype, Skoleår(skoleår))
     }
 }
+
+

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/SkolepengerMaksbeløpTest.kt
@@ -105,5 +105,3 @@ internal class SkolepengerMaksbeløpTest {
         return maksbeløp(studietype, Skoleår(skoleår))
     }
 }
-
-


### PR DESCRIPTION
Hvorfor? 

Testene for skolepenger makssats ble litt dårligere etter at vi oppdaterte maks-sats for 2023. Prøver å legge inn nye tester for "neste år" som også skal fungere i årene som kommer. 

Vil også teste at vi oppdaterer makssats årlig og at vi oppdaterer både høyskole/universitet og videregående når vi nye år legges inn. 

