### PR TITLE
Ta av vent - sett saksbehandler på oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -26,6 +26,8 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -40,6 +42,9 @@ class BehandlingPåVentService(
     private val featureToggleService: FeatureToggleService,
     private val oppgaveService: OppgaveService,
 ) {
+
+    val logger: Logger = LoggerFactory.getLogger(javaClass)
+
     @Transactional
     fun settPåVent(behandlingId: UUID, settPåVentRequest: SettPåVentRequest) {
         val behandling = behandlingService.hentBehandling(behandlingId)
@@ -252,7 +257,18 @@ class BehandlingPåVentService(
                 nullstillVedtakService.nullstillVedtak(behandlingId)
             }
         }
+        fordelOppgaveTilSaksbehandler(behandlingId)
         taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId))
+    }
+
+    private fun fordelOppgaveTilSaksbehandler(behandlingId: UUID) {
+        val oppgave = oppgaveService.hentIkkeFerdigstiltOppgaveForBehandling(behandlingId)
+        val oppgaveId = oppgave?.id
+        if (oppgaveId != null) {
+            oppgaveService.fordelOppgave(oppgaveId, SikkerhetContext.hentSaksbehandler(), oppgave.versjon)
+        } else {
+            logger.warn("Finner ingen oppgave å oppdatere")
+        }
     }
 
     private fun opprettHistorikkInnslag(behandling: Behandling, stegUtfall: StegUtfall) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
@@ -358,6 +358,9 @@ internal class BehandlingPåVentServiceTest {
 
         @Test
         fun `skal ta behandling av vent og sende melding til DVH`() {
+            val oppgaveId = 1234561L
+            mockSettSaksbehandlerPåOppgave(oppgaveId)
+
             behandlingPåVentService.taAvVent(behandlingId)
 
             verify { behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES) }
@@ -379,6 +382,7 @@ internal class BehandlingPåVentServiceTest {
             }
             verify(exactly = 0) { nullstillVedtakService.nullstillVedtak(any()) }
             verify(exactly = 0) { behandlingService.oppdaterForrigeBehandlingId(any(), any()) }
+            verify { oppgaveService.fordelOppgave(oppgaveId, "bob", any()) }
         }
 
         @Test
@@ -400,7 +404,9 @@ internal class BehandlingPåVentServiceTest {
         }
 
         @Test
-        internal fun `skal oppdatere nullstille vedtak og oppdatere forrigeBehandlingId hvis man må nullstille vedtaket`() {
+        internal fun `skal nullstille vedtak og oppdatere forrigeBehandlingId hvis man må nullstille vedtaket`() {
+            val oppgaveId = 123456L
+            mockSettSaksbehandlerPåOppgave(oppgaveId)
             mockFinnSisteIverksatteBehandling(tidligereIverksattBehandling)
 
             behandlingPåVentService.taAvVent(behandlingId)
@@ -409,7 +415,14 @@ internal class BehandlingPåVentServiceTest {
                 behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES)
                 behandlingService.oppdaterForrigeBehandlingId(behandlingId, tidligereIverksattBehandling.id)
                 nullstillVedtakService.nullstillVedtak(behandlingId)
+                oppgaveService.fordelOppgave(oppgaveId, "bob", any())
             }
+        }
+
+        private fun mockSettSaksbehandlerPåOppgave(oppgaveId: Long) {
+            val oppgave = oppgave(oppgaveId)
+            every { oppgaveService.hentIkkeFerdigstiltOppgaveForBehandling(behandlingId) } returns oppgave
+            every { oppgaveService.fordelOppgave(any(), any(), any()) } returns oppgaveId
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
@@ -214,6 +214,7 @@ class OppgaveClientMock {
             fristFerdigstillelse = LocalDate.of(2020, 2, 1).toString(),
             prioritet = OppgavePrioritet.NORM,
             status = StatusEnum.OPPRETTET,
+            versjon = 2,
         )
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal oppdatere oppgaven med gjeldende saksbehandler som ansvarlig når en behandling tas av vent. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13714)

Må deployes samtidig som https://github.com/navikt/familie-ef-sak-frontend/pull/2449