### PR TITLE
Datoperiode i utenlandsopphold brukes ikke av noen, men gjør at vi kr…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/MedlemskapMapper.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ef.sak.vilkår.dto.MedlemskapRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.MedlemskapSøknadsgrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.UtenlandsoppholdDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
-import no.nav.familie.kontrakter.felles.Datoperiode
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -47,7 +46,6 @@ class MedlemskapMapper(
                 UtenlandsoppholdDto(
                     fraDato = it.fradato,
                     tilDato = it.tildato,
-                    periode = Datoperiode(it.fradato, it.tildato),
                     land = it.land?.let { land -> kodeverkService.hentLand(land, LocalDate.now()) },
                     årsak = it.årsakUtenlandsopphold,
                 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/MedlemskapDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/MedlemskapDto.kt
@@ -5,7 +5,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpe
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.InnflyttingDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.OppholdstillatelseDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.UtflyttingDto
-import no.nav.familie.kontrakter.felles.Datoperiode
 import no.nav.familie.kontrakter.felles.medlemskap.Medlemskapsinfo
 import no.nav.familie.kontrakter.felles.medlemskap.PeriodeInfo
 import java.time.LocalDate
@@ -44,12 +43,8 @@ fun PeriodeInfo.tilDto(): MedlUnntaksperiodeDto =
     MedlUnntaksperiodeDto(this.fom, this.tom, this.gjelderMedlemskapIFolketrygden)
 
 data class UtenlandsoppholdDto(
-    @Deprecated("Bruk periode!", ReplaceWith("periode.fomDato")) val fraDato: LocalDate? = null,
-    @Deprecated("Bruk periode!", ReplaceWith("periode.tomDato")) val tilDato: LocalDate? = null,
-    val periode: Datoperiode = Datoperiode(
-        fraDato ?: error("Periode eller fraDato må ha verdi"),
-        tilDato ?: error("Periode eller tilDato må ha verdi"),
-    ),
+    val fraDato: LocalDate? = null,
+    val tilDato: LocalDate? = null,
     val land: String? = null,
     val årsak: String,
 )


### PR DESCRIPTION
…asje for en enkelt behandling hvor bruker har tastet inn større fradato enn tildato. 

### Hvorfor er denne endringen nødvendig? ✨

Tror vi bør vurdere å rydde litt i datoperiodebruken. Der det ikke benyttes noe sted - fjern de. Der vi bruker det - oppdatere frontend til å bruke de også. 

Ref: [PR fra 2022](https://github.com/navikt/familie-ef-sak/commit/e8cd4e1a6053c51e1a1fc43f98a50845e494dc1b)