### PR TITLE
Slett tabell for deprecated mellomlagret frittstående brev

### DIFF
--- a/src/main/resources/db/migration/V140__slett_mellomlager_frittstående_brev.sql
+++ b/src/main/resources/db/migration/V140__slett_mellomlager_frittstående_brev.sql
@@ -1,0 +1,1 @@
+DROP TABLE mellomlagret_frittstaende_brev;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Frittstående brev er erstattet av sanitybrev, og koden som brukte denne tabellen er slettet i https://github.com/navikt/familie-ef-sak/pull/2328 🗑️ 
