### PR TITLE
skal ikke kunne godkjenne eller underkjenne vedtak dersom du ikke er …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -86,6 +86,7 @@ class VedtakController(
     ): Ressurs<UUID> {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandling, AuditLoggerEvent.UPDATE)
+        validerTilordnetRessurs(behandlingId)
         if (!request.godkjent && request.begrunnelse.isNullOrBlank()) {
             throw ApiFeil("Mangler begrunnelse", HttpStatus.BAD_REQUEST)
         }
@@ -156,7 +157,7 @@ class VedtakController(
 
     private fun validerTilordnetRessurs(behandlingId: UUID) {
         feilHvis(!tilordnetRessursService.tilordnetRessursErInnloggetSaksbehandler((behandlingId))) {
-            "Behandlingen har en annen eier og du kan derfor lagre vedtaket"
+            "Behandlingen har en annen eier og du kan derfor ikke lagre vedtaket"
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
@@ -41,6 +41,7 @@ class OppgaveClientMock {
                 oppgave5,
                 oppgave6,
                 oppgave7,
+                oppgave8,
                 tilbakekreving1,
                 oppgavePapirsøknad,
                 oppgaveEttersending,
@@ -191,6 +192,8 @@ class OppgaveClientMock {
         lagOppgave(24683L, Oppgavetype.BehandleSak, tilordnetRessurs = null, behandlesAvApplikasjon = "familie-ef-sak")
     private val oppgave7 =
         lagOppgave(24684L, Oppgavetype.BehandleSak, tilordnetRessurs = "julenissen", behandlesAvApplikasjon = "familie-ef-sak")
+    private val oppgave8 =
+        lagOppgave(24685L, Oppgavetype.BehandleSak, tilordnetRessurs = "BESLUTTER_2", behandlesAvApplikasjon = "familie-ef-sak")
     private val oppgavePapirsøknad =
         lagOppgave(
             5L,


### PR DESCRIPTION
…ansvarlig saksbehandler for behandleSak oppgaven

### Hvorfor er denne endringen nødvendig? ✨
Denne sjekken skulle vært inkludert i en tidligere PR. Man skal ikke kunne underkjenne eller godkjenne et vedtak dersom man ikke er ansvarlig saksbehandler for tilhørende behandle-sak-oppgave.