### PR TITLE
Skal fjerne deprecated endepunkt som ikke skal være i bruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -81,12 +81,4 @@ class BrevMellomlagerController(
 
         return Ressurs.success(mellomlagringBrevService.hentMellomlagretFrittståendeSanitybrev(fagsakId))
     }
-
-    @Deprecated("Skal ikke brukes men noen saksbehandlere sitter fremdeles med utdatert frontend.")
-    @GetMapping("/frittstaende/{fagsakId}")
-    fun deprecatedHentMellomlagretFrittståendeBrev(@PathVariable fagsakId: UUID): Ressurs<Unit?> {
-        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
-        tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(null)
-    }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Nyeste versjon av frontend skal ikke bruke dette endepunktet.

Kan merges om noen dager, når alle saksbehandlere har fått oppdatert versjon av frontend.
