### PR TITLE
Oppgave for barn født i måneden etter oppgitt terminmåned

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20230905101454_06fa3d7</felles.version>
         <prosessering.version>2.20231005144526_f184554</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20231017092640_6499c6b</kontrakter.version>
+        <kontrakter.version>3.0_20231020124114_c84c4b4</kontrakter.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.14.0</cucumber.version>
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BarnController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BarnController.kt
@@ -32,7 +32,7 @@ class BarnController(
         if (!SikkerhetContext.erMaskinTilMaskinToken()) {
             tilgangService.validerTilgangTilPerson(personIdent.ident, AuditLoggerEvent.ACCESS)
         }
-        return Ressurs.success(nyeBarnService.finnNyeEllerTidligereFødteBarn(personIdent))
+        return Ressurs.success(nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(personIdent))
     }
 
     @GetMapping("fagsak/{fagsakId}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -59,7 +59,6 @@ class NyeBarnService(
             nyttBarnList.addAll(finnForTidligtFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
             nyttBarnList.addAll(finnForSentFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
         }
-        nyttBarnList.forEach { logger.info("Nytt barn : ${it.personIdent}") }
         return NyeBarnDto(nyttBarnList)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -59,7 +59,7 @@ class NyeBarnService(
             nyttBarnList.addAll(finnForTidligtFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
             nyttBarnList.addAll(finnForSentFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
         }
-
+        nyttBarnList.forEach { logger.info("Nytt barn : ${it.personIdent}") }
         return NyeBarnDto(nyttBarnList)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -57,6 +57,7 @@ class NyeBarnService(
                 },
             )
             nyttBarnList.addAll(finnForTidligtFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
+            nyttBarnList.addAll(finnForSentFødteBarn(barnSidenGjeldendeBehandling, fagsak.stønadstype))
         }
 
         return NyeBarnDto(nyttBarnList)
@@ -116,6 +117,15 @@ class NyeBarnService(
             }
     }
 
+    private fun finnForSentFødteBarn(kobledeBarn: NyeBarnData, stønadstype: StønadType): List<NyttBarn> {
+        return kobledeBarn.kobledeBarn
+            .filter { it.behandlingBarn.personIdent == null }
+            .filter { barnFødtEtterTermin(it) }
+            .map {
+                val barn = it.barn ?: error("Skal ha filtrert ut matchet barn uten barn")
+                NyttBarn(barn.personIdent, stønadstype, NyttBarnÅrsak.FØDT_ETTER_TERMIN)
+            }
+    }
     private fun barnFødtFørTermin(barn: MatchetBehandlingBarn): Boolean {
         val pdlBarn = barn.barn
         val behandlingBarn = barn.behandlingBarn
@@ -124,6 +134,16 @@ class NyeBarnService(
         }
         val fødselsdato = pdlBarn.fødsel.gjeldende().fødselsdato ?: return false
         return YearMonth.from(fødselsdato) < YearMonth.from(behandlingBarn.fødselTermindato)
+    }
+
+    private fun barnFødtEtterTermin(barn: MatchetBehandlingBarn): Boolean {
+        val pdlBarn = barn.barn
+        val behandlingBarn = barn.behandlingBarn
+        if (pdlBarn == null || behandlingBarn.fødselTermindato == null) {
+            return false
+        }
+        val fødselsdato = pdlBarn.fødsel.gjeldende().fødselsdato ?: return false
+        return YearMonth.from(fødselsdato).plusMonths(1) > YearMonth.from(behandlingBarn.fødselTermindato)
     }
 
     private data class NyeBarnData(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -40,7 +40,7 @@ class NyeBarnService(
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    fun finnNyeEllerTidligereFødteBarn(personIdent: PersonIdent): NyeBarnDto {
+    fun finnNyeEllerUtenforTerminFødteBarn(personIdent: PersonIdent): NyeBarnDto {
         val personIdenter = personService.hentPersonIdenter(personIdent.ident).identer()
         val nyttBarnList = mutableListOf<NyttBarn>()
         val fagsaker = fagsakService.finnFagsaker(personIdenter)
@@ -118,13 +118,14 @@ class NyeBarnService(
     }
 
     private fun finnForSentFødteBarn(kobledeBarn: NyeBarnData, stønadstype: StønadType): List<NyttBarn> {
-        return kobledeBarn.kobledeBarn
+        val forSentFødteBarn = kobledeBarn.kobledeBarn
             .filter { it.behandlingBarn.personIdent == null }
             .filter { barnFødtEtterTermin(it) }
             .map {
                 val barn = it.barn ?: error("Skal ha filtrert ut matchet barn uten barn")
                 NyttBarn(barn.personIdent, stønadstype, NyttBarnÅrsak.FØDT_ETTER_TERMIN)
             }
+        return forSentFødteBarn
     }
     private fun barnFødtFørTermin(barn: MatchetBehandlingBarn): Boolean {
         val pdlBarn = barn.barn
@@ -143,7 +144,7 @@ class NyeBarnService(
             return false
         }
         val fødselsdato = pdlBarn.fødsel.gjeldende().fødselsdato ?: return false
-        return YearMonth.from(fødselsdato).plusMonths(1) > YearMonth.from(behandlingBarn.fødselTermindato)
+        return YearMonth.from(fødselsdato).month > YearMonth.from(behandlingBarn.fødselTermindato).month
     }
 
     private data class NyeBarnData(

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceIntegrationTest.kt
@@ -39,8 +39,8 @@ class NyeBarnServiceIntegrationTest : OppslagSpringRunnerTest() {
             ),
         )
 
-        assertThat(nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
-        assertThat(nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
+        assertThat(nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
+        assertThat(nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
         assertThat(taskService.findAll().filter { it.type == OpprettOppgaveForMigrertFødtBarnTask.TYPE }).hasSize(1)
     }
 
@@ -55,7 +55,7 @@ class NyeBarnServiceIntegrationTest : OppslagSpringRunnerTest() {
             ),
         )
 
-        assertThat(nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
+        assertThat(nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent(ident)).nyeBarn).hasSize(2)
         assertThat(taskService.findAll().filter { it.type == OpprettOppgaveForMigrertFødtBarnTask.TYPE }).isEmpty()
     }
 
@@ -70,7 +70,7 @@ class NyeBarnServiceIntegrationTest : OppslagSpringRunnerTest() {
             ),
         )
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent(ident)).nyeBarn // PdlClient.hentBarn er mocket til å returnere 2 barn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent(ident)).nyeBarn // PdlClient.hentBarn er mocket til å returnere 2 barn
         assertThat(barn).hasSize(2)
         assertThat(barn.all { it.stønadstype == StønadType.BARNETILSYN }).isTrue
     }
@@ -83,7 +83,7 @@ class NyeBarnServiceIntegrationTest : OppslagSpringRunnerTest() {
     internal fun `finnNyeEllerTidligereFødteBarn skal ikke feile hvis det ikke finnes en behandling på fagsaken`() {
         testoppsettService.lagreFagsak(fagsak(identer = fagsakpersoner(setOf(ident)), migrert = true))
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent(ident)).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent(ident)).nyeBarn
 
         assertThat(barn).isEmpty()
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -238,7 +238,7 @@ class NyeBarnServiceTest {
             )
 
             val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
-            assertThat(barn).hasSize(0)
+            assertThat(barn).isEmpty()
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -203,9 +203,9 @@ class NyeBarnServiceTest {
         }
 
         @Test
-        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blir født i en senere måned`() {
-            val terminDato = LocalDate.of(2021, 1, 1)
-            val fødselsdato = LocalDate.of(2021, 1, 30)
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blir født for sent inn i neste måned`() {
+            val terminDato = LocalDate.of(2021, 1, 30)
+            val fødselsdato = terminDato.plusWeeks(3)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
             val pdlBarn = mapOf(
                 fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -183,7 +183,7 @@ class NyeBarnServiceTest {
     inner class FinnNyeEllerUtenforTerminFødteBarn {
 
         @Test
-        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blitt født i en tidligere måned`() {
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blir født i en tidligere måned`() {
             val terminDato = LocalDate.of(2021, 2, 1)
             val fødselsdato = terminDato.minusMonths(1)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -203,9 +203,9 @@ class NyeBarnServiceTest {
         }
 
         @Test
-        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blitt født i en senere måned`() {
-            val terminDato = LocalDate.of(2021, 1, 25)
-            val fødselsdato = terminDato.plusWeeks(3)
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blir født i en senere måned`() {
+            val terminDato = LocalDate.of(2021, 1, 1)
+            val fødselsdato = LocalDate.of(2021, 1, 30)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
             val pdlBarn = mapOf(
                 fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnServiceTest.kt
@@ -63,7 +63,7 @@ class NyeBarnServiceTest {
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med et nytt barn i PDL siden behandling, forvent ett nytt barn`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med et nytt barn i PDL siden behandling, forvent ett nytt barn`() {
         val pdlBarn = mapOf(
             fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
             fnrForNyttBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoNyttBarn)),
@@ -71,13 +71,13 @@ class NyeBarnServiceTest {
         every { personService.hentPersonMedBarn(any()) } returns søkerMedBarn(pdlBarn)
         every { barnService.finnBarnPåBehandling(any()) } returns listOf(behandlingBarn(fnrForEksisterendeBarn))
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(1)
         assertThat(barn.first()).isEqualTo(NyttBarn(fnrForNyttBarn, StønadType.OVERGANGSSTØNAD, NyttBarnÅrsak.BARN_FINNES_IKKE_PÅ_BEHANDLING))
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med ett født terminbarn i PDL, forvent ingen treff`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med ett født terminbarn i PDL, forvent ingen treff`() {
         val terminDato = YearMonth.now().atEndOfMonth()
         val fødselsdato = YearMonth.now().atDay(15)
         val fnrForPdlBarn = FnrGenerator.generer(fødselsdato)
@@ -91,12 +91,12 @@ class NyeBarnServiceTest {
             behandlingBarn(fødselTermindato = terminDato),
         )
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(0)
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med tvillinger i PDL av terminbarn med alle i behandlingen, forvent ingen nye barn`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med tvillinger i PDL av terminbarn med alle i behandlingen, forvent ingen nye barn`() {
         val terminDato = YearMonth.now().atEndOfMonth()
         val fødselsdato = YearMonth.now().atDay(15)
         val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -113,12 +113,12 @@ class NyeBarnServiceTest {
             behandlingBarn(fødselTermindato = terminDato),
         )
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(0)
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med tvillinger i PDL av terminbarn, men bare ett i behandlingen, forvent ett nytt barn`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med tvillinger i PDL av terminbarn, men bare ett i behandlingen, forvent ett nytt barn`() {
         val terminDato = YearMonth.now().atEndOfMonth()
         val fødselsdato = YearMonth.now().atDay(15)
         val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -134,23 +134,23 @@ class NyeBarnServiceTest {
             behandlingBarn(fødselTermindato = terminDato),
         )
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(1)
         assertThat(barn.single().årsak).isEqualTo(NyttBarnÅrsak.BARN_FINNES_IKKE_PÅ_BEHANDLING)
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med ett og samme barn i PDL siden behandling, forvent ingen treff`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med ett og samme barn i PDL siden behandling, forvent ingen treff`() {
         val pdlBarn = mapOf(fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)))
         every { personService.hentPersonMedBarn(any()) } returns søkerMedBarn(pdlBarn)
         every { barnService.finnBarnPåBehandling(any()) } returns listOf(behandlingBarn(fnrForEksisterendeBarn))
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(0)
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med ett ekstra voksent barn i PDL skal returnere det voksne barnet som nytt barn`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med ett ekstra voksent barn i PDL skal returnere det voksne barnet som nytt barn`() {
         val pdlBarn = mapOf(
             fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
             fnrForVoksentBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoVoksentBarn)),
@@ -158,13 +158,13 @@ class NyeBarnServiceTest {
         every { personService.hentPersonMedBarn(any()) } returns søkerMedBarn(pdlBarn)
         every { barnService.finnBarnPåBehandling(any()) } returns listOf(behandlingBarn(fnrForEksisterendeBarn))
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(1)
         assertThat(barn[0].personIdent).isEqualTo(fnrForVoksentBarn)
     }
 
     @Test
-    fun `finnNyeEllerTidligereFødteBarn med ett ekstra terminbarn i PDL, forvent ingen treff`() {
+    fun `finnNyeEllerUtenforTerminFødteBarn med ett ekstra terminbarn i PDL, forvent ingen treff`() {
         val pdlBarn = mapOf(
             fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
             fnrForNyttBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoNyttBarn)),
@@ -175,15 +175,15 @@ class NyeBarnServiceTest {
             behandlingBarn(fødselTermindato = fødselsdatoNyttBarn),
         )
 
-        val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+        val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
         assertThat(barn).hasSize(0)
     }
 
     @Nested
-    inner class FinnNyeEllerTidligereFødteBarn {
+    inner class FinnNyeEllerUtenforTerminFødteBarn {
 
         @Test
-        internal fun `finnNyeEllerTidligereFødteBarn - skal finne barn som blitt født i en tidligere måned`() {
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blitt født i en tidligere måned`() {
             val terminDato = LocalDate.of(2021, 2, 1)
             val fødselsdato = terminDato.minusMonths(1)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -197,13 +197,52 @@ class NyeBarnServiceTest {
                 behandlingBarn(fødselTermindato = terminDato),
             )
 
-            val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
             assertThat(barn).hasSize(1)
             assertThat(barn.map { it.årsak }).containsExactly(NyttBarnÅrsak.FØDT_FØR_TERMIN)
         }
 
         @Test
-        internal fun `finnNyeEllerTidligereFødteBarn - født i samme måned skal ikke returnere noe`() {
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal finne barn som blitt født i en senere måned`() {
+            val terminDato = LocalDate.of(2021, 1, 25)
+            val fødselsdato = terminDato.plusWeeks(3)
+            val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
+            val pdlBarn = mapOf(
+                fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
+                fnrForTerminbarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdato)),
+            )
+            every { personService.hentPersonMedBarn(any()) } returns søkerMedBarn(pdlBarn)
+            every { barnService.finnBarnPåBehandling(any()) } returns listOf(
+                behandlingBarn(fnrForEksisterendeBarn),
+                behandlingBarn(fødselTermindato = terminDato),
+            )
+
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            assertThat(barn).hasSize(1)
+            assertThat(barn.map { it.årsak }).containsExactly(NyttBarnÅrsak.FØDT_ETTER_TERMIN)
+        }
+
+        @Test
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - skal ikke finne barn som blitt født for sent innen samme måned`() {
+            val terminDato = LocalDate.of(2021, 1, 1)
+            val fødselsdato = terminDato.plusWeeks(3)
+            val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
+            val pdlBarn = mapOf(
+                fnrForEksisterendeBarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdatoEksisterendeBarn)),
+                fnrForTerminbarn to pdlBarn(fødsel = fødsel(fødselsdato = fødselsdato)),
+            )
+            every { personService.hentPersonMedBarn(any()) } returns søkerMedBarn(pdlBarn)
+            every { barnService.finnBarnPåBehandling(any()) } returns listOf(
+                behandlingBarn(fnrForEksisterendeBarn),
+                behandlingBarn(fødselTermindato = terminDato),
+            )
+
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            assertThat(barn).hasSize(0)
+        }
+
+        @Test
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - født i samme måned skal ikke returnere noe`() {
             val terminDato = LocalDate.of(2021, 3, 31)
             val fødselsdato = LocalDate.of(2021, 3, 1)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -217,12 +256,12 @@ class NyeBarnServiceTest {
                 behandlingBarn(fødselTermindato = terminDato),
             )
 
-            val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
             assertThat(barn).isEmpty()
         }
 
         @Test
-        internal fun `finnNyeEllerTidligereFødteBarn - født før termin, men har allerede personident i behandlingbarn - dvs allerede behandlet`() {
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - født før termin, men har allerede personident i behandlingbarn - dvs allerede behandlet`() {
             val terminDato = LocalDate.of(2021, 3, 1)
             val fødselsdato = terminDato.minusMonths(1)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -236,12 +275,12 @@ class NyeBarnServiceTest {
                 behandlingBarn(fødselTermindato = terminDato, fnr = fnrForTerminbarn),
             )
 
-            val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
             assertThat(barn).isEmpty()
         }
 
         @Test
-        internal fun `finnNyeEllerTidligereFødteBarn - ukjent barn`() {
+        internal fun `finnNyeEllerUtenforTerminFødteBarn - ukjent barn`() {
             val terminDato = LocalDate.of(2021, 3, 1)
             val fødselsdato = terminDato.minusMonths(1)
             val fnrForTerminbarn = FnrGenerator.generer(fødselsdato)
@@ -254,7 +293,7 @@ class NyeBarnServiceTest {
                 behandlingBarn(fnrForEksisterendeBarn),
             )
 
-            val barn = nyeBarnService.finnNyeEllerTidligereFødteBarn(PersonIdent("fnr til søker")).nyeBarn
+            val barn = nyeBarnService.finnNyeEllerUtenforTerminFødteBarn(PersonIdent("fnr til søker")).nyeBarn
             assertThat(barn).hasSize(1)
             assertThat(barn.map { it.årsak }).containsExactly(NyttBarnÅrsak.BARN_FINNES_IKKE_PÅ_BEHANDLING)
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er behov for å opprette en oppgave av typen "VurderLivshendelse" hvis et barn blir født i måneden etter oppgitt terminmåned. Utleder derfor barn som blir født i måneden etter som familie-ef-personhendelse mottar og oppretter oppgave av : https://github.com/navikt/familie-ef-personhendelse/pull/449

Testet / verifisert ok i preprod. 

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15812