### PR TITLE
Skal fjerne feltet utgifter fra SkolepengerUtgiftDto. Dette feltet er…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
@@ -75,7 +75,6 @@ class BeregningSkolepengerService(
             .map { (key, value) ->
                 BeløpsperiodeSkolepenger(
                     årMånedFra = key,
-                    utgifter = value.sumOf { it.utgifter ?: 0 },
                     beløp = value.sumOf { it.stønad },
                 )
             }
@@ -237,7 +236,6 @@ class BeregningSkolepengerService(
         brukerfeilHvis(manglende.isNotEmpty()) {
             val manglendePerioder = manglende.joinToString(", \n") { (_, utgiftsperiode) ->
                 "fakturadato=${utgiftsperiode.årMånedFra} " +
-                    "utgifter=${utgiftsperiode.utgifter} " +
                     "stønad=${utgiftsperiode.stønad}"
             }
             "Mangler utgiftsperioder fra forrige vedtak \n$manglendePerioder"

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkoleårDtoer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkoleårDtoer.kt
@@ -16,7 +16,5 @@ data class BeregningSkolepengerResponse(
 
 data class BeløpsperiodeSkolepenger(
     val årMånedFra: YearMonth,
-    @Deprecated("Skal ikke brukes når nytt UI tas i bruk")
-    val utgifter: Int? = null,
     val beløp: Int,
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -25,7 +25,6 @@ class FeatureToggleController(private val featureToggleService: FeatureToggleSer
         Toggle.ULIKE_INNTEKTER,
         Toggle.VURDER_KONSEKVENS_OPPGAVER_LOKALKONTOR,
         Toggle.AUTOMATISKE_OPPGAVER_FREMLEGGSOPPGAVE,
-        Toggle.UTBEDRET_GUI_SKOLEPENGER,
         Toggle.ÅRSAK_REVURDERING_BESKRIVELSE,
     )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -44,7 +44,6 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     TILLAT_MIGRERING_7_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-7-ar-tilbake", "Permission"),
     AUTOMATISKE_OPPGAVER_FREMLEGGSOPPGAVE("familie.ef.sak.automatiske-oppgaver.fremleggsoppgave"),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT("familie.ef.sak.automatiske-brev-innhenting-karakterutskrift"),
-    UTBEDRET_GUI_SKOLEPENGER("familie.ef.sak.frontend-skolepenger-utbedret-gui"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakSkolepengerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakSkolepengerDto.kt
@@ -70,8 +70,6 @@ data class DelårsperiodeSkoleårDto(
 data class SkolepengerUtgiftDto(
     val id: UUID,
     val årMånedFra: YearMonth,
-    @Deprecated("Skal ikke brukes når nytt UI tas i bruk")
-    val utgifter: Int? = null,
     val stønad: Int,
 )
 
@@ -81,7 +79,6 @@ fun SkoleårsperiodeSkolepengerDto.tilDomene() = SkoleårsperiodeSkolepenger(
         SkolepengerUtgift(
             id = it.id,
             utgiftsdato = it.årMånedFra.atDay(1),
-            utgifter = it.utgifter,
             stønad = it.stønad,
         )
     }.sortedBy { it.utgiftsdato },
@@ -130,6 +127,5 @@ fun DelårsperiodeSkoleårSkolepenger.tilDto() = DelårsperiodeSkoleårDto(
 fun SkolepengerUtgift.tilDto() = SkolepengerUtgiftDto(
     id = this.id,
     årMånedFra = YearMonth.from(this.utgiftsdato),
-    utgifter = this.utgifter,
     stønad = this.stønad,
 )

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerServiceTest.kt
@@ -38,7 +38,6 @@ internal class BeregningSkolepengerServiceTest {
 
     private val defaultFra = YearMonth.of(2021, 8)
     private val defaultTil = YearMonth.of(2022, 6)
-    private val defaultUtgift = 100
     private val defaultStønad = 50
 
     @BeforeEach
@@ -55,7 +54,7 @@ internal class BeregningSkolepengerServiceTest {
         val delårsperiode = delårsperiode()
         val skoleårsperiode = SkoleårsperiodeSkolepengerDto(listOf(delårsperiode), listOf(utgift))
         val beregnedePerioder = service.beregnYtelse(listOf(skoleårsperiode), førstegangsbehandling.id)
-        assertThat(beregnedePerioder.perioder).containsOnly(BeløpsperiodeSkolepenger(defaultFra, 100, 50))
+        assertThat(beregnedePerioder.perioder).containsOnly(BeløpsperiodeSkolepenger(defaultFra, 50))
     }
 
     @Nested
@@ -249,7 +248,7 @@ internal class BeregningSkolepengerServiceTest {
             every { vedtakService.hentVedtak(førstegangsbehandling.id) } returns vedtak(skoleårsperioder)
 
             val beregnedePerioder = service.beregnYtelse(skoleårsperioder, revurdering.id)
-            assertThat(beregnedePerioder.perioder).containsOnly(BeløpsperiodeSkolepenger(defaultFra, 100, 50))
+            assertThat(beregnedePerioder.perioder).containsOnly(BeløpsperiodeSkolepenger(defaultFra, 50))
         }
 
         @Test
@@ -329,7 +328,7 @@ internal class BeregningSkolepengerServiceTest {
 
             val perioder = service.beregnYtelse(skoleårsperioder, revurdering.id, erOpphør = true)
             assertThat(perioder.perioder)
-                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultUtgift, defaultStønad))
+                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultStønad))
         }
 
         @Test
@@ -349,7 +348,7 @@ internal class BeregningSkolepengerServiceTest {
 
             val perioder = service.beregnYtelse(skoleårsperioder, revurdering.id, erOpphør = true)
             assertThat(perioder.perioder)
-                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultUtgift, defaultStønad))
+                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultStønad))
         }
 
         @Test
@@ -367,7 +366,7 @@ internal class BeregningSkolepengerServiceTest {
 
             val perioder = service.beregnYtelse(skoleårsperioder, revurdering.id, erOpphør = true)
             assertThat(perioder.perioder)
-                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultUtgift, defaultStønad))
+                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultStønad))
         }
     }
 
