### PR TITLE
Papirsøknad + Terminbarn på manuelle revurderinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingsController.kt
@@ -47,7 +47,7 @@ class RevurderingsController(
             "Kan ikke behandle nye barn på revurdering med årsak G-omregning"
         }
 
-        feilHvis((revurderingInnhold.barnSomSkalFødes.isNotEmpty() || revurderingInnhold.behandlingsårsak == BehandlingÅrsak.PAPIRSØKNAD) && !featureToggleService.isEnabled(Toggle.PAPIRSOKNAD_OG_TERMINBARN_REVURDERING)){
+        feilHvis((revurderingInnhold.barnSomSkalFødes.isNotEmpty() || revurderingInnhold.behandlingsårsak == BehandlingÅrsak.PAPIRSØKNAD) && !featureToggleService.isEnabled(Toggle.PAPIRSOKNAD_OG_TERMINBARN_REVURDERING)) {
             "Featuretoggle for papirsøknad / terminbarn på revurdering er ikke skrudd på"
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingsController.kt
@@ -5,6 +5,8 @@ import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.behandling.dto.RevurderingsinformasjonDto
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -25,6 +27,7 @@ import java.util.UUID
 class RevurderingsController(
     private val revurderingService: RevurderingService,
     private val tilgangService: TilgangService,
+    private val featureToggleService: FeatureToggleService,
 ) {
 
     @PostMapping("{fagsakId}")
@@ -32,7 +35,7 @@ class RevurderingsController(
         tilgangService.validerTilgangTilFagsak(revurderingInnhold.fagsakId, AuditLoggerEvent.CREATE)
         tilgangService.validerHarSaksbehandlerrolle()
         brukerfeilHvis(revurderingInnhold.behandlingsårsak == BehandlingÅrsak.SØKNAD) {
-            "Systemet har ikke støtte for å revurdere med årsak “Søknad” for øyeblikket. " +
+            "Systemet har ikke støtte for å revurdere med årsak “Søknad”. " +
                 "Vurder om behandlingen skal opprettes via en oppgave i oppgavebenken, " +
                 "eller med revurderingsårsak \"Nye opplysninger\". " +
                 "Hvis du trenger å \"flytte\" en søknad som er journalført mot infotrygd, kontakt superbrukere for flytting av journalpost"
@@ -43,6 +46,11 @@ class RevurderingsController(
         ) {
             "Kan ikke behandle nye barn på revurdering med årsak G-omregning"
         }
+
+        feilHvis((revurderingInnhold.barnSomSkalFødes.isNotEmpty() || revurderingInnhold.behandlingsårsak == BehandlingÅrsak.PAPIRSØKNAD) && !featureToggleService.isEnabled(Toggle.PAPIRSOKNAD_OG_TERMINBARN_REVURDERING)){
+            "Featuretoggle for papirsøknad / terminbarn på revurdering er ikke skrudd på"
+        }
+
         val revurdering = revurderingService.opprettRevurderingManuelt(revurderingInnhold)
         return Ressurs.success(revurdering.id)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/RevurderingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/RevurderingDto.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.behandling.dto
 
+import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import java.time.LocalDate
@@ -10,4 +11,5 @@ data class RevurderingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn,
+    val barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -24,6 +24,7 @@ class FeatureToggleController(
         Toggle.FRONTEND_VIS_INNTEKT_PERSONOVERSIKT,
         Toggle.VIS_KA_VEDTAK_ALTERNATIV,
         Toggle.VIS_NY_JOURNALFØRING,
+        Toggle.PAPIRSOKNAD_OG_TERMINBARN_REVURDERING,
     )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -25,7 +25,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     GJENBRUK_VILKÅR_PÅ_TVERS_AV_BEHANDLINGER("familie.ef.sak.gjenbruk-vilkaar-paa-tvers-av-behandlinger", "Må testes i preprod"),
     VIS_KA_VEDTAK_ALTERNATIV("familie.ef.sak.frontend.vis-ka-uten-brev"),
     VIS_NY_JOURNALFØRING("familie.ef.sak-ny-journalforing"),
-    PAPIRSOKNAD_OG_TERMINBARN_REVURDERING("familie.ef.sak-papirsoknad-og-terminbarn-paa-revurdering"),
+    PAPIRSOKNAD_OG_TERMINBARN_REVURDERING("familie.ef.sak.papirsoknad-og-terminbarn-paa-revurdering"),
 
     // Operational
     AUTOMATISK_MIGRERING("familie.ef.sak.automatisk-migrering", "Kan denne slettes?"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -25,6 +25,7 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     GJENBRUK_VILKÅR_PÅ_TVERS_AV_BEHANDLINGER("familie.ef.sak.gjenbruk-vilkaar-paa-tvers-av-behandlinger", "Må testes i preprod"),
     VIS_KA_VEDTAK_ALTERNATIV("familie.ef.sak.frontend.vis-ka-uten-brev"),
     VIS_NY_JOURNALFØRING("familie.ef.sak-ny-journalforing"),
+    PAPIRSOKNAD_OG_TERMINBARN_REVURDERING("familie.ef.sak-papirsoknad-og-terminbarn-paa-revurdering"),
 
     // Operational
     AUTOMATISK_MIGRERING("familie.ef.sak.automatisk-migrering", "Kan denne slettes?"),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal kunne ha papirsøknad og terminbarn på manuelle revurderinger.

Dersom noen har fått et barn siden sist, men journalføringen går skeis så skal det være mulig å etterregistrere dette barnet før det blir født og registrert i PDL.

Henger sammen med https://github.com/navikt/familie-ef-sak-frontend/pull/2602 og [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15806)