### PR TITLE
Nye satser for barnetilsyn i 2024

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/BeregningBarnetilsynUtil.kt
@@ -19,6 +19,10 @@ object BeregningBarnetilsynUtil {
     private val eldreBarnetilsynsatser: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
+                Datoperiode(YearMonth.of(2023, 7), YearMonth.of(2023, 12)),
+                maxbeløp = mapOf(1 to 4480, 2 to 5844, 3 to 6623),
+            ),
+            MaxbeløpBarnetilsynSats(
                 Datoperiode(YearMonth.of(2023, 1), YearMonth.of(2023, 6)),
                 maxbeløp = mapOf(1 to 4369, 2 to 5700, 3 to 6460),
             ),
@@ -48,8 +52,8 @@ object BeregningBarnetilsynUtil {
     val satserForBarnetilsyn: List<MaxbeløpBarnetilsynSats> =
         listOf(
             MaxbeløpBarnetilsynSats(
-                Datoperiode(LocalDate.of(2023, 7, 1), LocalDate.MAX),
-                maxbeløp = mapOf(1 to 4480, 2 to 5844, 3 to 6623),
+                Datoperiode(LocalDate.of(2024, 1, 1), LocalDate.MAX),
+                maxbeløp = mapOf(1 to 4650, 2 to 6066, 3 to 6875),
             ),
         ) + eldreBarnetilsynsatser
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -223,15 +223,15 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
                 listOf(
                     PeriodeMedBeløp(
                         Månedsperiode(
-                            YearMonth.of(2023, 9),
-                            YearMonth.of(2023, 10),
+                            YearMonth.of(2024, 9),
+                            YearMonth.of(2024, 10),
                         ),
                         1000,
                     ),
                 ),
             ),
-            fom = YearMonth.of(2022, 6),
-            tom = YearMonth.of(2023, 12),
+            fom = YearMonth.of(2023, 6),
+            tom = YearMonth.of(2024, 12),
         )
         ferdigstillVedtak(vedtak, behandling, fagsakBarnetilsyn)
 
@@ -243,7 +243,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         assertThat(barnetilsynPerioder?.size).isEqualTo(3) // 3 perioder: Før, under og etter kontantstøtte-periode
         assertThat(barnetilsynPerioder?.first()?.utgifter).isEqualTo(8000)
         assertThat(barnetilsynPerioder?.first()?.barn?.size).isEqualTo(2)
-        assertThat(barnetilsynPerioder?.first()?.periode?.fom).isEqualTo(YearMonth.of(2023, 7))
+        assertThat(barnetilsynPerioder?.first()?.periode?.fom).isEqualTo(YearMonth.of(2024, 1))
     }
 
     /**


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Nye satser for barnetilsyn. Denne PRen skal merges etter uttrekk av personer som skal revurderes pga satsendringene.

Ref rutine for satsendring: 
 https://github.com/navikt/familie-ef-sak/blob/master/doc/BarnetilsynSatsendring_README.md

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-16102