### PR TITLE
Reverter forrige endring fordi det skal kjøres nytt inntektsuttrekk på 2 måneder med beløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -163,10 +163,10 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '3 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '2 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
         """,
     )
-    fun finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
+    fun finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
 
     // language=PostgreSQL
     @Query(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -180,10 +180,10 @@ class VedtakController(
         return Ressurs.success(forventetInntekt)
     }
 
-    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteTreMaaneder")
+    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteToMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteTreMåneder(): Ressurs<List<String>> {
-        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder())
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(): Ressurs<List<String>> {
+        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder())
     }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")
@@ -218,7 +218,6 @@ class VedtakController(
                     it.personIdent,
                     it.forventetInntektForMåned.forventetInntektForrigeMåned,
                     it.forventetInntektForMåned.forventetInntektToMånederTilbake,
-                    it.forventetInntektForMåned.forventetInntektTreMånederTilbake,
                 )
             },
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
@@ -81,7 +81,7 @@ class VedtakService(
             if (vedtak.erVedtakAktivtForDato(LocalDate.now())) {
                 createForventetInntektForBehandling(vedtak)
             } else {
-                ForventetInntektForBehandling(vedtak.behandlingId, null, null, null)
+                ForventetInntektForBehandling(vedtak.behandlingId, null, null)
             }
         }.associateBy { it.behandlingId }
     }
@@ -91,7 +91,6 @@ class VedtakService(
             vedtak.behandlingId,
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(1)),
             createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(2)),
-            createForventetInntektForMåned(vedtak, YearMonth.now().minusMonths(3)),
         )
     }
 
@@ -116,14 +115,12 @@ data class ForventetInntektForBehandling(
     val behandlingId: UUID,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
-    val forventetInntektTreMånederTilbake: Int?,
 )
 
 data class ForventetInntektForPersonIdent(
     val personIdent: String,
     val forventetInntektForrigeMåned: Int?,
     val forventetInntektToMånederTilbake: Int?,
-    val forventetInntektTreMånederTilbake: Int?,
 )
 
 fun Vedtak.erVedtakAktivtForDato(dato: LocalDate) = this.perioder?.perioder?.any {

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -74,7 +74,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         fagsakPersonRepository.insert(person4)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
-        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder()
+        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteToMåneder()
         assertThat(resultat.size).isEqualTo(3)
         assertThat(resultat).containsAll(listOf("1", "2", "3"))
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal gjøre et nytt uttrekk med to måneder bare og med beløp. Burde egentlig gjort antall måneder tilbake til en parameter, men har litt dårlig tid til å fikse det ordentlig til møtet i morgen, så gjør bare en revert enn sålenge. Fikser det så fort det blir tid.
Hører til denne: https://github.com/navikt/familie-ef-personhendelse/pull/442