### PR TITLE
Skal kaste feilmelding dersom ingen identer returneres fra PDL for henting av sammenslåtte perioder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.infotrygd.InfotrygdUtils.KLAGETYPER
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdEndringKode
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
@@ -72,7 +73,10 @@ class InfotrygdService(
 
     private fun hentSammenslåttePerioderFraReplika(personIdent: String): InfotrygdPeriodeResponse {
         val personIdenter = hentPersonIdenter(personIdent)
-        feilHvis(personIdenter.isEmpty()) { "Finner ikke identer for oppslag oppslag" }
+        feilHvis(personIdenter.isEmpty()) {
+            secureLogger.warn("Finner ikke $personIdent i pdl, kan følgelig ikke hente perioder fra replika")
+            "Det finnes ingen identer i pdl for oppslaget"
+        }
         return hentSammenslåttePerioderFraReplika(personIdenter)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.infotrygd
 
 import no.nav.familie.ef.sak.infotrygd.InfotrygdUtils.KLAGETYPER
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdEndringKode
@@ -71,6 +72,7 @@ class InfotrygdService(
 
     private fun hentSammenslåttePerioderFraReplika(personIdent: String): InfotrygdPeriodeResponse {
         val personIdenter = hentPersonIdenter(personIdent)
+        feilHvis(personIdenter.isEmpty()) { "Finner ikke identer for oppslag oppslag" }
         return hentSammenslåttePerioderFraReplika(personIdenter)
     }
 
@@ -117,6 +119,7 @@ class InfotrygdService(
         stønadstyper: Set<StønadType> = StønadType.values().toSet(),
     ): InfotrygdPeriodeResponse {
         require(stønadstyper.isNotEmpty()) { "Må sende med stønadstype" }
+        require(identer.isNotEmpty()) { "Finner ingen identer for oppslag" }
         val request = InfotrygdPeriodeRequest(identer, stønadstyper)
         return infotrygdReplikaClient.hentSammenslåttePerioder(request)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -119,7 +119,6 @@ class InfotrygdService(
         stønadstyper: Set<StønadType> = StønadType.values().toSet(),
     ): InfotrygdPeriodeResponse {
         require(stønadstyper.isNotEmpty()) { "Må sende med stønadstype" }
-        require(identer.isNotEmpty()) { "Finner ingen identer for oppslag" }
         val request = InfotrygdPeriodeRequest(identer, stønadstyper)
         return infotrygdReplikaClient.hentSammenslåttePerioder(request)
     }


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨

`hentSammenslåttePerioder` i familie-ef-infotrygd returnerer `BadRequest` dersom det ikke sendes med noen identer. Ettersom `pdlClient.hentPersonidenter` kun logger at man ikke finner personidenter må vi selv sjekke om identene som sendes til`infotrygdReplikaClient` ikke er tom. 