### PR TITLE
Grupperer dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     open-pull-requests-limit: 10
     registries:
       - familie-felles
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: org.jetbrains.kotlinx:kotlinx-coroutines-core
         versions:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Samler alle oppdateringer av avhengigheter i en PR