### PR TITLE
Retter på local config ifm Unleash Next

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/CustonUnleashStrategies.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/CustonUnleashStrategies.kt
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class FeatureToggleConfig {
+class CustonUnleashStrategies {
 
     @Bean
     fun strategies(): List<Strategy> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleConfig.kt
@@ -5,6 +5,7 @@ import no.nav.familie.unleash.DefaultUnleashService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
 @Configuration
 class FeatureToggleConfig(
@@ -18,6 +19,7 @@ class FeatureToggleConfig(
         return listOf(ByUserIdStrategy(), ByEnvironmentStrategy())
     }
 
+    @Profile("!mock-featuretoggle")
     @Bean
     fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
         return DefaultUnleashService(apiUrl, apiToken, appName, strategies)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleConfig.kt
@@ -1,27 +1,14 @@
 package no.nav.familie.ef.sak.infrastruktur.featuretoggle
 
 import io.getunleash.strategy.Strategy
-import no.nav.familie.unleash.DefaultUnleashService
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 
 @Configuration
-class FeatureToggleConfig(
-    @Value("\${UNLEASH_SERVER_API_URL}") private val apiUrl: String,
-    @Value("\${UNLEASH_SERVER_API_TOKEN}") private val apiToken: String,
-    @Value("\${NAIS_APP_NAME}") private val appName: String,
-) {
+class FeatureToggleConfig {
 
     @Bean
     fun strategies(): List<Strategy> {
         return listOf(ByUserIdStrategy(), ByEnvironmentStrategy())
-    }
-
-    @Profile("!mock-featuretoggle")
-    @Bean
-    fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
-        return DefaultUnleashService(apiUrl, apiToken, appName, strategies)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -1,17 +1,17 @@
 package no.nav.familie.ef.sak.infrastruktur.featuretoggle
 
-import no.nav.familie.unleash.DefaultUnleashService
+import no.nav.familie.unleash.UnleashService
 import org.springframework.stereotype.Service
 
 @Service
-class FeatureToggleService(val defaultUnleashService: DefaultUnleashService) {
+class FeatureToggleService(val unleashService: UnleashService) {
 
     fun isEnabled(toggle: Toggle): Boolean {
-        return defaultUnleashService.isEnabled(toggle.toggleId)
+        return unleashService.isEnabled(toggle.toggleId)
     }
 
     fun isEnabled(toggle: Toggle, defaultValue: Boolean): Boolean {
-        return defaultUnleashService.isEnabled(toggle.toggleId, defaultValue)
+        return unleashService.isEnabled(toggle.toggleId, defaultValue)
     }
 }
 

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -35,7 +35,7 @@ fun main(args: Array<String>) {
             "mock-sigrun",
             "mock-historiskpensjon",
             "mock-featuretoggle",
-        )
+            )
         .properties(properties)
         .run(*args)
 }

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -35,7 +35,7 @@ fun main(args: Array<String>) {
             "mock-sigrun",
             "mock-historiskpensjon",
             "mock-featuretoggle",
-            )
+        )
         .properties(properties)
         .run(*args)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -1,11 +1,9 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
 
-import io.getunleash.strategy.Strategy
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
-import no.nav.familie.unleash.DefaultUnleashService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -14,11 +12,6 @@ import org.springframework.context.annotation.Profile
 @Profile("mock-featuretoggle")
 @Configuration
 class FeatureToggleMock {
-
-    @Bean
-    fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
-        return mockk()
-    }
 
     @Bean
     @Primary

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -1,18 +1,25 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
 
+import io.getunleash.strategy.Strategy
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.unleash.DefaultUnleashService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
 
+@Profile("mock-featuretoggle")
 @Configuration
 class FeatureToggleMock {
 
-    @Profile("mock-featuretoggle")
+    @Bean
+    fun defaultUnleashService(strategies: List<Strategy>): DefaultUnleashService {
+        return mockk()
+    }
+
     @Bean
     @Primary
     fun featureToggleService(): FeatureToggleService {

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -7,12 +7,8 @@ no.nav.security.jwt:
     accepted_audience: aud-localhost
     cookie_name: localhost-idtoken
 
-funksjonsbrytere:
+unleash:
   enabled: false
-  unleash:
-    uri: http://localhost:4242/api
-    environment: local
-    applicationName: familie-ef-sak
 
 FAMILIE_INTEGRASJONER_URL: http://localhost:8385
 FAMILIE_BREV_API_URL: http://localhost:8001

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -37,12 +37,8 @@ rolle:
   kode7: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
 
-funksjonsbrytere:
+unleash:
   enabled: false
-  unleash:
-    uri: http://localhost:4242/api
-    environment: local
-    applicationName: familie-ef-sak
 
 UNLEASH_SERVER_API_URL: http://localhost:4242/api
 UNLEASH_SERVER_API_TOKEN: token


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Trenger å rette på konfigurasjon ifm mocking av Unleash Next. Legger til en negering av profile i faktisk FeatureToggleConfig. Bedre forslag til hvordan vi kan bønne opp kun defaultUnleashService i FeatureToggleMock ? 

Update : Å bønne opp UnleashService i FeatureToggleConfig blir jo feil, siden dette skal gjøres i felles. Det er jo litt av poenget. Fjerner derfor det meste av configen, utenom strategies. 