### PR TITLE
Flyttet aktivitetArbeidForBehandlingIds fra vurderingsservice 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -20,8 +20,6 @@ import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
-import no.nav.familie.ef.sak.vilkår.regler.RegelId
-import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkårsvurderinger
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -209,19 +207,6 @@ class VurderingService(
 
         vilkårsvurderingRepository.insertAll(kopiAvVurderinger.values.toList() + nyeBarnVurderinger)
         tilbakestillEndretTidForKopierteVurderinger(kopiAvVurderinger, tidligereVurderinger)
-    }
-
-    fun aktivitetArbeidForBehandlingIds(behandlingIds: Collection<UUID>): Map<UUID, SvarId?> {
-        val vilkårsvurderinger =
-            vilkårsvurderingRepository.findByTypeAndBehandlingIdIn(VilkårType.AKTIVITET_ARBEID, behandlingIds)
-
-        return vilkårsvurderinger.associate { vilkårsvurdering ->
-            val delvilkårsvurderinger = vilkårsvurdering.delvilkårsvurdering.delvilkårsvurderinger
-
-            vilkårsvurdering.behandlingId to delvilkårsvurderinger.map { delvilkårsvurdering ->
-                delvilkårsvurdering.vurderinger.single { it.regelId == RegelId.ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM }.svar
-            }.single()
-        }
     }
 
     private fun validerAtVurderingerKanKopieres(

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilkjentytelse/AndelsHistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilkjentytelse/AndelsHistorikkServiceTest.kt
@@ -1,0 +1,53 @@
+package no.nav.familie.ef.sak.tilkjentytelse
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
+import no.nav.familie.ef.sak.vilkår.Vurdering
+import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class AndelsHistorikkServiceTest {
+
+    private val vilkårsvurderingRepository = mockk<VilkårsvurderingRepository>()
+
+    val andelsHistorikkService = AndelsHistorikkService(mockk(), mockk(), mockk(), mockk(), vilkårsvurderingRepository, mockk(), mockk())
+
+    private val behandlingId = UUID.randomUUID()
+
+    @Test
+    internal fun `Skal returnere aktivitet i historikk`() {
+        val vilkårsvurderingList = VilkårType.hentVilkårForStønad(StønadType.BARNETILSYN).map {
+            vilkårsvurdering(
+                behandlingId = behandlingId,
+                resultat = Vilkårsresultat.OPPFYLT,
+                type = VilkårType.AKTIVITET_ARBEID,
+                delvilkårsvurdering = listOf(
+                    Delvilkårsvurdering(
+                        Vilkårsresultat.OPPFYLT,
+                        listOf(Vurdering(RegelId.ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM, SvarId.ER_I_ARBEID)),
+                    ),
+                ),
+            )
+        }
+
+        every {
+            vilkårsvurderingRepository.findByTypeAndBehandlingIdIn(
+                VilkårType.AKTIVITET_ARBEID,
+                listOf(behandlingId),
+            )
+        } returns vilkårsvurderingList
+
+        val behandlingIdToSvarID = andelsHistorikkService.aktivitetArbeidForBehandlingIds(listOf(behandlingId))
+
+        Assertions.assertThat(behandlingIdToSvarID[behandlingId]).isEqualTo(SvarId.ER_I_ARBEID)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceIntegrasjonsTest.kt
@@ -16,8 +16,6 @@ import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.vilkårsvurdering
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
-import no.nav.familie.ef.sak.vilkår.regler.RegelId
-import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.SivilstandRegel
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -118,28 +116,6 @@ internal class VurderingServiceIntegrasjonsTest : OppslagSpringRunnerTest() {
             },
         )
             .hasMessage("Tidligere behandling=$tidligereBehandlingId har ikke noen vilkår")
-    }
-
-    @Test
-    internal fun `aktivitet arbeid for behandlingIds`() {
-        val fagsak = testoppsettService.lagreFagsak(fagsak(stønadstype = StønadType.BARNETILSYN))
-        val behandling = behandling(fagsak)
-        behandlingRepository.insert(behandling)
-        val vilkårsvurdering = vilkårsvurdering(
-            behandling.id,
-            Vilkårsresultat.OPPFYLT,
-            VilkårType.AKTIVITET_ARBEID,
-            listOf(
-                Delvilkårsvurdering(
-                    Vilkårsresultat.OPPFYLT,
-                    listOf(Vurdering(RegelId.ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM, SvarId.ER_I_ARBEID)),
-                ),
-            ),
-        )
-        vilkårsvurderingRepository.insert(vilkårsvurdering)
-
-        val behandlingIdToSvarId = vurderingService.aktivitetArbeidForBehandlingIds(listOf(behandling.id))
-        assertThat(behandlingIdToSvarId[behandling.id]).isEqualTo(SvarId.ER_I_ARBEID)
     }
 
     private fun opprettVilkårsvurderinger(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -34,8 +34,6 @@ import no.nav.familie.ef.sak.vilkår.dto.LangAvstandTilSøker
 import no.nav.familie.ef.sak.vilkår.dto.SivilstandInngangsvilkårDto
 import no.nav.familie.ef.sak.vilkår.dto.SivilstandRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
-import no.nav.familie.ef.sak.vilkår.regler.RegelId
-import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.SivilstandRegel
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
@@ -81,8 +79,6 @@ internal class VurderingServiceTest {
     private val barn = søknadBarnTilBehandlingBarn(søknad.barn)
     private val behandling = behandling(fagsak(), BehandlingStatus.OPPRETTET, årsak = BehandlingÅrsak.PAPIRSØKNAD)
     private val behandlingId = UUID.randomUUID()
-
-    private val fnr = no.nav.familie.util.FnrGenerator.generer(LocalDate.now().minusYears(5))
 
     @BeforeEach
     fun setUp() {
@@ -316,34 +312,6 @@ internal class VurderingServiceTest {
 
         val erAlleVilkårOppfylt = vurderingService.erAlleVilkårOppfylt(behandlingId)
         assertThat(erAlleVilkårOppfylt).isFalse
-    }
-
-    @Test
-    internal fun `Skal returnere aktivitet i historikk`() {
-        val vilkårsvurderingList = VilkårType.hentVilkårForStønad(BARNETILSYN).map {
-            vilkårsvurdering(
-                behandlingId = behandlingId,
-                resultat = OPPFYLT,
-                type = VilkårType.AKTIVITET_ARBEID,
-                delvilkårsvurdering = listOf(
-                    Delvilkårsvurdering(
-                        OPPFYLT,
-                        listOf(Vurdering(RegelId.ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM, SvarId.ER_I_ARBEID)),
-                    ),
-                ),
-            )
-        }
-
-        every {
-            vilkårsvurderingRepository.findByTypeAndBehandlingIdIn(
-                VilkårType.AKTIVITET_ARBEID,
-                listOf(behandlingId),
-            )
-        } returns vilkårsvurderingList
-
-        val behandlingIdToSvarID = vurderingService.aktivitetArbeidForBehandlingIds(listOf(behandlingId))
-
-        assertThat(behandlingIdToSvarID[behandlingId]).isEqualTo(SvarId.ER_I_ARBEID)
     }
 
     private fun lagVilkårsvurderingerMedResultat(


### PR DESCRIPTION
Splittet refaktorering og PR - periodehistorikk i behandling. 

Flyttet aktivitetArbeidForBehandlingIds fra vurderingsservice til AndelsHistorikkService for å unngå dependency-loop.  

### Hvorfor er denne endringen nødvendig? ✨
Vil bruke AndlesHistorikkService i TidligereVedtaksperioderService. Da vil det bli dependency-loop via Vurderingsservice som via omveier bruker TidligereVedtaksperioderService. 

