### PR TITLE
Returner inntekt tre måneder tilbake for personhendelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -163,10 +163,10 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '2 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '3 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
         """,
     )
-    fun finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
+    fun finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
 
     // language=PostgreSQL
     @Query(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -218,6 +218,7 @@ class VedtakController(
                     it.personIdent,
                     it.forventetInntektForMåned.forventetInntektForrigeMåned,
                     it.forventetInntektForMåned.forventetInntektToMånederTilbake,
+                    it.forventetInntektForMåned.forventetInntektTreMånederTilbake,
                 )
             },
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -180,10 +180,10 @@ class VedtakController(
         return Ressurs.success(forventetInntekt)
     }
 
-    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteToMaaneder")
+    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteTreMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(): Ressurs<List<String>> {
-        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder())
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteTreMåneder(): Ressurs<List<String>> {
+        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder())
     }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
@@ -81,7 +81,7 @@ class VedtakService(
             if (vedtak.erVedtakAktivtForDato(LocalDate.now())) {
                 createForventetInntektForBehandling(vedtak)
             } else {
-                ForventetInntektForBehandling(vedtak.behandlingId, null, null)
+                ForventetInntektForBehandling(vedtak.behandlingId, null, null, null)
             }
         }.associateBy { it.behandlingId }
     }
@@ -91,6 +91,7 @@ class VedtakService(
             vedtak.behandlingId,
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(1)),
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(2)),
+            createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(3)),
         )
     }
 
@@ -115,12 +116,14 @@ data class ForventetInntektForBehandling(
     val behandlingId: UUID,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
+    val forventetInntektTreMånederTilbake: Int?,
 )
 
 data class ForventetInntektForPersonIdent(
     val personIdent: String,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
+    val forventetInntektTreMånederTilbake: Int?,
 )
 
 fun Vedtak.erVedtakAktivtForDato(dato: LocalDate) = this.perioder?.perioder?.any {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -68,7 +68,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val person3 = fagsakPerson(identer = setOf(PersonIdent("3")))
         fagsakPersonRepository.insert(person3)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val person4 = fagsakPerson(identer = setOf(PersonIdent("4")))
         fagsakPersonRepository.insert(person4)

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -74,7 +74,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         fagsakPersonRepository.insert(person4)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
-        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder()
+        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder()
         assertThat(resultat.size).isEqualTo(3)
         assertThat(resultat).containsAll(listOf("1", "2", "3"))
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig for saksbehandlere å se på inntektsuttrekk som går over 3 mnd. Det er personhendelse som bruker dette endepunktet: https://github.com/navikt/familie-ef-personhendelse/pull/441

Det er ikke lagd favro-oppgave på dette.