### PR TITLE
Send inn antall måneder som parameter for finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -163,10 +163,10 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - '3 month'::interval) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - make_interval(months := :antallMåneder)) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
         """,
     )
-    fun finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD): List<String>
+    fun finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(stønadstype: StønadType = StønadType.OVERGANGSSTØNAD, antallMåneder: Int = 3): List<String>
 
     // language=PostgreSQL
     @Query(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 import java.time.YearMonth
@@ -180,10 +181,10 @@ class VedtakController(
         return Ressurs.success(forventetInntekt)
     }
 
-    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteTreMaaneder")
+    @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(): Ressurs<List<String>> {
-        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder())
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(@RequestParam antallMaaneder: Int = 3): Ressurs<List<String>> {
+        return Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = antallMaaneder))
     }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -57,7 +57,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     private val ident = "123"
 
     @Test
-    fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste to måneder`() {
+    fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste måneder`() {
         val person1 = fagsakPerson(identer = setOf(PersonIdent("1")))
         fagsakPersonRepository.insert(person1)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.G_OMREGNING, status = FERDIGSTILT))
@@ -74,9 +74,13 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
         fagsakPersonRepository.insert(person4)
         behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
-        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteTreMåneder()
+        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 3)
         assertThat(resultat.size).isEqualTo(3)
         assertThat(resultat).containsAll(listOf("1", "2", "3"))
+
+        val resultatSiste2Mnd = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 4)
+        assertThat(resultatSiste2Mnd.size).isEqualTo(2)
+        assertThat(resultatSiste2Mnd).containsAll(listOf("1", "2"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -60,7 +60,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste måneder`() {
         val person1 = fagsakPerson(identer = setOf(PersonIdent("1")))
         fagsakPersonRepository.insert(person1)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3).plusHours(1), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val person2 = fagsakPerson(identer = setOf(PersonIdent("2")))
         fagsakPersonRepository.insert(person2)
@@ -68,7 +68,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val person3 = fagsakPerson(identer = setOf(PersonIdent("3")))
         fagsakPersonRepository.insert(person3)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person3)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(4).plusHours(1), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val person4 = fagsakPerson(identer = setOf(PersonIdent("4")))
         fagsakPersonRepository.insert(person4)

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -60,7 +60,7 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     fun `skal finne alle personer med aktiv stønad som ikke er manuelt revurdert siste måneder`() {
         val person1 = fagsakPerson(identer = setOf(PersonIdent("1")))
         fagsakPersonRepository.insert(person1)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.G_OMREGNING, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person1)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(3), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val person2 = fagsakPerson(identer = setOf(PersonIdent("2")))
         fagsakPersonRepository.insert(person2)
@@ -72,15 +72,15 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
 
         val person4 = fagsakPerson(identer = setOf(PersonIdent("4")))
         fagsakPersonRepository.insert(person4)
-        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now(), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
+        behandlingRepository.insert(behandling(testoppsettService.lagreFagsak(fagsak(person = person4)), resultat = INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(5), årsak = BehandlingÅrsak.NYE_OPPLYSNINGER, status = FERDIGSTILT))
 
         val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 3)
         assertThat(resultat.size).isEqualTo(3)
-        assertThat(resultat).containsAll(listOf("1", "2", "3"))
+        assertThat(resultat).containsAll(listOf("2", "3", "4"))
 
-        val resultatSiste2Mnd = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 4)
-        assertThat(resultatSiste2Mnd.size).isEqualTo(2)
-        assertThat(resultatSiste2Mnd).containsAll(listOf("1", "2"))
+        val resultatSiste4Mnd = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 4)
+        assertThat(resultatSiste4Mnd.size).isEqualTo(2)
+        assertThat(resultatSiste4Mnd).containsAll(listOf("2", "4"))
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er stadig behov for å endre hvor langt tilbake inntektsuttrekket skal gå. Parameteriserer antall måneder slik at det ikke er nødvendig å endre ef-sak hver gang det skal endres.