### PR TITLE
Skal ikke hente tidligere vedtakshistorikk for personopplysninger som…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
@@ -79,7 +79,7 @@ class SendKarakterutskriftBrevTilIverksettTask(
     }
 
     private fun validerHarIkkeVergemål(ident: String, opggave: Oppgave) {
-        val personopplysninger = personopplysningerService.hentPersonopplysninger(ident)
+        val personopplysninger = personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(ident)
         val harVerge = personopplysninger.vergemål.isNotEmpty()
         feilHvis(harVerge) {
             "Kan ikke automatisk sende brev for oppgaveId=${opggave.id}. Brev om innhenting av karakterutskrift skal ikke sendes automatisk fordi bruker har vergemål. Saken må følges opp manuelt og tasken kan avvikshåndteres."

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service
 class GrunnlagsdataRegisterService(
     private val personService: PersonService,
     private val personopplysningerIntegrasjonerClient: PersonopplysningerIntegrasjonerClient,
-    private val tidligereVedaksperioderService: TidligereVedaksperioderService,
+    private val tidligereVedtaksperioderService: TidligereVedtaksperioderService,
 ) {
 
     fun hentGrunnlagsdataFraRegister(
@@ -27,7 +27,7 @@ class GrunnlagsdataRegisterService(
         val grunnlagsdataFraPdl = hentGrunnlagsdataFraPdl(personIdent, emptyList())
         val medlUnntak = personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(personIdent)
         val tidligereVedtaksperioder =
-            tidligereVedaksperioderService.hentTidligereVedtaksperioder(grunnlagsdataFraPdl.søker.folkeregisteridentifikator)
+            tidligereVedtaksperioderService.hentTidligereVedtaksperioder(grunnlagsdataFraPdl.søker.folkeregisteridentifikator)
         val tidligereVedtasksperioderAnnenForelder = hentTidligereVedtaksperioderAnnenForelder(grunnlagsdataFraPdl.barneForeldre)
 
         return GrunnlagsdataDomene(
@@ -73,7 +73,7 @@ class GrunnlagsdataRegisterService(
         return loggTid("antall=${barneForeldre.size}") {
             barneForeldre.entries.associate { (ident, annenForelder) ->
                 val folkeregisteridentifikatorer = annenForelder.folkeregisteridentifikator
-                ident to tidligereVedaksperioderService.hentTidligereVedtaksperioder(folkeregisteridentifikatorer)
+                ident to tidligereVedtaksperioderService.hentTidligereVedtaksperioder(folkeregisteridentifikatorer)
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -28,11 +28,11 @@ class GrunnlagsdataRegisterService(
         val medlUnntak = personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(personIdent)
         val tidligereVedtaksperioder =
             tidligereVedtaksperioderService.hentTidligereVedtaksperioder(grunnlagsdataFraPdl.søker.folkeregisteridentifikator)
-        val tidligereVedtasksperioderAnnenForelder = hentTidligereVedtaksperioderAnnenForelder(grunnlagsdataFraPdl.barneForeldre)
+        val tidligereVedtaksperioderAnnenForelder = hentTidligereVedtaksperioderAnnenForelder(grunnlagsdataFraPdl.barneForeldre)
 
         return GrunnlagsdataDomene(
             søker = mapSøker(grunnlagsdataFraPdl.søker, grunnlagsdataFraPdl.andrePersoner),
-            annenForelder = mapAnnenForelder(grunnlagsdataFraPdl.barneForeldre, tidligereVedtasksperioderAnnenForelder),
+            annenForelder = mapAnnenForelder(grunnlagsdataFraPdl.barneForeldre, tidligereVedtaksperioderAnnenForelder),
             medlUnntak = medlUnntak,
             barn = mapBarn(grunnlagsdataFraPdl.barn),
             tidligereVedtaksperioder = tidligereVedtaksperioder,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
@@ -98,6 +98,12 @@ class GrunnlagsdataService(
         }
     }
 
+    fun hentGrunnlagsdataUtenTidligereVedtakshistorikk(personIdent: String): GrunnlagsdataDomene {
+        return loggTid {
+            grunnlagsdataRegisterService.hentGrunnlagsdataUtenVedtakshitorikkFraRegister(personIdent)
+        }
+    }
+
     fun oppdaterEndringer(grunnlagsdata: Grunnlagsdata): Grunnlagsdata {
         return grunnlagsdataRepository.update(grunnlagsdata)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -34,7 +34,7 @@ class PersonopplysningerController(
     @GetMapping("/behandling/{behandlingId}")
     fun personopplysninger(@PathVariable behandlingId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(behandlingId))
+        return Ressurs.success(personopplysningerService.hentPersonopplysninger(behandlingId))
     }
 
     @GetMapping("/behandling/{behandlingId}/endringer")

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -34,7 +34,7 @@ class PersonopplysningerController(
     @GetMapping("/behandling/{behandlingId}")
     fun personopplysninger(@PathVariable behandlingId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(personopplysningerService.hentPersonopplysninger(behandlingId))
+        return Ressurs.success(personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(behandlingId))
     }
 
     @GetMapping("/behandling/{behandlingId}/endringer")
@@ -47,7 +47,7 @@ class PersonopplysningerController(
     fun personopplysningerFraFagsakPersonId(@PathVariable fagsakPersonId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
-        return Ressurs.success(personopplysningerService.hentPersonopplysninger(aktivIdent))
+        return Ressurs.success(personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(aktivIdent))
     }
 
     @PostMapping("/nav-kontor")

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -33,7 +33,7 @@ class PersonopplysningerService(
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hentPersonopplysningerUtenVedtakshistorikk(behandlingId: UUID): PersonopplysningerDto {
+    fun hentPersonopplysninger(behandlingId: UUID): PersonopplysningerDto {
         val personIdent = behandlingService.hentAktivIdent(behandlingId)
         val søkerIdenter = personService.hentPersonIdenter(personIdent)
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdata(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -33,7 +33,7 @@ class PersonopplysningerService(
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hentPersonopplysninger(behandlingId: UUID): PersonopplysningerDto {
+    fun hentPersonopplysningerUtenVedtakshistorikk(behandlingId: UUID): PersonopplysningerDto {
         val personIdent = behandlingService.hentAktivIdent(behandlingId)
         val søkerIdenter = personService.hentPersonIdenter(personIdent)
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdata(behandlingId)
@@ -70,8 +70,8 @@ class PersonopplysningerService(
     }
 
     @Cacheable("personopplysninger", cacheManager = "shortCache")
-    fun hentPersonopplysninger(personIdent: String): PersonopplysningerDto {
-        val grunnlagsdata = grunnlagsdataService.hentFraRegisterForPersonOgAndreForeldre(personIdent, emptyList())
+    fun hentPersonopplysningerUtenVedtakshistorikk(personIdent: String): PersonopplysningerDto {
+        val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdataUtenTidligereVedtakshistorikk(personIdent)
         val egenAnsatt = egenAnsatt(personIdent)
         val identerFraPdl = personService.hentPersonIdenter(personIdent)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
@@ -15,7 +15,7 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import org.springframework.stereotype.Service
 
 @Service
-class TidligereVedaksperioderService(
+class TidligereVedtaksperioderService(
     private val fagsakPersonService: FagsakPersonService,
     private val fagsakService: FagsakService,
     private val behandlingService: BehandlingService,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -51,7 +51,7 @@ object GrunnlagsdataMapper {
                 dødsfall = it.value.dødsfall,
                 navn = it.value.navn.gjeldende(),
                 folkeregisteridentifikator = mapFolkeregisteridentifikator(it.value.folkeregisteridentifikator),
-                tidligereVedtaksperioder = tidligereVedtaksperioderAnnenForelder.getValue(it.key),
+                tidligereVedtaksperioder = tidligereVedtaksperioderAnnenForelder[it.key],
             )
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/KarakterutskriftBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/karakterutskrift/KarakterutskriftBrevTaskTest.kt
@@ -43,7 +43,7 @@ internal class KarakterutskriftBrevTaskTest {
 
     @BeforeEach
     private fun setUp() {
-        every { personopplysningerService.hentPersonopplysninger(any<String>()) } returns mockk {
+        every { personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(any<String>()) } returns mockk {
             every { vergemål } returns emptyList()
         }
     }
@@ -91,7 +91,7 @@ internal class KarakterutskriftBrevTaskTest {
         )
         every { behandlingService.finnesBehandlingForFagsak(any()) } returns true
         every { fagsakService.finnFagsaker(any()) } returns listOf(fagsak())
-        every { personopplysningerService.hentPersonopplysninger(any<String>()) } returns mockk {
+        every { personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(any<String>()) } returns mockk {
             every { vergemål } returns listOf(mockk())
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
-internal class TidligereVedaksperioderServiceTest {
+internal class TidligereVedtaksperioderServiceTest {
 
     private val fagsakPersonService = mockk<FagsakPersonService>()
     private val fagsakService = mockk<FagsakService>()
@@ -40,7 +40,7 @@ internal class TidligereVedaksperioderServiceTest {
     private val infotrygdReplikaClient = mockk<InfotrygdReplikaClient>()
     private val infotrygdService = InfotrygdService(infotrygdReplikaClient, personService)
 
-    private val service = TidligereVedaksperioderService(
+    private val service = TidligereVedtaksperioderService(
         fagsakPersonService,
         fagsakService,
         behandlingService,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataReposi
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
@@ -43,11 +43,11 @@ internal class GrunnlagsdataServiceTest {
     private val personService = PersonService(pdlClient, ConcurrentMapCacheManager())
     private val søknadService = mockk<SøknadService>()
     private val personopplysningerIntegrasjonerClient = mockk<PersonopplysningerIntegrasjonerClient>()
-    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
+    private val tidligereVedtaksperioderService = mockk<TidligereVedtaksperioderService>(relaxed = true)
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         personService,
         personopplysningerIntegrasjonerClient,
-        tidligereVedaksperioderService,
+        tidligereVedtaksperioderService,
     )
 
     private val søknad = SøknadsskjemaMapper.tilDomene(
@@ -128,11 +128,11 @@ internal class GrunnlagsdataServiceTest {
         val folkeregisteridentifikatorAnnenForelder = folkeregisteridentifikator(annenForelderFnr)
         val defaultTidligereInnvilgetVedtak = TidligereInnvilgetVedtak(true, true, false)
 
-        every { tidligereVedaksperioderService.hentTidligereVedtaksperioder(eq(listOf(identifikatorSøker))) } returns
+        every { tidligereVedtaksperioderService.hentTidligereVedtaksperioder(eq(listOf(identifikatorSøker))) } returns
             TidligereVedtaksperioder(defaultTidligereInnvilgetVedtak)
 
         every {
-            tidligereVedaksperioderService.hentTidligereVedtaksperioder(listOf(folkeregisteridentifikatorAnnenForelder))
+            tidligereVedtaksperioderService.hentTidligereVedtaksperioder(listOf(folkeregisteridentifikatorAnnenForelder))
         } returns
             TidligereVedtaksperioder(defaultTidligereInnvilgetVedtak, defaultTidligereInnvilgetVedtak)
 
@@ -143,9 +143,9 @@ internal class GrunnlagsdataServiceTest {
         assertThat(tidligereVedtaksperioder.infotrygd.harTidligereBarnetilsyn).isTrue
         assertThat(tidligereVedtaksperioder.infotrygd.harTidligereSkolepenger).isFalse
 
-        verify(exactly = 1) { tidligereVedaksperioderService.hentTidligereVedtaksperioder(listOf(identifikatorSøker)) }
+        verify(exactly = 1) { tidligereVedtaksperioderService.hentTidligereVedtaksperioder(listOf(identifikatorSøker)) }
         verify(exactly = 1) {
-            tidligereVedaksperioderService.hentTidligereVedtaksperioder(listOf(folkeregisteridentifikatorAnnenForelder))
+            tidligereVedtaksperioderService.hentTidligereVedtaksperioder(listOf(folkeregisteridentifikatorAnnenForelder))
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -83,18 +83,18 @@ internal class PersonopplysningerServiceTest {
             emptyList(),
             emptyList(),
         )
-        val søker = personopplysningerService.hentPersonopplysninger("01010172272")
+        val søker = personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("01010172272")
         assertThat(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(søker))
             .isEqualToIgnoringWhitespace(readFile("/json/personopplysningerDto.json"))
     }
 
     @Test
     internal fun `skal cache egenAnsatt når man kaller med samme ident`() {
-        personopplysningerService.hentPersonopplysninger("1")
-        personopplysningerService.hentPersonopplysninger("1")
+        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("1")
+        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("1")
         verify(exactly = 1) { personopplysningerIntegrasjonerClient.egenAnsatt(any()) }
 
-        personopplysningerService.hentPersonopplysninger("2")
+        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("2")
         verify(exactly = 2) { personopplysningerIntegrasjonerClient.egenAnsatt(any()) }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -11,7 +11,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataServic
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.InnflyttingUtflyttingMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.PersonopplysningerMapper
@@ -35,7 +35,7 @@ internal class PersonopplysningerServiceTest {
     private lateinit var søknadService: SøknadService
     private lateinit var behandlingService: BehandlingService
 
-    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
+    private val tidligereVedtaksperioderService = mockk<TidligereVedtaksperioderService>(relaxed = true)
 
     @BeforeEach
     internal fun setUp() {
@@ -48,7 +48,7 @@ internal class PersonopplysningerServiceTest {
         val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
             personService,
             personopplysningerIntegrasjonerClient,
-            tidligereVedaksperioderService,
+            tidligereVedtaksperioderService,
         )
 
         grunnlagsdataService = GrunnlagsdataService(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagServiceTest.kt
@@ -15,7 +15,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataReposi
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedaksperioderService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.tilSøknadsverdier
@@ -44,12 +44,12 @@ internal class VilkårGrunnlagServiceTest {
     private val kodeverkService = mockk<KodeverkService>(relaxed = true)
     private val medlemskapMapper = MedlemskapMapper(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true), kodeverkService)
     private val behandlingService = mockk<BehandlingService>()
-    private val tidligereVedaksperioderService = mockk<TidligereVedaksperioderService>(relaxed = true)
+    private val tidligereVedtaksperioderService = mockk<TidligereVedtaksperioderService>(relaxed = true)
 
     private val grunnlagsdataRegisterService = GrunnlagsdataRegisterService(
         personService,
         personopplysningerIntegrasjonerClient,
-        tidligereVedaksperioderService,
+        tidligereVedtaksperioderService,
     )
 
     private val fagsakService = mockk<FagsakService>()


### PR DESCRIPTION
… brukes på personopplysningssiden da dette ikke er i bruk.

Hovedpoenget er å kunne vise personopplysningssiden selv om "historisk pensjon" er nede. Men etter å ha sett igjennom bruken av tidligere vedtaksperioder så er den kun i bruke for personopplysninger på en _behandling_ - og ikke for en person. Vet ikke om det er "hacky" å løse det på denne måten, eller om det er greit nok? Frontend bruker den iallefall ikke. 


[Favro-kort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12266)