### PR TITLE
Skal validere vedtak ikke kan ha mer enn 4 måneder med periodetypen PERIODE_FØR_FØDSEL

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -189,6 +189,10 @@ class BeregnYtelseSteg(
             ) {
                 "Kan ikke inneholde aktivitet eller periode av type migrering"
             }
+            val perioderFørFødsel = data.perioder.filter { it.periodeType === VedtaksperiodeType.PERIODE_FØR_FØDSEL }
+            brukerfeilHvis(perioderFørFødsel.sumOf { it.periode.lengdeIHeleMåneder() } > 4) {
+                "Vedtaket kan ikke inneholde mer enn 4 måneder med periodetypen periode før fødesel"
+            }
         }
         if (data is InnvilgelseBarnetilsyn) {
             barnService.validerBarnFinnesPåBehandling(saksbehandling.id, data.perioder.flatMap { it.barn }.toSet())


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å unngå at saksbehandlere gjør feil i vedtak

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12792)