@@ -431,7 +430,7 @@ internal class BeregningSkolepengerServiceTest {
 
             val perioder = service.beregnYtelse(skoleårsperioder, revurdering.id, erOpphør = true)
             assertThat(perioder.perioder)
-                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultUtgift, defaultStønad))
+                .containsOnly(BeløpsperiodeSkolepenger(defaultFra, defaultStønad))
         }
 
         @Test
@@ -493,12 +492,10 @@ internal class BeregningSkolepengerServiceTest {
     private fun utgift(
         id: UUID = UUID.randomUUID(),
         fra: YearMonth = defaultFra,
-        utgifter: Int = defaultUtgift,
         stønad: Int = defaultStønad,
     ) = SkolepengerUtgiftDto(
         id = id,
         årMånedFra = fra,
-        utgifter = utgifter,
         stønad = stønad,
     )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakDtoUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakDtoUtil.kt
@@ -144,7 +144,6 @@ object VedtakDtoUtil {
                 SkolepengerUtgiftDto(
                     id = UUID.fromString("c076a0b9-0eb9-4a1b-bdcb-d75ebc40570d"),
                     årMånedFra = YearMonth.of(2021, 1),
-                    utgifter = 500,
                     stønad = 500,
                 ),
             ),


### PR DESCRIPTION
… ikke lenger i bruk. Fjerner feature-toggle for nytt design av skolepenger

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14613)

Frontend:
* https://github.com/navikt/familie-ef-sak-frontend/pull/2512

### Hvorfor er denne endringen nødvendig? ✨
Etter lanseringen av skolepenger 2.0 har ikke feltet utgifter vært i bruk på utgiftsperioder for skolepenger. Fjerner derfor dette feltet og alle steder det er i bruk.
