### PR TITLE
Fikset indentering på beskrivelsen av oppgave til lokalkontoret på se…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/OppgaveBeskrivelse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/OppgaveBeskrivelse.kt
@@ -7,7 +7,8 @@ object OppgaveBeskrivelse {
     """.trimMargin()
 
     val innstillingOmBrukersUtdanning =
-        """Vi trenger en vurdering fra dere fordi bruker tar/skal ta utdanning. 
+        """
+            Vi trenger en vurdering fra dere fordi bruker tar/skal ta utdanning. 
             Dere må gjøre vurderingen etter retningslinjene til folketrygdloven § 15-6 første ledd bokstav c og § 5 i Forskrift om stønad til enslig mor eller far.
             
             Dere må skrive vurderingen i et notat i Gosys med tittelen «Innstilling utdanning». 


### PR DESCRIPTION
…tt-på-vent-oppgaven

Første raden har indentering 0, samtidig som de andre radene har 12, og trimIndent fjerner leading spaces fra "felles" indentering

### Hvorfor er denne endringen nødvendig? ✨
Fordi det ser rart ut idag, og virker litt ulogisk at det er ønsket 👀 

Bild fra hvordan det ser ut idag:
![image](https://github.com/navikt/familie-ef-sak/assets/937168/5fe977b2-1254-479d-8e49-7bc653b2a982)


Avventer svar fra Lars før jeg merger
