### PR TITLE
Rydd toggles

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingUtenOppgaveTask.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ef.sak.behandling.oppgavekontroll
 
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -16,12 +14,11 @@ import java.util.*
     settTilManuellOppfølgning = true,
     beskrivelse = "Finn åpne behandlinger uten behandle sak oppgave",
 )
-class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService, val featureToggleService: FeatureToggleService) : AsyncTaskStep {
+class BehandlingUtenOppgaveTask(val behandlingsoppgaveService: BehandlingsoppgaveService) : AsyncTaskStep {
 
     override fun doTask(task: Task) {
         val antallÅpneBehandlingerUtenOppgave = behandlingsoppgaveService.antallÅpneBehandlingerUtenOppgave()
-        val skalKasteFeilHvisOppgaveMangler = featureToggleService.isEnabled(Toggle.KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING)
-        feilHvis(skalKasteFeilHvisOppgaveMangler && antallÅpneBehandlingerUtenOppgave > 0) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
+        feilHvis(antallÅpneBehandlingerUtenOppgave > 0) { "Åpne behandlinger uten behandleSak oppgave funnet på fagsak " }
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningService.kt
@@ -3,8 +3,6 @@ package no.nav.familie.ef.sak.beregning
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.VedtakService
@@ -15,7 +13,6 @@ import no.nav.familie.ef.sak.vedtak.dto.ResultatType
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
 import no.nav.familie.kontrakter.felles.ef.StønadType
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.YearMonth
@@ -26,20 +23,13 @@ class ValiderOmregningService(
     private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val beregningService: BeregningService,
     private val vedtakHistorikkService: VedtakHistorikkService,
-    private val featureToggleService: FeatureToggleService,
 ) {
-
-    private val logger = LoggerFactory.getLogger(javaClass)
 
     fun validerHarSammePerioderSomTidligereVedtak(
         data: InnvilgelseOvergangsstønad,
         saksbehandling: Saksbehandling,
     ) {
         if (!saksbehandling.erOmregning || saksbehandling.erMaskinellOmregning) {
-            return
-        }
-        if (featureToggleService.isEnabled(Toggle.G_OMREGNING_REVURDER_HOPP_OVER_VALIDER_TIDLIGERE_VEDTAK)) {
-            logger.warn("Skipper validering av tidligere perioder vid g-omregning for behandling=${saksbehandling.id}")
             return
         }
         val tidligerePerioder = hentVedtakshistorikkFraNyesteGrunnbeløp(saksbehandling)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -12,32 +12,37 @@ interface FeatureToggleService : DisposableBean {
 }
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
-    AUTOMATISK_MIGRERING("familie.ef.sak.automatisk-migrering"),
-    MIGRERING_BARNETILSYN("familie.ef.sak.migrering.barnetilsyn"),
-    G_BEREGNING("familie.ef.sak.g-beregning"),
-    G_BEREGNING_SCHEDULER("familie.ef.sak.g-beregning-scheduler"),
-    G_OMREGNING_REVURDER_HOPP_OVER_VALIDER_TIDLIGERE_VEDTAK("familie.ef.sak.revurder-g-omregning-hopp-over-valider-tidligere-vedtak"),
-    G_BEREGNING_INKLUDER_SATT_PÅ_VENT("familie.ef.sak.inkluder-satt-pa-vent-gomregning"),
-    G_BEREGNING_TILLAT_MANUELL_OPPRETTELSE_AV_G_TASK("familie.ef.sak.tillat-opprettelse-av-g-task", "Permission"),
-    SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS("familie.ef.sak.bruk-nye-maxsatser"),
+    // Release
+    G_BEREGNING_INKLUDER_SATT_PÅ_VENT(
+        "familie.ef.sak.inkluder-satt-pa-vent-gomregning",
+        "Usikker på om vi ønsker denne eller ikke. Ta en vurdering før 2024?",
+    ),
+    FRONTEND_VIS_INNTEKT_PERSONOVERSIKT("familie.ef.sak.frontend.vis-inntekt-personoversikt", "Ikke ferdigstilt ennå"),
 
+    // Operational
+    AUTOMATISK_MIGRERING("familie.ef.sak.automatisk-migrering", "Kan denne slettes?"),
+    G_BEREGNING("familie.ef.sak.g-beregning", "Operational"),
+    G_BEREGNING_SCHEDULER("familie.ef.sak.g-beregning-scheduler", "Operational"),
+    SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS("familie.ef.sak.bruk-nye-maxsatser", "Operational"),
+    FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER("familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler", "Operational- kun preprod"),
+    FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR("familie.ef.sak.frontend-automatisk-utfylle-vilkar", "Operational - kun preprod"),
+    AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT(
+        "familie.ef.sak.automatiske-brev-innhenting-karakterutskrift",
+        "Operational - sesongavhengig",
+    ),
+
+    // Permission
+    MIGRERING_BARNETILSYN("familie.ef.sak.migrering.barnetilsyn", "Permission"),
+    G_BEREGNING_TILLAT_MANUELL_OPPRETTELSE_AV_G_TASK("familie.ef.sak.tillat-opprettelse-av-g-task", "Permission"),
     OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST(
         "familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost",
         "Permission",
     ),
     BEHANDLING_KORRIGERING("familie.ef.sak.behandling-korrigering", "Permission"),
-
-    VILKÅR_GJENBRUK("familie.ef.sak.vilkaar-gjenruk"),
-
-    FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER("familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler"),
-    FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR("familie.ef.sak.frontend-automatisk-utfylle-vilkar"),
-    FRONTEND_SATSENDRING("familie.ef.sak.frontend-vis-satsendring"),
-    FRONTEND_VIS_INNTEKT_PERSONOVERSIKT("familie.ef.sak.frontend.vis-inntekt-personoversikt"),
-    KAST_FEIL_HVIS_OPPGAVE_MANGLER_PÅ_ÅPEN_BEHANDLING("familie.ef.sak.kast-feil-hvis-oppgave-mangler-pa-apen-behandling"),
+    FRONTEND_SATSENDRING("familie.ef.sak.frontend-vis-satsendring", "Permission"),
     TILLAT_MIGRERING_5_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-5-ar-tilbake", "Permission"),
     TILLAT_MIGRERING_7_ÅR_TILBAKE("familie.ef.sak.tillat-migrering-7-ar-tilbake", "Permission"),
-    AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT("familie.ef.sak.automatiske-brev-innhenting-karakterutskrift"),
-    UTVIKLER_MED_VEILEDERRROLLE("familie.ef.sak.utviklere-med-veilederrolle"),
+    UTVIKLER_MED_VEILEDERRROLLE("familie.ef.sak.utviklere-med-veilederrolle", "Permission"),
     ;
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -233,7 +233,7 @@ class VurderingService(
                     behandlingId = nyBehandlingsId,
                     sporbar = Sporbar(),
                     barnId = finnBarnId(vurdering.barnId, barnIdMap),
-                    opphavsvilkår = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) vurdering.opprettOpphavsvilkår() else null,
+                    opphavsvilkår = vurdering.opprettOpphavsvilkår(),
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataEndring
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -93,7 +93,7 @@ class GjenbrukVilkårService(
                     behandlingId = behandlingId,
                     sporbar = it.sporbar,
                     barnId = it.barnId,
-                    opphavsvilkår = if (featureToggleService.isEnabled(Toggle.VILKÅR_GJENBRUK)) tidligereVurdering.opprettOpphavsvilkår() else null,
+                    opphavsvilkår = tidligereVurdering.opprettOpphavsvilkår(),
                 )
             }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -11,7 +11,6 @@ import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
@@ -25,7 +25,6 @@ import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
@@ -6,9 +6,7 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.beregning.BeregningService
 import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.ValiderOmregningService
-import no.nav.familie.ef.sak.felles.util.mockFeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -38,7 +36,6 @@ class ValiderOmregningServiceTest {
 
     val vedtakService = mockk<VedtakService>()
     val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
-    val featureToggleService = mockFeatureToggleService()
     val beregningService = BeregningService()
     val vedtakHistorikkService = mockk<VedtakHistorikkService>()
     val validerOmregningService = ValiderOmregningService(
@@ -46,7 +43,6 @@ class ValiderOmregningServiceTest {
         tilkjentYtelseRepository,
         beregningService,
         vedtakHistorikkService,
-        featureToggleService,
     )
 
     @Test
@@ -94,12 +90,6 @@ class ValiderOmregningServiceTest {
     inner class ValiderHarSammePerioderSomTidligereVedtak {
 
         private val år = Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed.year
-
-        @BeforeEach
-        internal fun setUp() {
-            val toggle = Toggle.G_OMREGNING_REVURDER_HOPP_OVER_VALIDER_TIDLIGERE_VEDTAK
-            every { featureToggleService.isEnabled(toggle) } returns false
-        }
 
         @Test
         internal fun `skal ikke validere hvis det er maskinell g-omregning`() {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal fjerne unødvendige toggles: 
- vilkaar-gjenruk (Denne har vært true veldig lenge og trengs ikke)
- revurder-g-omregning-hopp-over-valider-tidligere-vedtaks (Denne har aldri vært skrudd på, slik jeg ser det - og kan følgelig fjernes "as is")
- kast-feil-hvis-oppgave-mangler-pa-apen-behandling (Denne har vært true siden vi begynte å kjøre oppgave-sjekken - og det er fint)

Husk å slette toggles fra unleash etter deploy!