### PR TITLE
Vil ikke ta med migreringer når vi henter kandidater til gjenbruk i n…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -136,6 +136,7 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         WHERE f.fagsak_person_id = :fagsakPersonId
          AND b.resultat IN ('OPPHØRT', 'INNVILGET', 'AVSLÅTT', 'IKKE_SATT')
          AND b.status NOT IN ('OPPRETTET')
+         AND b.arsak != 'MIGRERING'
     """,
     )
     fun finnBehandlingerForGjenbrukAvVilkår(fagsakPersonId: UUID): List<Behandling>


### PR DESCRIPTION
Vil ikke ta med migreringer når vi henter kandidater til gjenbruk i nye behandlinger.

### Hvorfor er denne endringen nødvendig? ✨

Vi ønsker ikke gjenbruke vilkårsvurderinger fra migreringer. Gir lite mening da det ikke er noen innhold på disse vilkårsvurderingene.  

Favro: 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14329

Barnetilsyn med to os behandlinger (en migrering og et avslag)
![image](https://github.com/navikt/familie-ef-sak/assets/53942238/6ceb63e8-5437-42fc-ba40-5bd93a2254f2)

