### PR TITLE
Trenger å wrappe personidenten for å unngå at den omsluttes av fnutter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.ef.søknad.KanSendePåminnelseRequest
+import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
@@ -49,8 +50,8 @@ class EksternBehandlingController(
 
     @PostMapping("har-loepende-barnetilsyn")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
-    fun harLøpendeBarnetilsyn(@RequestBody personIdent: String): Ressurs<Boolean> {
-        return Ressurs.success(eksternBehandlingService.harLøpendeBarnetilsyn(personIdent))
+    fun harLøpendeBarnetilsyn(@RequestBody personIdent: PersonIdent): Ressurs<Boolean> {
+        return Ressurs.success(eksternBehandlingService.harLøpendeBarnetilsyn(personIdent.ident))
     }
 
     @GetMapping("kan-opprette-revurdering-klage/{eksternFagsakId}")


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

familie-ef-personhendelse bruker endepunktet har-loepende-barnetilsyn, og vi ønsker å wrappe personidenten

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd