### PR TITLE
Utgifter for skolepenger skal være nullable og ikke sendes med til iverksetting/statistikk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230508082643_6b28bd8</felles.version>
         <prosessering.version>2.20230505153212_2bc6a06</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20230627152200_afdca38</kontrakter.version>
+        <kontrakter.version>3.0_20230705132547_9303863</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.12.0</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
@@ -75,21 +75,15 @@ class BeregningSkolepengerService(
             .map { (key, value) ->
                 BeløpsperiodeSkolepenger(
                     årMånedFra = key,
-                    utgifter = value.sumOf { it.utgifter },
+                    utgifter = value.sumOf { it.utgifter ?: 0 },
                     beløp = value.sumOf { it.stønad },
                 )
             }
     }
 
     private fun validerFornuftigeBeløp(skoleårsperioder: List<SkoleårsperiodeSkolepengerDto>) {
-        brukerfeilHvis(skoleårsperioder.any { periode -> periode.utgiftsperioder.any { it.utgifter < 1 } }) {
-            "Utgifter må være høyere enn 0kr"
-        }
         brukerfeilHvis(skoleårsperioder.any { periode -> periode.utgiftsperioder.any { it.stønad < 0 } }) {
             "Stønad kan ikke være lavere enn 0kr"
-        }
-        brukerfeilHvis(skoleårsperioder.any { periode -> periode.utgiftsperioder.any { it.stønad > it.utgifter } }) {
-            "Stønad kan ikke være overstige utgifter"
         }
 
         skoleårsperioder.forEach { skoleårsperiode ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkoleårDtoer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkoleårDtoer.kt
@@ -16,6 +16,7 @@ data class BeregningSkolepengerResponse(
 
 data class BeløpsperiodeSkolepenger(
     val årMånedFra: YearMonth,
-    val utgifter: Int,
+    @Deprecated("Skal ikke brukes når nytt UI tas i bruk")
+    val utgifter: Int? = null,
     val beløp: Int,
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -455,7 +455,6 @@ fun DelårsperiodeSkoleårSkolepenger.tilIverksettDto() = DelårsperiodeSkoleår
 
 fun SkolepengerUtgift.tilIverksettDto() = SkolepengerUtgiftDto(
     utgiftsdato = this.utgiftsdato,
-    utgifter = this.utgifter,
     stønad = this.stønad,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/domain/Vedtak.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/domain/Vedtak.kt
@@ -181,7 +181,7 @@ data class DelårsperiodeSkoleårSkolepenger(
 data class SkolepengerUtgift(
     val id: UUID,
     val utgiftsdato: LocalDate,
-    val utgifter: Int,
+    val utgifter: Int? = null,
     val stønad: Int,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakSkolepengerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakSkolepengerDto.kt
@@ -70,7 +70,8 @@ data class DelårsperiodeSkoleårDto(
 data class SkolepengerUtgiftDto(
     val id: UUID,
     val årMånedFra: YearMonth,
-    val utgifter: Int,
+    @Deprecated("Skal ikke brukes når nytt UI tas i bruk")
+    val utgifter: Int? = null,
     val stønad: Int,
 )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -56,7 +56,6 @@ import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -56,6 +56,7 @@ import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -358,6 +359,7 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
         }
 
         @Test
+        @Disabled("Feiler uventet i github actions.")
         internal fun `skal kunne angre send til beslutter`() {
             val behandlingId = opprettBehandling(steg = StegType.SEND_TIL_BESLUTTER, status = BehandlingStatus.UTREDES)
             opprettOppgave(oppgaveType = Oppgavetype.GodkjenneVedtak)
@@ -383,6 +385,7 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
         }
 
         @Test
+        @Disabled("Feiler uventet i github actions.")
         internal fun `skal kunne angre send til beslutter når godkjenne vedtak-oppgaven er plukket av saksbehandler`() {
             opprettBehandling(steg = StegType.SEND_TIL_BESLUTTER, status = BehandlingStatus.UTREDES)
             sendTilBeslutter(SAKSBEHANDLER)

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VedtakControllerTest.kt
@@ -359,7 +359,6 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
         }
 
         @Test
-        @Disabled("Feiler uventet i github actions.")
         internal fun `skal kunne angre send til beslutter`() {
             val behandlingId = opprettBehandling(steg = StegType.SEND_TIL_BESLUTTER, status = BehandlingStatus.UTREDES)
             opprettOppgave(oppgaveType = Oppgavetype.GodkjenneVedtak)
@@ -385,7 +384,6 @@ internal class VedtakControllerTest : OppslagSpringRunnerTest() {
         }
 
         @Test
-        @Disabled("Feiler uventet i github actions.")
         internal fun `skal kunne angre send til beslutter når godkjenne vedtak-oppgaven er plukket av saksbehandler`() {
             opprettBehandling(steg = StegType.SEND_TIL_BESLUTTER, status = BehandlingStatus.UTREDES)
             sendTilBeslutter(SAKSBEHANDLER)

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerServiceTest.kt
@@ -194,15 +194,6 @@ internal class BeregningSkolepengerServiceTest {
 
     @Nested
     inner class ValideringAvBeløp {
-        @Test
-        internal fun `utgifter er mindre enn 1`() {
-            val periode = SkoleårsperiodeSkolepengerDto(listOf(delårsperiode()), listOf(utgift(utgifter = 0)))
-            val skoleårsperioder = listOf(periode)
-
-            assertThatThrownBy { service.beregnYtelse(skoleårsperioder, førstegangsbehandling.id) }
-                .isInstanceOf(ApiFeil::class.java)
-                .hasMessageContaining("Utgifter må være høyere enn 0kr")
-        }
 
         @Test
         internal fun `stønad kan ikke være under 0kr`() {
@@ -212,16 +203,6 @@ internal class BeregningSkolepengerServiceTest {
             assertThatThrownBy { service.beregnYtelse(skoleårsperioder, førstegangsbehandling.id) }
                 .isInstanceOf(ApiFeil::class.java)
                 .hasMessageContaining("Stønad kan ikke være lavere enn 0kr")
-        }
-
-        @Test
-        internal fun `stønad kan ikke være høyere enn utgifter`() {
-            val periode = SkoleårsperiodeSkolepengerDto(listOf(delårsperiode()), listOf(utgift(stønad = 200)))
-            val skoleårsperioder = listOf(periode)
-
-            assertThatThrownBy { service.beregnYtelse(skoleårsperioder, førstegangsbehandling.id) }
-                .isInstanceOf(ApiFeil::class.java)
-                .hasMessageContaining("Stønad kan ikke være overstige utgifter")
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
@@ -472,7 +472,6 @@ internal class IverksettingDtoMapperTest {
 
         assertThat(vedtaksperiode.utgiftsperioder).hasSize(1)
         assertThat(vedtaksperiode.utgiftsperioder[0].utgiftsdato).isEqualTo(LocalDate.of(2021, 2, 1))
-        assertThat(vedtaksperiode.utgiftsperioder[0].utgifter).isEqualTo(200)
         assertThat(vedtaksperiode.utgiftsperioder[0].stønad).isEqualTo(150)
     }
 


### PR DESCRIPTION
**Hvorfor?**
Ved overgang til nytt UI skal saksbehandlere ikke lengre oppgi utgifter for skolepenger, bare stønadsbeløp. Vi må støtte nytt og gammelt UI samtidig så feltet kan derfor ikke fjernes.

[Favro oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12239)

**PS:** kan ikke merges før https://github.com/navikt/familie-ef-iverksett/pull/786 er merget