### PR TITLE
Skal returnere 200 OK med body null på deprecated endepunkt. Noen saksbe…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -81,4 +81,12 @@ class BrevMellomlagerController(
 
         return Ressurs.success(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId))
     }
+
+    @Deprecated("Skal ikke brukes men noen saksbehandlere sitter fremdeles med utdatert frontend.")
+    @GetMapping("/frittstaende/{fagsakId}")
+    fun deprecatedHentMellomlagretFrittståendeBrev(@PathVariable fagsakId: UUID): Ressurs<Unit?> {
+        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
+        tilgangService.validerHarSaksbehandlerrolle()
+        return Ressurs.success(null)
+    }
 }


### PR DESCRIPTION
…handlere sitter fremdeles med utdatert frontend, og forsøker derfor å kalle dette endepunktet. Med data = null vil frontenden forkaste mallomlagret respons

### Hvorfor er denne endringen nødvendig? ✨
Etter jeg merget https://github.com/navikt/familie-ef-sak/pull/2328 har det vært noen få saksbehandlere som sitter med utdatert frontend som forsøker å hente mellomlagret brev fra det gamle endepunktet. Ved å returnere 200 OK med data = null vil frontenden automatisk bytte til den nye typen frittstående brev.