### PR TITLE
Feil ved uthenting av oppgave/journalpost for utviklere i prod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -45,6 +45,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     AUTOMATISKE_OPPGAVER_FREMLEGGSOPPGAVE("familie.ef.sak.automatiske-oppgaver.fremleggsoppgave"),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT("familie.ef.sak.automatiske-brev-innhenting-karakterutskrift"),
     UTBEDRET_GUI_SKOLEPENGER("familie.ef.sak.frontend-skolepenger-utbedret-gui"),
+    UTVIKLER_MED_VEILEDERRROLLE("familie.ef.sak.utviklere-med-veilederrolle")
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -45,7 +45,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     AUTOMATISKE_OPPGAVER_FREMLEGGSOPPGAVE("familie.ef.sak.automatiske-oppgaver.fremleggsoppgave"),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT("familie.ef.sak.automatiske-brev-innhenting-karakterutskrift"),
     UTBEDRET_GUI_SKOLEPENGER("familie.ef.sak.frontend-skolepenger-utbedret-gui"),
-    UTVIKLER_MED_VEILEDERRROLLE("familie.ef.sak.utviklere-med-veilederrolle")
+    UTVIKLER_MED_VEILEDERRROLLE("familie.ef.sak.utviklere-med-veilederrolle"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
@@ -22,7 +24,8 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.NavHttpHeaders
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
@@ -32,6 +35,7 @@ import java.net.URI
 class JournalpostClient(
     @Qualifier("azure") restOperations: RestOperations,
     integrasjonerConfig: IntegrasjonerConfig,
+    private val featureToggleService: FeatureToggleService,
 ) :
     AbstractPingableRestClient(restOperations, "journalpost") {
 
@@ -40,21 +44,24 @@ class JournalpostClient(
     private val dokarkivUri: URI = integrasjonerConfig.dokarkivUri
 
     fun finnJournalposter(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<Journalpost> {
+        validerIkkeUtviklerMedVeilederrolle()
         return postForEntity<Ressurs<List<Journalpost>>>(journalpostURI, journalposterForBrukerRequest).data
             ?: error("Kunne ikke hente vedlegg for ${journalposterForBrukerRequest.brukerId.id}")
     }
 
     fun finnJournalposterForBrukerOgTema(journalposterForBrukerOgTemaRequest: JournalposterForVedleggRequest): List<Journalpost> {
+        validerIkkeUtviklerMedVeilederrolle()
         return postForEntity<Ressurs<List<Journalpost>>>(URI.create("$journalpostURI/temaer"), journalposterForBrukerOgTemaRequest).data
             ?: error("Kunne ikke hente vedlegg for ${journalposterForBrukerOgTemaRequest.brukerId.id}")
     }
 
     fun hentJournalpost(journalpostId: String): Journalpost {
+        validerIkkeUtviklerMedVeilederrolle()
         val ressurs = try {
             getForEntity<Ressurs<Journalpost>>(URI.create("$journalpostURI?journalpostId=$journalpostId"))
         } catch (e: RessursException) {
             if (e.message?.contains("Fant ikke journalpost i fagarkivet") == true) {
-                throw ApiFeil("Finner ikke journalpost i fagarkivet", HttpStatus.BAD_REQUEST)
+                throw ApiFeil("Finner ikke journalpost i fagarkivet", BAD_REQUEST)
             } else {
                 throw e
             }
@@ -62,7 +69,17 @@ class JournalpostClient(
         return ressurs.getDataOrThrow()
     }
 
+    private fun validerIkkeUtviklerMedVeilederrolle() {
+        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+            throw ApiFeil(
+                "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
+                FORBIDDEN,
+            )
+        }
+    }
+
     fun hentDokument(journalpostId: String, dokumentInfoId: String, dokumentVariantformat: DokumentVariantformat): ByteArray {
+        // TODO: feil her hvis utviklere med veilederrolle
         return getForEntity<Ressurs<ByteArray>>(
             UriComponentsBuilder
                 .fromUriString(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -44,19 +44,19 @@ class JournalpostClient(
     private val dokarkivUri: URI = integrasjonerConfig.dokarkivUri
 
     fun finnJournalposter(journalposterForBrukerRequest: JournalposterForBrukerRequest): List<Journalpost> {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         return postForEntity<Ressurs<List<Journalpost>>>(journalpostURI, journalposterForBrukerRequest).data
             ?: error("Kunne ikke hente vedlegg for ${journalposterForBrukerRequest.brukerId.id}")
     }
 
     fun finnJournalposterForBrukerOgTema(journalposterForBrukerOgTemaRequest: JournalposterForVedleggRequest): List<Journalpost> {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         return postForEntity<Ressurs<List<Journalpost>>>(URI.create("$journalpostURI/temaer"), journalposterForBrukerOgTemaRequest).data
             ?: error("Kunne ikke hente vedlegg for ${journalposterForBrukerOgTemaRequest.brukerId.id}")
     }
 
     fun hentJournalpost(journalpostId: String): Journalpost {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         val ressurs = try {
             getForEntity<Ressurs<Journalpost>>(URI.create("$journalpostURI?journalpostId=$journalpostId"))
         } catch (e: RessursException) {
@@ -69,7 +69,7 @@ class JournalpostClient(
         return ressurs.getDataOrThrow()
     }
 
-    private fun validerIkkeUtviklerMedVeilederrolle() {
+    private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
         if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
@@ -79,7 +79,7 @@ class JournalpostClient(
     }
 
     fun hentDokument(journalpostId: String, dokumentInfoId: String, dokumentVariantformat: DokumentVariantformat): ByteArray {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         return getForEntity<Ressurs<ByteArray>>(
             UriComponentsBuilder
                 .fromUriString(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -79,7 +79,7 @@ class JournalpostClient(
     }
 
     fun hentDokument(journalpostId: String, dokumentInfoId: String, dokumentVariantformat: DokumentVariantformat): ByteArray {
-        // TODO: feil her hvis utviklere med veilederrolle
+        validerIkkeUtviklerMedVeilederrolle()
         return getForEntity<Ressurs<ByteArray>>(
             UriComponentsBuilder
                 .fromUriString(

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -28,7 +28,7 @@ import java.net.URI
 class OppgaveClient(
     @Qualifier("azure") restOperations: RestOperations,
     integrasjonerConfig: IntegrasjonerConfig,
-    private val featureToggleService: FeatureToggleService
+    private val featureToggleService: FeatureToggleService,
 ) :
     AbstractPingableRestClient(restOperations, "oppgave") {
 
@@ -139,7 +139,6 @@ class OppgaveClient(
             )
         }
     }
-
 
     private fun <T> pakkUtRespons(
         respons: Ressurs<T>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ef.sak.felles.util.medContentTypeJsonUTF8
 import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.IntegrasjonException
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -26,6 +28,7 @@ import java.net.URI
 class OppgaveClient(
     @Qualifier("azure") restOperations: RestOperations,
     integrasjonerConfig: IntegrasjonerConfig,
+    private val featureToggleService: FeatureToggleService
 ) :
     AbstractPingableRestClient(restOperations, "oppgave") {
 
@@ -41,6 +44,7 @@ class OppgaveClient(
     }
 
     fun finnOppgaveMedId(oppgaveId: Long): Oppgave {
+        validerIkkeUtviklerMedVeilederrolle()
         val uri = URI.create("$oppgaveUri/$oppgaveId")
 
         val respons = getForEntity<Ressurs<Oppgave>>(uri)
@@ -48,6 +52,7 @@ class OppgaveClient(
     }
 
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
+        validerIkkeUtviklerMedVeilederrolle()
         val uri = URI.create("$oppgaveUri/v4")
 
         val respons =
@@ -125,6 +130,16 @@ class OppgaveClient(
         val respons = getForEntity<Ressurs<FinnMappeResponseDto>>(uri)
         return pakkUtRespons(respons, uri, "finnMappe")
     }
+
+    private fun validerIkkeUtviklerMedVeilederrolle() {
+        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+            throw ApiFeil(
+                "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
+                HttpStatus.FORBIDDEN,
+            )
+        }
+    }
+
 
     private fun <T> pakkUtRespons(
         respons: Ressurs<T>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -44,7 +44,7 @@ class OppgaveClient(
     }
 
     fun finnOppgaveMedId(oppgaveId: Long): Oppgave {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         val uri = URI.create("$oppgaveUri/$oppgaveId")
 
         val respons = getForEntity<Ressurs<Oppgave>>(uri)
@@ -52,7 +52,7 @@ class OppgaveClient(
     }
 
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto {
-        validerIkkeUtviklerMedVeilederrolle()
+        kastApiFeilDersomUtviklerMedVeilederrolle()
         val uri = URI.create("$oppgaveUri/v4")
 
         val respons =
@@ -131,7 +131,7 @@ class OppgaveClient(
         return pakkUtRespons(respons, uri, "finnMappe")
     }
 
-    private fun validerIkkeUtviklerMedVeilederrolle() {
+    private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
         if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -134,7 +134,7 @@ class OppgaveClient(
     private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
         if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
-                "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
+                "Kan ikke hente ut oppgaver som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
                 HttpStatus.FORBIDDEN,
             )
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
@@ -32,6 +32,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.boot.web.client.RestTemplateBuilder
@@ -53,14 +54,6 @@ internal class JournalpostClientTest {
         @BeforeAll
         @JvmStatic
         fun initClass() {
-            every {
-                featureToggleService.isEnabled(any())
-            } answers {
-                if (firstArg<Toggle>() == Toggle.UTVIKLER_MED_VEILEDERRROLLE) {
-                    false
-                }
-                true
-            }
             wiremockServerItem = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
             wiremockServerItem.start()
             integrasjonerConfig = IntegrasjonerConfig(URI.create(wiremockServerItem.baseUrl()))
@@ -78,6 +71,15 @@ internal class JournalpostClientTest {
     @AfterEach
     fun tearDownEachTest() {
         wiremockServerItem.resetAll()
+    }
+
+    @BeforeEach
+    fun setup() {
+        every {
+            featureToggleService.isEnabled(any())
+        } answers {
+            firstArg<Toggle>() != Toggle.UTVIKLER_MED_VEILEDERRROLLE
+        }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Featuretoggle for å feile internt i ef-sak dersom en utvikler prøver å hente ut informasjon fra joark eller oppgave. Dette for å unngå at kallene går videre og feiler med forbidden i de løsningene.

I produksjon har vi veiledertilgang til vår egen løsning, men ikke tilgang til oppgave, dokarkiv og andre omkringliggende løsninger. Derfor er det bedre at vi feiler på innsiden av vår løsning i disse tilfellene.

Alle med veilederrolle i prod bør inn i lista [her](https://unleash.nais.io/#/features/strategies/familie.ef.sak.utviklere-med-veilederrolle)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14379)
