### PR TITLE
Skal sende med grunnbeløp til iverksett for bruk ved publisering av g…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230508082643_6b28bd8</felles.version>
         <prosessering.version>2.20230621155918_9c5de0f</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20230721145217_128807b</kontrakter.version>
+        <kontrakter.version>3.0_20230728094537_980f7a3</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.12.1</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -49,6 +49,7 @@ import no.nav.familie.kontrakter.ef.iverksett.Brevmottaker
 import no.nav.familie.kontrakter.ef.iverksett.DelvilkårsvurderingDto
 import no.nav.familie.kontrakter.ef.iverksett.DelårsperiodeSkoleårSkolepengerDto
 import no.nav.familie.kontrakter.ef.iverksett.FagsakdetaljerDto
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.ef.iverksett.IverksettBarnetilsynDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettOvergangsstønadDto
@@ -304,6 +305,7 @@ class IverksettingDtoMapper(
             oppgaverForOpprettelseService.hentOppgaverForOpprettelseEllerNull(vedtak.behandlingId)?.let {
                 OppgaverForOpprettelseDto(oppgavetyper = it.oppgavetyper)
             } ?: OppgaverForOpprettelseDto(oppgavetyper = emptyList()),
+            grunnbeløp = grunnbeløpFraTilkjentYtelse(tilkjentYtelse),
         )
 
     @Improvement("Opphørårsak må utledes ved revurdering")
@@ -474,4 +476,10 @@ fun MottakerRolle.tilIverksettDto(): Brevmottaker.MottakerRolle =
         MottakerRolle.FULLMAKT -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.VERGE -> Brevmottaker.MottakerRolle.VERGE
         MottakerRolle.BRUKER -> Brevmottaker.MottakerRolle.BRUKER
+    }
+
+private fun grunnbeløpFraTilkjentYtelse(tilkjentYtelse: TilkjentYtelse?) =
+    tilkjentYtelse?.let {
+        val grunnbeløp = Grunnbeløpsperioder.finnGrunnbeløp(it.grunnbeløpsmåned)
+        Grunnbeløp(periode = grunnbeløp.periode, grunnbeløp = grunnbeløp.grunnbeløp)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
@@ -68,6 +68,7 @@ import no.nav.familie.kontrakter.ef.iverksett.BehandlingKategori
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingsdetaljerDto
 import no.nav.familie.kontrakter.ef.iverksett.Brevmottaker
 import no.nav.familie.kontrakter.ef.iverksett.FagsakdetaljerDto
+import no.nav.familie.kontrakter.ef.iverksett.Grunnbeløp
 import no.nav.familie.kontrakter.ef.iverksett.IverksettBarnetilsynDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettDto
 import no.nav.familie.kontrakter.ef.iverksett.IverksettOvergangsstønadDto
@@ -320,6 +321,16 @@ internal class IverksettingDtoMapperTest {
     private fun assertAlleFelter(iverksettDto: IverksettOvergangsstønadDto, behandlingId: UUID?) {
         assertAlleFelterIverksettDto(iverksettDto, behandlingId, StønadType.OVERGANGSSTØNAD)
         assertVedtaksperiode(iverksettDto.vedtak)
+        assertGrunnbeløp(iverksettDto)
+    }
+
+    private fun assertGrunnbeløp(iverksettDto: IverksettOvergangsstønadDto) {
+        assertThat(iverksettDto.vedtak.grunnbeløp).isEqualTo(
+            Grunnbeløp(
+                Grunnbeløpsperioder.nyesteGrunnbeløp.periode,
+                Grunnbeløpsperioder.nyesteGrunnbeløp.grunnbeløp,
+            ),
+        )
     }
 
     private fun assertAlleFelter(iverksettDto: IverksettBarnetilsynDto, behandlingId: UUID?) {

--- a/src/test/resources/omregning/expectedIverksettDto.json
+++ b/src/test/resources/omregning/expectedIverksettDto.json
@@ -307,6 +307,13 @@
       }
     ],
     "tilbakekreving": null,
-    "brevmottakere": []
+    "brevmottakere": [],
+    "grunnbeløp": {
+      "periode": {
+        "fom": "2022-05",
+        "tom": "2023-04"
+      },
+      "grunnbeløp": 111477
+    }
   }
 }


### PR DESCRIPTION
…omregningsmelding

### Hvorfor er denne endringen nødvendig? ✨
Fortsettelse på https://github.com/navikt/familie-kontrakter/pull/816

> Når vi iverksetter en behandling med behandlingsårsak GOmregning publiserer familie-ef-iverksett en melding til bruker med informasjon om Gomregningen (SendBrukernotifikasjonVedGOmregningTask). Frem til nå har vi bare hardkodet nyeste grunnbeløp i iverksett. Ulempen med dette er at vi hvert år må huske å oppdatere iverksett med nyeste G. Ved å sende det G med fra ef-sak slipper vi å ha dette i iverksett, og vi kan være sikre på at det brukes riktig grunnbeløp i melding til bruker.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13586)