### PR TITLE
Må ha snillere og bedre validering på journalføring med ny avsender -…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringHelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringHelper.kt
@@ -40,15 +40,15 @@ object JournalføringHelper {
     }
 
     fun validerGyldigAvsender(journalpost: Journalpost, request: JournalføringRequestV2) {
-        if (journalpost.avsenderMottaker == null) {
+        if (journalpost.manglerAvsenderMottaker()) {
             brukerfeilHvis(request.nyAvsender == null) {
                 "Kan ikke journalføre uten avsender"
             }
             brukerfeilHvis(!request.nyAvsender.erBruker && request.nyAvsender.navn.isNullOrBlank()) {
                 "Må sende inn navn på ny avsender"
             }
-            brukerfeilHvis(!request.nyAvsender.erBruker && request.nyAvsender.personIdent.isNullOrBlank()) {
-                "Må sende inn ident på ny avsender"
+            brukerfeilHvis(request.nyAvsender.erBruker && request.nyAvsender.personIdent.isNullOrBlank()) {
+                "Må sende inn ident på ny avsender hvis det er bruker"
             }
         } else {
             brukerfeilHvis(request.nyAvsender != null) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostUtil.kt
@@ -18,3 +18,4 @@ fun DokumentInfo.harOriginaldokument() = this.dokumentvarianter?.any { it.varian
     ?: false
 
 fun Journalpost.harUgyldigAvsenderMottaker(): Boolean = this.journalposttype != Journalposttype.N && this.avsenderMottaker?.navn.isNullOrBlank()
+fun Journalpost.manglerAvsenderMottaker(): Boolean = this.avsenderMottaker?.erLikBruker != true && this.avsenderMottaker?.navn.isNullOrBlank() || this.avsenderMottaker?.id.isNullOrBlank()

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -53,6 +53,7 @@ import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggReques
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostRequest
 import no.nav.familie.kontrakter.felles.dokarkiv.OppdaterJournalpostResponse
 import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.journalpost.AvsenderMottaker
 import no.nav.familie.kontrakter.felles.journalpost.DokumentInfo
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariant
 import no.nav.familie.kontrakter.felles.journalpost.Dokumentvariantformat
@@ -459,6 +460,24 @@ internal class JournalføringServiceTest {
                     BulkOppdaterLogiskVedleggRequest(titler = listOf("Samværserklæring")),
                 )
             }
+        }
+
+        @Test
+        internal fun `skal sette avsenderMottaker`() {
+            val ingenAvsenderMottaker = AvsenderMottaker(null, null, null, null, false)
+            val journalpostUtenAvsender = ustrukturertJournalpost.copy(avsenderMottaker = ingenAvsenderMottaker)
+            every { journalpostClient.hentJournalpost(journalpostId) } returns journalpostUtenAvsender
+            mockOpprettBehandling(behandlingId, UUID.randomUUID())
+            every { behandlingService.finnesBehandlingSomIkkeErFerdigstiltEllerSattPåVent(any()) } returns false
+            val request = lagRequestV2(
+                aksjon = Journalføringsaksjon.JOURNALFØR_PÅ_FAGSAK,
+                årsak = Journalføringsårsak.PAPIRSØKNAD,
+                nyAvsender = NyAvsender(false, "Fjasball", null),
+            )
+
+            journalføringService.fullførJournalpostV2(request, journalpostUtenAvsender)
+
+            assertThat(slotJournalpost.captured.avsenderMottaker).isNotNull
         }
     }
 


### PR DESCRIPTION
… journalposten kan inneholde null i avsenderMottaker, eller null på alle felter fra start. Når avsender er bruker forventer vi også at ident blir sendt inn - dersom avsender ikke er bruker så setter vi bare navnet i første omgang

### Hvorfor er denne endringen nødvendig? ✨