### PR TITLE
Skal ha strengere frist for gomregning for åpne behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -197,7 +197,7 @@ class IverksettingDtoMapper(
             "Kan ikke iverksette med utdatert grunnbeløp gyldig fra $gMånedTilkjentYtelse. Denne behandlingen må beregnes og simuleres på nytt"
 
         val nyttGrunnbeløpForInneværendeÅrRegistrertIEF = Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.year == DatoUtil.inneværendeÅr()
-        val fristGOmregning = LocalDate.of(DatoUtil.inneværendeÅr(), Month.JUNE, 15)
+        val fristGOmregning = LocalDate.of(DatoUtil.inneværendeÅr(), Month.JUNE, 1)
 
         if (nyttGrunnbeløpForInneværendeÅrRegistrertIEF && DatoUtil.dagensDato() < fristGOmregning) {
             validerBehandlingBrukerÅretsEllerFjoråretsG(gMånedTilkjentYtelse, feilmelding)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Etter diskusjon med @ma10s. For å begrense antall behandlinger som må gomregnes forkorter vi tidsrommet vi tillater iverksetting med gammel G. Har også beskrevet denne valideringen litt mer i GOmregning-readme'en https://github.com/navikt/familie-ef-sak/commit/098fd19be5c883c406d30e97dd02c3c424ca8ec6

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13587)