### PR TITLE
Alternativ revurdering iverksette ka vedtak uten brev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230905101454_06fa3d7</felles.version>
         <prosessering.version>2.20230807154047_d770f01</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20230918090258_bf0dfa7</kontrakter.version>
+        <kontrakter.version>3.0_20230925140159_1b0dbac</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.14.0</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/Saksbehandling.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/Saksbehandling.kt
@@ -40,7 +40,8 @@ data class Saksbehandling(
     val endretTid: LocalDateTime,
 ) {
     val skalSendeBrev: Boolean = !skalIkkeSendeBrev
-    val skalIkkeSendeBrev get() = erKorrigeringUtenBrev || erOmregning || erSatsendring || erMigrering
+    val skalIkkeSendeBrev get() = erIverksettingKAVedtak || erKorrigeringUtenBrev || erOmregning || erSatsendring || erMigrering
+    val erIverksettingKAVedtak get() = årsak == BehandlingÅrsak.IVERKSETTE_KA_VEDTAK
     val erKorrigeringUtenBrev get() = årsak == BehandlingÅrsak.KORRIGERING_UTEN_BREV
     val erSatsendring get() = årsak == BehandlingÅrsak.SATSENDRING
     val erMigrering get() = årsak == BehandlingÅrsak.MIGRERING

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
@@ -90,6 +90,7 @@ internal class ÅrsakRevurderingServiceTest {
                 BehandlingÅrsak.SØKNAD,
                 BehandlingÅrsak.MIGRERING,
                 BehandlingÅrsak.G_OMREGNING,
+                BehandlingÅrsak.IVERKSETTE_KA_VEDTAK,
                 BehandlingÅrsak.KORRIGERING_UTEN_BREV,
                 BehandlingÅrsak.PAPIRSØKNAD,
                 BehandlingÅrsak.SATSENDRING,

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
@@ -135,7 +135,7 @@ internal class BeslutteVedtakStegTest {
         every {
             vedtaksbrevService.lagEndeligBeslutterbrev(
                 any(),
-                vedtakKreverBeslutter
+                vedtakKreverBeslutter,
             )
         } returns Fil("123".toByteArray())
 
@@ -150,7 +150,7 @@ internal class BeslutteVedtakStegTest {
         verify(exactly = 1) {
             behandlingService.oppdaterResultatPåBehandling(
                 behandlingId,
-                BehandlingResultat.INNVILGET
+                BehandlingResultat.INNVILGET,
             )
         }
         verify(exactly = 1) { iverksett.iverksett(any(), any()) }
@@ -162,7 +162,7 @@ internal class BeslutteVedtakStegTest {
         val nesteSteg = utførTotrinnskontroll(
             godkjent = false,
             begrunnelse = "begrunnelse",
-            årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET)
+            årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET),
         )
 
         val deserializedPayload = objectMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(taskSlot[1].payload)
@@ -200,7 +200,7 @@ internal class BeslutteVedtakStegTest {
     @Test
     internal fun `skal ikke ha beslutter ved avslag og mindre inntektsendringer`() {
         every { vedtakService.hentVedtak(any()) } returns vedtak(behandlingId, resultatType = ResultatType.AVSLÅ).copy(
-            avslåÅrsak = AvslagÅrsak.MINDRE_INNTEKTSENDRINGER
+            avslåÅrsak = AvslagÅrsak.MINDRE_INNTEKTSENDRINGER,
         )
         every {
             vedtaksbrevService.lagEndeligBeslutterbrev(any(), vedtakErUtenBeslutter)
@@ -228,7 +228,7 @@ internal class BeslutteVedtakStegTest {
         assertThrows<ApiFeil> {
             utførTotrinnskontroll(
                 godkjent = false,
-                årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET)
+                årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET),
             )
         }
     }
@@ -239,7 +239,7 @@ internal class BeslutteVedtakStegTest {
             utførTotrinnskontroll(
                 godkjent = false,
                 begrunnelse = "bergrunnelse",
-                årsakerUnderkjent = emptyList()
+                årsakerUnderkjent = emptyList(),
             )
         }
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeslutteVedtakStegTest.kt
@@ -132,7 +132,12 @@ internal class BeslutteVedtakStegTest {
     @Test
     internal fun `skal opprette iverksettMotOppdragTask etter beslutte vedtak hvis godkjent`() {
         every { vedtakService.hentVedtaksresultat(behandlingId) } returns ResultatType.INNVILGE
-        every { vedtaksbrevService.lagEndeligBeslutterbrev(any(), vedtakKreverBeslutter) } returns Fil("123".toByteArray())
+        every {
+            vedtaksbrevService.lagEndeligBeslutterbrev(
+                any(),
+                vedtakKreverBeslutter
+            )
+        } returns Fil("123".toByteArray())
 
         val nesteSteg = utførTotrinnskontroll(godkjent = true)
 
@@ -142,14 +147,23 @@ internal class BeslutteVedtakStegTest {
         assertThat(taskSlot[2].type).isEqualTo(BehandlingsstatistikkTask.TYPE)
         assertThat(objectMapper.readValue<BehandlingsstatistikkTaskPayload>(taskSlot[2].payload).hendelse)
             .isEqualTo(Hendelse.BESLUTTET)
-        verify(exactly = 1) { behandlingService.oppdaterResultatPåBehandling(behandlingId, BehandlingResultat.INNVILGET) }
+        verify(exactly = 1) {
+            behandlingService.oppdaterResultatPåBehandling(
+                behandlingId,
+                BehandlingResultat.INNVILGET
+            )
+        }
         verify(exactly = 1) { iverksett.iverksett(any(), any()) }
         verify(exactly = 0) { iverksett.iverksettUtenBrev(any()) }
     }
 
     @Test
     internal fun `skal opprette opprettBehandleUnderkjentVedtakOppgave etter beslutte vedtak hvis underkjent`() {
-        val nesteSteg = utførTotrinnskontroll(godkjent = false, begrunnelse = "begrunnelse", årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET))
+        val nesteSteg = utførTotrinnskontroll(
+            godkjent = false,
+            begrunnelse = "begrunnelse",
+            årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET)
+        )
 
         val deserializedPayload = objectMapper.readValue<OpprettOppgaveTask.OpprettOppgaveTaskData>(taskSlot[1].payload)
 
@@ -168,6 +182,14 @@ internal class BeslutteVedtakStegTest {
     }
 
     @Test
+    internal fun `skal ikke sende brev hvis årsaken er iverksette KA vedtak`() {
+        utførTotrinnskontroll(true, opprettSaksbehandling(BehandlingÅrsak.IVERKSETTE_KA_VEDTAK))
+
+        verify(exactly = 0) { iverksett.iverksett(any(), any()) }
+        verify(exactly = 1) { iverksett.iverksettUtenBrev(any()) }
+    }
+
+    @Test
     internal fun `skal ikke sende brev hvis årsaken er g-omregning`() {
         utførTotrinnskontroll(true, opprettSaksbehandling(BehandlingÅrsak.G_OMREGNING))
 
@@ -177,7 +199,9 @@ internal class BeslutteVedtakStegTest {
 
     @Test
     internal fun `skal ikke ha beslutter ved avslag og mindre inntektsendringer`() {
-        every { vedtakService.hentVedtak(any()) } returns vedtak(behandlingId, resultatType = ResultatType.AVSLÅ).copy(avslåÅrsak = AvslagÅrsak.MINDRE_INNTEKTSENDRINGER)
+        every { vedtakService.hentVedtak(any()) } returns vedtak(behandlingId, resultatType = ResultatType.AVSLÅ).copy(
+            avslåÅrsak = AvslagÅrsak.MINDRE_INNTEKTSENDRINGER
+        )
         every {
             vedtaksbrevService.lagEndeligBeslutterbrev(any(), vedtakErUtenBeslutter)
         } returns Fil("123".toByteArray())
@@ -189,12 +213,23 @@ internal class BeslutteVedtakStegTest {
 
     @Test
     internal fun `skal feile dersom vedtak underkjent og mangler begrunnelse`() {
-        assertThrows<ApiFeil> { utførTotrinnskontroll(godkjent = false, årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET)) }
+        assertThrows<ApiFeil> {
+            utførTotrinnskontroll(
+                godkjent = false,
+                årsakerUnderkjent = listOf(ÅrsakUnderkjent.AKTIVITET)
+            )
+        }
     }
 
     @Test
     internal fun `skal feile dersom vedtak underkjent og mangler årsaker til underkjennelse`() {
-        assertThrows<ApiFeil> { utførTotrinnskontroll(godkjent = false, begrunnelse = "bergrunnelse", årsakerUnderkjent = emptyList()) }
+        assertThrows<ApiFeil> {
+            utførTotrinnskontroll(
+                godkjent = false,
+                begrunnelse = "bergrunnelse",
+                årsakerUnderkjent = emptyList()
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker et nytt alternativ når saksbehandler kun skal registrere vedtak hvor bruker har fått vedtak fra KS, uten å sende brev.

Frontend: https://github.com/navikt/familie-ef-sak-frontend/pull/2528
Kontrakter: https://github.com/navikt/familie-kontrakter/pull/834
Favro:https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15499