### PR TITLE
Vil ikke flagge behandling som "mangler oppgave" hvis oppgave for behandling er opprettet nylig. 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -189,8 +189,11 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT b.*, f.stonadstype
         FROM behandling b
         JOIN fagsak f ON f.id = b.fagsak_id
+        JOIN oppgave o on b.id = o.behandling_id
         WHERE NOT b.status = 'FERDIGSTILT'
-        AND b.opprettet_tid < :opprettetTidFør
+        AND o.ferdigstilt = false
+        AND o.type in ('BehandleSak', 'GodkjenneVedtak', 'BehandleUnderkjentVedtak')
+        AND o.opprettet_tid < :opprettetTidFør
         AND f.stonadstype=:stønadstype
         """,
     )


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vil ikke flagge behandling som "mangler oppgave" hvis oppgave for behandling er opprettet nylig. 

Vi prøver å finne åpne behandlinger som ikke har oppgave. 

Nåsituasjon:
Når vi sjekker dette i dag henter vi alle våre gamle behandlinger og alle gamle "behandle sak" oppgaver og sammenlikner. Dersom det nylig er laget en ny oppgave for behandlingen vil behandlingen bli flagget. Vi henter ikke "nyere" oppgaver.  

Ved f.eks: underkjent av beslutter lager vi ny BehandleSak oppgave. Disse finner ikke vi pga begrensninger i søk etter oppgaver. 

Vi ønsker å luke bort falske positive: behandlinger som er gamle, men hvor det er laget "ny" oppgave.   

### Diskusjon/alternative løsninger: 

Alternativ 1:
Vi beholder finn gamle behandlinger som i dag, men før vi flagger manglende oppgave sjekker vi konkret oppgave mot gosys. (Vi regner ikke med at det skal bli veldig mange av disse) 

Alternativ 2
Vi øker antall oppgaver vi henter fra gosys/oppgave? 
