### PR TITLE
Skal ikke redigere behandling uten ansvarlig saksbehandler

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -218,7 +218,7 @@ class BehandlingPåVentService(
         brukerfeilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke sette behandling med status ${behandling.status} på vent"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandling.id)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandling.id)) {
             "Behandlingen har en ny eier og kan derfor ikke settes på vent av deg"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -268,7 +268,7 @@ class BehandlingService(
                 HttpStatus.BAD_REQUEST,
             )
         }
-        if (!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandling.id)) {
+        if (!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandling.id)) {
             throw ApiFeil(
                 "Behandlingen har en annen eier og kan derfor ikke henlegges av deg",
                 HttpStatus.BAD_REQUEST,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
@@ -64,7 +64,7 @@ class RevurderingService(
         brukerfeilHvis(behandlingService.hentBehandling(behandlingId).status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke slette revurderingsinformasjon når behandlingen er låst"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             "Behandlingen har en ny eier og du kan derfor ikke slette revurderingsinformasjon"
         }
         årsakRevurderingService.slettRevurderingsinformasjon(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingService.kt
@@ -64,7 +64,7 @@ class ÅrsakRevurderingService(
         feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst og kan ikke oppdatere revurderingsinformasjon"
         }
-        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull((saksbehandling.id))) {
+        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler((saksbehandling.id))) {
             "Behandlingen har en ny eier og du kan derfor ikke oppdatere revurderingsinformasjon"
         }
         årsakRevurderingsRepository.deleteById(saksbehandling.id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
@@ -85,7 +85,7 @@ class SendTilBeslutterSteg(
     }
 
     private fun validerAtSaksbehandlerErAnsvarligForBehandling(saksbehandling: Saksbehandling) {
-        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(saksbehandling.id)) {
+        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(saksbehandling.id)) {
             "Behandlingen har en ny eier og kan derfor ikke sendes til totrinnskontroll av deg"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingSteg.kt
@@ -46,7 +46,7 @@ class ÅrsakRevurderingSteg(
         brukerfeilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst og kan ikke oppdatere årsak til revurdering"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(saksbehandling.id)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(saksbehandling.id)) {
             "Behandlingen har en ny eier og du kan derfor ikke oppdatere årsak til revurdering"
         }
         brukerfeilHvisIkke(årsakRevurdering.årsak.erGyldigForStønadstype(saksbehandling.stønadstype)) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereService.kt
@@ -111,7 +111,7 @@ class BrevmottakereService(
     }
 
     private fun validerAtSaksbehandlerEierbehandling(behandlingId: UUID) {
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             "Behandlingen eies av noen andre og brevmottakere kan derfor ikke endres av deg"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevService.kt
@@ -188,7 +188,7 @@ class VedtaksbrevService(
                 httpStatus = HttpStatus.BAD_REQUEST,
             )
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(saksbehandling.id)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(saksbehandling.id)) {
             "Behandlingen har en ny eier"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
@@ -31,7 +31,7 @@ class TilordnetRessursService(
 
         return when (rolle) {
             SaksbehandlerRolle.INNLOGGET_SAKSBEHANDLER, SaksbehandlerRolle.OPPGAVE_FINNES_IKKE -> true
-            SaksbehandlerRolle.ANNEN_SAKSBEHANDLER, SaksbehandlerRolle.UTVIKLER_MED_VEILDERROLLE, SaksbehandlerRolle.IKKE_SATT  -> false
+            SaksbehandlerRolle.ANNEN_SAKSBEHANDLER, SaksbehandlerRolle.UTVIKLER_MED_VEILDERROLLE, SaksbehandlerRolle.IKKE_SATT -> false
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
@@ -18,13 +18,20 @@ class TilordnetRessursService(
     private val featureToggleService: FeatureToggleService,
 ) {
 
-    fun tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId: UUID): Boolean {
+    /**
+     * [SaksbehandlerRolle.OPPGAVE_FINNES_IKKE]: I de tilfellene hvor man manuelt oppretter en revurdering
+     * fra fagsakoversikten vil man øyeblikkelig bli redirectet inn i revurderingen. Da har ikke oppgavesystemet
+     * rukket å opprette en behandle-sak-oppgave enda. I disse tilfellene ønsker vi å sende med oppgave-finnes-ikke
+     * til frontend for å skjule visningen av ansvarlig saksbehandler frem til oppgavesystemet rekker å opprette
+     * behandle-sak-oppgaven. Man må kunne redigere frontend i dette tilfellet.
+     */
+    fun tilordnetRessursErInnloggetSaksbehandler(behandlingId: UUID): Boolean {
         val oppgave = if (erUtviklerMedVeilderrolle()) null else hentIkkeFerdigstiltOppgaveForBehandling(behandlingId)
         val rolle = utledSaksbehandlerRolle(oppgave)
 
         return when (rolle) {
-            SaksbehandlerRolle.IKKE_SATT, SaksbehandlerRolle.INNLOGGET_SAKSBEHANDLER, SaksbehandlerRolle.OPPGAVE_FINNES_IKKE -> true
-            SaksbehandlerRolle.ANNEN_SAKSBEHANDLER, SaksbehandlerRolle.UTVIKLER_MED_VEILDERROLLE -> false
+            SaksbehandlerRolle.INNLOGGET_SAKSBEHANDLER, SaksbehandlerRolle.OPPGAVE_FINNES_IKKE -> true
+            SaksbehandlerRolle.ANNEN_SAKSBEHANDLER, SaksbehandlerRolle.UTVIKLER_MED_VEILDERROLLE, SaksbehandlerRolle.IKKE_SATT  -> false
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
@@ -58,7 +58,7 @@ class GrunnlagsdataService(
         brukerfeilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke laste inn nye grunnlagsdata for behandling med status ${behandling.status}"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             "Behandlingen har en ny eier og du kan derfor ikke laste inn nye grunnlagsdata"
         }
         slettGrunnlagsdataHvisFinnes(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -38,7 +38,7 @@ class SimuleringService(
     fun simuler(saksbehandling: Saksbehandling): Simuleringsoppsummering {
         if (saksbehandling.status.behandlingErLåstForVidereRedigering() ||
             !tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER) ||
-            !tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(saksbehandling.id)
+            !tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(saksbehandling.id)
         ) {
             return hentLagretSimuleringsoppsummering(saksbehandling.id)
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
@@ -68,7 +68,7 @@ class TilbakekrevingService(
         brukerfeilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst for redigering"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandling.id)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandling.id)) {
             "Behandlingen har en ny eier og er derfor låst for redigering av deg"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakService.kt
@@ -36,7 +36,7 @@ class NullstillVedtakService(
         feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandling er låst og vedtak kan ikke slettes"
         }
-        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             "Behandlingen har en annen eier og vedtak kan derfor ikke slettes av deg"
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -148,7 +148,7 @@ class VedtakController(
         feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst og vedtaket kan derfor ikke lagres"
         }
-        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull((saksbehandling.id))) {
+        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler((saksbehandling.id))) {
             "Behandlingen har en annen eier og du kan derfor lagre vedtaket"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -60,6 +60,9 @@ class VedtakController(
     fun sendTilBeslutter(@PathVariable behandlingId: UUID, @RequestBody sendTilBeslutter: SendTilBeslutterDto?): Ressurs<UUID> {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandling, AuditLoggerEvent.UPDATE)
+
+        validerTilordnetRessurs(behandlingId)
+
         val vedtakErUtenBeslutter = vedtakService.hentVedtak(behandlingId).utledVedtakErUtenBeslutter()
 
         return if (vedtakErUtenBeslutter.value) {
@@ -148,7 +151,11 @@ class VedtakController(
         feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst og vedtaket kan derfor ikke lagres"
         }
-        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler((saksbehandling.id))) {
+        validerTilordnetRessurs(saksbehandling.id)
+    }
+
+    private fun validerTilordnetRessurs(behandlingId: UUID) {
+        feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler((behandlingId))) {
             "Behandlingen har en annen eier og du kan derfor lagre vedtaket"
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -174,7 +174,7 @@ class VurderingService(
 
     private fun behandlingErLåstForVidereRedigeringForInnloggetSaksbehandler(behandlingId: UUID) =
         behandlingService.hentBehandling(behandlingId).status.behandlingErLåstForVidereRedigering() ||
-            !tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)
+            !tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)
 
     private fun finnEndringerIGrunnlagsdata(behandlingId: UUID): List<GrunnlagsdataEndring> {
         val oppdaterteGrunnlagsdata = grunnlagsdataService.hentFraRegister(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
@@ -173,7 +173,7 @@ class VurderingStegService(
         if (behandlingErLåstForVidereRedigering(behandlingId)) {
             throw ApiFeil("Behandlingen er låst for videre redigering", HttpStatus.BAD_REQUEST)
         }
-        if (!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        if (!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             throw ApiFeil("Behandlingen eies av en annen saksbehandler", HttpStatus.BAD_REQUEST)
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -143,7 +143,7 @@ class GjenbrukVilkårService(
         brukerfeilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Behandlingen er låst og vilkår kan ikke oppdateres på behandling med id=$behandlingId"
         }
-        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(behandlingId)) {
+        brukerfeilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(behandlingId)) {
             "Behandling med id=$behandlingId eies av noen andre og vilkår kan derfor ikke oppdateres av deg"
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceTest.kt
@@ -93,7 +93,7 @@ internal class BehandlingPåVentServiceTest {
                 ),
             )
         }
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @AfterEach

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
@@ -47,7 +47,7 @@ internal class ÅrsakRevurderingServiceTest {
 
         justRun { årsakRevurderingsRepository.deleteById(any()) }
         every { årsakRevurderingsRepository.insert(capture(årsakRevurderingSlot)) } answers { firstArg() }
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
@@ -169,7 +169,7 @@ internal class SendTilBeslutterStegTest {
         every { behandlingshistorikkService.finnSisteBehandlingshistorikk(any(), any()) } returns
             Behandlingshistorikk(behandlingId = UUID.randomUUID(), steg = StegType.SEND_TIL_BESLUTTER)
         mockBrukerContext(saksbehandlerNavn)
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @AfterEach

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingStegTest.kt
@@ -35,7 +35,7 @@ internal class ÅrsakRevurderingStegTest {
     @BeforeEach
     internal fun setUp() {
         justRun { årsakRevurderingService.oppdaterRevurderingsinformasjon(any(), any(), any()) }
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     private val gyldigRevurderingsinformasjon = revurderingsinformasjon()

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
@@ -26,7 +26,7 @@ internal class BrevmottakereServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @Test
@@ -89,7 +89,7 @@ internal class BrevmottakereServiceTest {
     @Test
     fun `skal feile hvis saksbehandler ikke eier behandling`() {
         every { brevmottakereRepository.findByIdOrNull(behandling.id) } returns mockk()
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns false
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns false
 
         val brevmottakereDto = BrevmottakereDto(
             personer = listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/SettPåVentStepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/SettPåVentStepDefinitions.kt
@@ -146,7 +146,7 @@ class SettPåVentStepDefinitions {
         every { oppgaveService.oppdaterOppgave(capture(oppgaveSlot)) } just Runs
         every { taskService.save(capture(taskSlot)) } answers { firstArg() }
         every { oppgaveService.finnMapper("4489") } returns mapper
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
 
         påVentService.settPåVent(behandling.id, settOppgavePåVentRequest)
         unmockkObject(SikkerhetContext)

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
@@ -81,7 +81,7 @@ internal class SimuleringServiceTest {
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
         every { simuleringsresultatRepository.deleteById(any()) } just Runs
         every { simuleringsresultatRepository.insert(any()) } returns simuleringsresultat
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
 
         val simulerSlot = slot<SimuleringDto>()
         every {
@@ -142,7 +142,7 @@ internal class SimuleringServiceTest {
         every { behandlingService.hentBehandling(any()) } returns behandling
         every { tilkjentYtelseService.hentForBehandling(any()) } returns tilkjentYtelse
         every { simuleringsresultatRepository.deleteById(any()) } just Runs
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
 
         val simulerSlot = slot<Simuleringsresultat>()
         every { simuleringsresultatRepository.insert(capture(simulerSlot)) } answers { firstArg() }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
@@ -84,7 +84,7 @@ internal class TilordnetRessursServiceTest {
     inner class UtledSaksbehandlerRolle {
 
         @Test
-        internal fun `skal returnere true dersom tilordnet ressurs er null`() {
+        internal fun `skal returnere false dersom tilordnet ressurs er null`() {
             every {
                 oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
                     any(),
@@ -94,9 +94,9 @@ internal class TilordnetRessursServiceTest {
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()).copy(tilordnetRessurs = null) }
 
             val erSaksbehandlerEllerNull =
-                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(UUID.randomUUID())
+                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(UUID.randomUUID())
 
-            assertThat(erSaksbehandlerEllerNull).isTrue()
+            assertThat(erSaksbehandlerEllerNull).isFalse()
         }
 
         @Test
@@ -109,7 +109,7 @@ internal class TilordnetRessursServiceTest {
             } answers { null }
 
             val erSaksbehandlerEllerNull =
-                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(UUID.randomUUID())
+                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(UUID.randomUUID())
 
             assertThat(erSaksbehandlerEllerNull).isTrue()
         }
@@ -125,7 +125,7 @@ internal class TilordnetRessursServiceTest {
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()).copy(tilordnetRessurs = "NAV1234") }
 
             val erSaksbehandlerEllerNull =
-                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(UUID.randomUUID())
+                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(UUID.randomUUID())
 
             assertThat(erSaksbehandlerEllerNull).isTrue()
         }
@@ -141,7 +141,7 @@ internal class TilordnetRessursServiceTest {
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()).copy(tilordnetRessurs = "NAV2345") }
 
             val erSaksbehandlerEllerNull =
-                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(UUID.randomUUID())
+                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(UUID.randomUUID())
 
             assertThat(erSaksbehandlerEllerNull).isFalse()
         }
@@ -159,7 +159,7 @@ internal class TilordnetRessursServiceTest {
             every { featureToggleService.isEnabled(any()) } returns true
 
             val erSaksbehandlerEllerNull =
-                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(UUID.randomUUID())
+                tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(UUID.randomUUID())
 
             assertThat(erSaksbehandlerEllerNull).isFalse()
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/BehandlingServiceTest.kt
@@ -80,7 +80,7 @@ internal class BehandlingServiceTest {
     @BeforeEach
     fun reset() {
         clearAllMocks(answers = false)
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @Test
@@ -204,7 +204,7 @@ internal class BehandlingServiceTest {
         val behandling =
             behandling(fagsak(), type = BehandlingType.FØRSTEGANGSBEHANDLING, status = BehandlingStatus.UTREDES)
 
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns false
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns false
 
         every {
             behandlingRepository.findByIdOrThrow(any())

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/VedtaksbrevServiceTest.kt
@@ -276,7 +276,7 @@ internal class VedtaksbrevServiceTest {
         every { vedtaksbrevRepository.existsById(any()) } returns false
         every { vedtaksbrevRepository.insert(capture(vedtaksbrevSlot)) } returns vedtaksbrev
         every { familieDokumentClient.genererPdfFraHtml(any()) } returns "123".toByteArray()
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
 
         vedtaksbrevService.lagSaksbehandlerSanitybrev(
             saksbehandling(fagsak, behandling),
@@ -294,7 +294,7 @@ internal class VedtaksbrevServiceTest {
         every { vedtaksbrevRepository.update(capture(vedtaksbrevSlot)) } answers { firstArg() }
         every { brevClient.genererHtml(any(), any(), any(), any(), any()) } returns "html"
         every { familieDokumentClient.genererPdfFraHtml(any()) } returns "123".toByteArray()
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
 
         val now = SporbarUtils.now()
         vedtaksbrevService.lagSaksbehandlerSanitybrev(

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingServiceTest.kt
@@ -66,7 +66,7 @@ internal class TilbakekrevingServiceTest {
     fun setUp() {
         mockkObject(SikkerhetContext)
         every { SikkerhetContext.hentSaksbehandler() } returns "bob"
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @AfterAll

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/NullstillVedtakServiceTest.kt
@@ -57,7 +57,7 @@ class NullstillVedtakServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -116,7 +116,7 @@ internal class VurderingServiceTest {
                 sivilstand = sivilstand,
                 barnMedSamvær = barnMedSamvær,
             )
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     private fun lagBarnetilsynBarn(barnId: UUID = UUID.randomUUID()) = BarnMedSamværDto(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -132,7 +132,7 @@ internal class VurderingStegServiceTest {
                 ),
             )
         every { vilkårsvurderingRepository.insertAll(any()) } answers { firstArg() }
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
         val sivilstand = SivilstandInngangsvilkårDto(
             mockk(relaxed = true),
             SivilstandRegistergrunnlagDto(Sivilstandstype.GIFT, "1", "Navn", null),

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårServiceTest.kt
@@ -118,7 +118,7 @@ internal class GjenbrukVilkårServiceTest {
         )
 
         every { vilkårsvurderingRepository.updateAll(capture(vilkårsvurderingerSlot)) } answers { firstArg() }
-        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandlerEllerNull(any()) } returns true
+        every { tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler(any()) } returns true
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dersom ansvarlig saksbehandler ikke er satt skal man ikke kunne gjøre endringer på behandlingen.
Dette løser punkt 4 i [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15887)

De interessante endringene i denne PRen ligger i `TilordnetRessursService` og `VedtakController`.
Disse gjør slik at man ikke kan gjøre endringer dersom behandlingen ikke har en ansvarlig behandler, og at det gjøres en sjekk på dette når man prøver å godkjenne eller avslå vedtaket, henholdsvis.

Frontend PR:
* https://github.com/navikt/familie-ef-sak-frontend/pull/2582