### PR TITLE
Skal ikke ta med brukere med åpen behandling i inntektsuttrekket

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -164,6 +164,12 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
         WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '3 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        EXCEPT
+        (SELECT pi.ident
+         FROM fagsak
+                  JOIN behandling ON fagsak.id = behandling.fagsak_id
+                  JOIN person_ident pi ON fagsak.fagsak_person_id = pi.fagsak_person_id
+         WHERE behandling.status <> 'FERDIGSTILT' AND fagsak.stonadstype=:stønadstype)
         """,
     )
     fun finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -76,7 +76,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val person5 = fagsakPerson(identer = setOf(PersonIdent("5")))
         fagsakPersonRepository.insert(person5)
-        val fagsak = testoppsettService.lagreFagsak(fagsak(person = person5)) //Personer med åpen behandling på seg skal ikke med
+        val fagsak = testoppsettService.lagreFagsak(fagsak(person = person5)) // Personer med åpen behandling på seg skal ikke med
         behandlingRepository.insert(behandling(fagsak, resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
         behandlingRepository.insert(behandling(fagsak, resultat = IKKE_SATT, årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = UTREDES))
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -57,7 +57,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     private val ident = "123"
 
     @Test
-    fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste to måneder`() {
+    fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste tre måneder`() {
         val person1 = fagsakPerson(identer = setOf(PersonIdent("1")))
         fagsakPersonRepository.insert(person1)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.G_OMREGNING, status = FERDIGSTILT))
@@ -73,6 +73,12 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         val person4 = fagsakPerson(identer = setOf(PersonIdent("4")))
         fagsakPersonRepository.insert(person4)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+
+        val person5 = fagsakPerson(identer = setOf(PersonIdent("5")))
+        fagsakPersonRepository.insert(person5)
+        val fagsak = testoppsettService.lagreFagsak(fagsak(person = person5)) //Personer med åpen behandling på seg skal ikke med
+        behandlingRepository.insert(behandling(fagsak, resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(fagsak, resultat = IKKE_SATT, årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = UTREDES))
 
         val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder()
         assertThat(resultat.size).isEqualTo(3)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Inntekt skal alltid sjekkes ved en revurdering, uavhengig av grunn til revurdering. Det er derfor ikke nødvendig å lage inntektsoppgaver på brukere med en åpen behandling på seg. 
Det er ikke laget favro-kort på dette, men er blitt enig med Lars og Mirja om dette etter stikkprøver på forrige uttrekk.