### PR TITLE
Reverter forrige endring fordi det skal kjøres nytt inntektsuttrekk på 2 måneder med beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -163,10 +163,10 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '2 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '3 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
         """,
     )
-    fun finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
+    fun finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
 
     // language=PostgreSQL
     @Query(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -180,10 +180,10 @@ class VedtakController(
         return Ressurs.success(forventetInntekt)
     }
 
-    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteToMaaneder")
+    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteTreMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(): Ressurs<List<String>> {
-        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder())
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteTreMåneder(): Ressurs<List<String>> {
+        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder())
     }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")
@@ -218,6 +218,7 @@ class VedtakController(
                     it.personIdent,
                     it.forventetInntektForMåned.forventetInntektForrigeMåned,
                     it.forventetInntektForMåned.forventetInntektToMånederTilbake,
+                    it.forventetInntektForMåned.forventetInntektTreMånederTilbake,
                 )
             },
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
@@ -81,7 +81,7 @@ class VedtakService(
             if (vedtak.erVedtakAktivtForDato(LocalDate.now())) {
                 createForventetInntektForBehandling(vedtak)
             } else {
-                ForventetInntektForBehandling(vedtak.behandlingId, null, null)
+                ForventetInntektForBehandling(vedtak.behandlingId, null, null, null)
             }
         }.associateBy { it.behandlingId }
     }
@@ -91,6 +91,7 @@ class VedtakService(
             vedtak.behandlingId,
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(1)),
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(2)),
+            createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(3)),
         )
     }
 
@@ -115,12 +116,14 @@ data class ForventetInntektForBehandling(
     val behandlingId: UUID,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
+    val forventetInntektTreMånederTilbake: Int?,
 )
 
 data class ForventetInntektForPersonIdent(
     val personIdent: String,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
+    val forventetInntektTreMånederTilbake: Int?,
 )
 
 fun Vedtak.erVedtakAktivtForDato(dato: LocalDate) = this.perioder?.perioder?.any {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -68,13 +68,13 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val person3 = fagsakPerson(identer = setOf(PersonIdent("3")))
         fagsakPersonRepository.insert(person3)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val person4 = fagsakPerson(identer = setOf(PersonIdent("4")))
         fagsakPersonRepository.insert(person4)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
-        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder()
+        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder()
         assertThat(resultat.size).isEqualTo(3)
         assertThat(resultat).containsAll(listOf("1", "2", "3"))
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal kjøres en gang til med to måneder for å se differansen i beløp og ikke bare i prosent, ref PR: https://github.com/navikt/familie-ef-personhendelse/pull/442

Kunne gjort om antall måneder til en parameter, men pga tidspress til møtet i morgen så gjør jeg heller bare en revert. Skal gjøre om til en parameter så fort det er tid til det.