### PR TITLE
Skal kun validere om en bruker er utvikler dersom konteksten er saksb…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -45,6 +45,8 @@ object SikkerhetContext {
         return result
     }
 
+    fun erSaksbehandler(): Boolean = hentSaksbehandlerEllerSystembruker() != SYSTEM_FORKORTELSE
+
     fun hentSaksbehandlerEllerSystembruker() =
         Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
             .fold(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
@@ -70,7 +71,7 @@ class JournalpostClient(
     }
 
     private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
-        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+        if (SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
                 FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -132,7 +133,7 @@ class OppgaveClient(
     }
 
     private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
-        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+        if (SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut oppgaver som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
                 HttpStatus.FORBIDDEN,

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
@@ -12,10 +12,13 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.JournalpostClient
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
@@ -71,6 +74,7 @@ internal class JournalpostClientTest {
     @AfterEach
     fun tearDownEachTest() {
         wiremockServerItem.resetAll()
+        unmockkObject(SikkerhetContext)
     }
 
     @BeforeEach
@@ -80,6 +84,8 @@ internal class JournalpostClientTest {
         } answers {
             firstArg<Toggle>() != Toggle.UTVIKLER_MED_VEILEDERRROLLE
         }
+        mockkObject(SikkerhetContext)
+        every { SikkerhetContext.erSaksbehandler() } returns true
     }
 
     @Test


### PR DESCRIPTION
…ehandler, ikke når konteksten er systembruker

### Hvorfor er denne endringen nødvendig? ✨