### PR TITLE
Oppdater behandlingsstatus og steg ved journalføring når vilkår kopieres

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -3,8 +3,10 @@ package no.nav.familie.ef.sak.journalføring
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.migrering.InfotrygdPeriodeValideringService
+import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData
@@ -12,7 +14,6 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.iverksett.IverksettService
 import no.nav.familie.ef.sak.journalføring.JournalføringHelper.validerJournalføringNyBehandling
@@ -53,7 +54,6 @@ class JournalføringService(
     private val taskService: TaskService,
     private val barnService: BarnService,
     private val oppgaveService: OppgaveService,
-    private val featureToggleService: FeatureToggleService,
     private val journalpostService: JournalpostService,
     private val infotrygdPeriodeValideringService: InfotrygdPeriodeValideringService,
 ) {
@@ -214,15 +214,10 @@ class JournalføringService(
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType = UstrukturertDokumentasjonType.IKKE_VALGT,
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
     ): Behandling {
-        val behandlingsårsak = if (journalpost.harStrukturertSøknad()) {
-            BehandlingÅrsak.SØKNAD
-        } else {
-            ustrukturertDokumentasjonType.behandlingÅrsak()
-        }
         val behandling = behandlingService.opprettBehandling(
             behandlingType = behandlingstype,
             fagsakId = fagsak.id,
-            behandlingsårsak = behandlingsårsak,
+            behandlingsårsak = utledBehandlingÅrsak(journalpost, ustrukturertDokumentasjonType),
         )
         iverksettService.startBehandling(behandling, fagsak)
         if (journalpost.harStrukturertSøknad()) {
@@ -239,29 +234,44 @@ class JournalføringService(
             barnSomSkalFødes = barnSomSkalFødes,
             vilkårsbehandleNyeBarn = vilkårsbehandleNyeBarn,
         )
-        kopierVurderingerForEttersendingPåNyBehandling(ustrukturertDokumentasjonType, behandling, fagsak)
+        val forrigeBehandling = finnForrigeIverksatteEllerAvslåtteBehandling(fagsak)
+        if (skalKopiereVurderingerTilNyBehandling(ustrukturertDokumentasjonType)) {
+            forrigeBehandling?.let { kopierVurderingerOgOppdaterBehandling(behandling, it.id, fagsak) }
+        }
         return behandling
     }
 
-    private fun kopierVurderingerForEttersendingPåNyBehandling(
+    private fun utledBehandlingÅrsak(
+        journalpost: Journalpost,
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType,
+    ) = if (journalpost.harStrukturertSøknad()) {
+        BehandlingÅrsak.SØKNAD
+    } else {
+        ustrukturertDokumentasjonType.behandlingÅrsak()
+    }
+
+    private fun kopierVurderingerOgOppdaterBehandling(
         behandling: Behandling,
+        forrigeBehandlingId: UUID,
         fagsak: Fagsak,
     ) {
-        val erEttersending = ustrukturertDokumentasjonType == UstrukturertDokumentasjonType.ETTERSENDING
-        if (erEttersending) {
-            val forrigeBehandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
-            forrigeBehandling?.let {
-                val (_, metadata) = vurderingService.hentGrunnlagOgMetadata(behandling.id)
-                vurderingService.kopierVurderingerTilNyBehandling(
-                    it.id,
-                    behandling.id,
-                    metadata,
-                    fagsak.stønadstype,
-                )
-            }
-        }
+        val (_, metadata) = vurderingService.hentGrunnlagOgMetadata(behandling.id)
+        vurderingService.kopierVurderingerTilNyBehandling(
+            forrigeBehandlingId,
+            behandling.id,
+            metadata,
+            fagsak.stønadstype,
+        )
+        behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.UTREDES)
+        behandlingService.oppdaterStegPåBehandling(behandling.id, StegType.BEREGNE_YTELSE)
     }
+
+    private fun skalKopiereVurderingerTilNyBehandling(
+        ustrukturertDokumentasjonType: UstrukturertDokumentasjonType,
+    ): Boolean = ustrukturertDokumentasjonType.erEttersending()
+
+    private fun finnForrigeIverksatteEllerAvslåtteBehandling(fagsak: Fagsak) =
+        behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
 
     private fun opprettBehandlingsstatistikkTask(behandlingId: UUID, oppgaveId: Long? = null) {
         taskService.save(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -34,7 +34,7 @@ data class BarnSomSkalFødes(val fødselTerminDato: LocalDate) {
 enum class UstrukturertDokumentasjonType(val behandlingÅrsak: () -> BehandlingÅrsak) {
     PAPIRSØKNAD({ BehandlingÅrsak.PAPIRSØKNAD }),
     ETTERSENDING({ BehandlingÅrsak.NYE_OPPLYSNINGER }),
-    IKKE_VALGT({ error("Kan ikke bruke behandlingsårsak fra $IKKE_VALGT") }),;
+    IKKE_VALGT({ error("Kan ikke bruke behandlingsårsak fra $IKKE_VALGT") }), ;
 
     fun erEttersending(): Boolean = this == ETTERSENDING
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -34,7 +34,9 @@ data class BarnSomSkalFødes(val fødselTerminDato: LocalDate) {
 enum class UstrukturertDokumentasjonType(val behandlingÅrsak: () -> BehandlingÅrsak) {
     PAPIRSØKNAD({ BehandlingÅrsak.PAPIRSØKNAD }),
     ETTERSENDING({ BehandlingÅrsak.NYE_OPPLYSNINGER }),
-    IKKE_VALGT({ error("Kan ikke bruke behandlingsårsak fra $IKKE_VALGT") }),
+    IKKE_VALGT({ error("Kan ikke bruke behandlingsårsak fra $IKKE_VALGT") }),;
+
+    fun erEttersending(): Boolean = this == ETTERSENDING
 }
 
 enum class VilkårsbehandleNyeBarn {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -426,7 +426,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         val behandlingerForGjenbruk: List<Behandling> =
             behandlingRepository.finnBehandlingerForGjenbrukAvVilkår(fagsakBT.fagsakPersonId)
 
-        assertThat(behandlingerForGjenbruk).containsExactly(førstegangsbehandlingOS, førstegangsbehandlingBT)
+        assertThat(behandlingerForGjenbruk).containsExactlyInAnyOrder(førstegangsbehandlingOS, førstegangsbehandlingBT)
     }
 
     @Test
@@ -448,7 +448,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         val behandlingerForGjenbruk: List<Behandling> =
             behandlingRepository.finnBehandlingerForGjenbrukAvVilkår(fagsakSP.fagsakPersonId)
 
-        assertThat(behandlingerForGjenbruk).containsExactly(
+        assertThat(behandlingerForGjenbruk).containsExactlyInAnyOrder(
             førstegangsbehandlingOS,
             annengangsbehandlingOS,
             førstegangsbehandlingBT,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal sette behandlingsstatus til UTREDES og behandlingssteg til BEREGNE_YTELSE dersom journalføringen tilsier at vilkår blir kopiert. Uten dette vil saksbehandler ikke kunne velge Innvilgelse/avslag/opphør uten å først endre på et vilkår - dét er bakvendtland :) 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15345)
