### PR TITLE
Skal gi feilmelding om versjonskonflikt ved oppdatering av oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -96,12 +96,22 @@ class OppgaveClient(
     }
 
     fun oppdaterOppgave(oppgave: Oppgave): Long {
-        val response = patchForEntity<Ressurs<OppgaveResponse>>(
-            URI.create("$oppgaveUri/${oppgave.id!!}/oppdater"),
-            oppgave,
-            HttpHeaders().medContentTypeJsonUTF8(),
-        )
-        return response.getDataOrThrow().oppgaveId
+        try {
+            val response = patchForEntity<Ressurs<OppgaveResponse>>(
+                URI.create("$oppgaveUri/${oppgave.id!!}/oppdater"),
+                oppgave,
+                HttpHeaders().medContentTypeJsonUTF8(),
+            )
+            return response.getDataOrThrow().oppgaveId
+        } catch (e: RessursException) {
+            if (e.httpStatus == HttpStatus.CONFLICT) {
+                throw ApiFeil(
+                    "Oppgaven har endret seg siden du sist hentet oppgaver. For å kunne gjøre endringer må du laste inn siden på nytt",
+                    HttpStatus.CONFLICT,
+                )
+            }
+            throw e
+        }
     }
 
     fun finnMapper(enhetsnummer: String, limit: Int): FinnMappeResponseDto {


### PR DESCRIPTION
**Hvorfor?**
Ved oppdatering av oppgaver, f.eks. når saksbehandler setter en behandling på vent, kan det feile mot oppgavesystemet fordi saksbehandler har en gammel versjon av oppgaven. Saksbehandler bør få beskjed om dette så de kan laste siden på nytt. Tidligere har vi bare vist "Uventet feil", og saksbehandler har da prøvd mange ganger uten å skjønne hva som går galt.

<img width="1466" alt="image" src="https://github.com/navikt/familie-ef-sak/assets/21220467/87626474-9b3b-4745-a7cc-898d47f9a33a">
