### PR TITLE
Fjerner CPU throttle for pods, skal bare ha CPU limits for requests.

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -25,7 +25,6 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 1024Mi

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -26,6 +26,8 @@ spec:
     min: 2
     max: 4
   resources:
+    limits:
+      memory: 1024Mi
     requests:
       memory: 512Mi
       cpu: 500m

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -26,9 +26,6 @@ spec:
     min: 2
     max: 4
   resources:
-    limits:
-      memory: 1024Mi
-      cpu: 1500m
     requests:
       memory: 512Mi
       cpu: 500m

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -24,7 +24,6 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 50
   resources:
     limits:
       memory: 2048Mi

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -25,6 +25,8 @@ spec:
     min: 2
     max: 4
   resources:
+    limits:
+      memory: 2048Mi
     requests:
       memory: 512Mi
       cpu: 500m

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -25,9 +25,6 @@ spec:
     min: 2
     max: 4
   resources:
-    limits:
-      memory: 2048Mi
-      cpu: 1500m
     requests:
       memory: 512Mi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver godt hvorfor: 
https://home.robusta.dev/blog/stop-using-cpu-limits

Ser det har vært snakk om å bare fjerne dette for de største appene som det har mest å si for (ved oppstart), men tenker jeg gjør dette for alle appene når jeg først er i gang, da det er en såpass tydelig anbefaling fra nais-plattform.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)