### PR TITLE
Vil logge metadata for oppgave. Dette for å kunne feilsøke produksjon…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/LoggOppgaveMetadataTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/LoggOppgaveMetadataTask.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.ef.sak.oppgave
+
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.*
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = LoggOppgaveMetadataTask.TYPE,
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+    beskrivelse = "Finn og logg metadata for oppgave knyttet til behandling",
+)
+class LoggOppgaveMetadataTask(private val tilordnetRessursService: TilordnetRessursService) : AsyncTaskStep {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    override fun doTask(task: Task) {
+        logger.info("Henter oppgave for behandling ${task.payload}")
+        val oppgave = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(UUID.fromString(task.payload))
+        secureLogger.info("Oppgave hentet for behandling ${task.payload}: $oppgave")
+    }
+
+    companion object {
+
+        const val TYPE = "loggOppgaveMetadataTask"
+        fun opprettTask(behandlingId: UUID): Task {
+            return Task(
+                TYPE,
+                behandlingId.toString(),
+                Properties(),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveforvaltningsController.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.sak.oppgave
+
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/oppgave/forvaltning/")
+@ProtectedWithClaims(issuer = "azuread")
+class OppgaveforvaltningsController(
+    private val taskService: TaskService,
+    private val featureToggleService: FeatureToggleService,
+) {
+    @PostMapping("behandling/{behandlingId}")
+    fun loggOppgavemetadataFor(@PathVariable behandlingId: UUID) {
+        feilHvisIkke(erUtviklerMedVeilderrolle()) { "Kan kun kjøres av utvikler med veilederrolle" }
+        val task = LoggOppgaveMetadataTask.opprettTask(behandlingId)
+        taskService.save(task)
+    }
+
+    private fun erUtviklerMedVeilderrolle(): Boolean =
+        SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)
+}


### PR DESCRIPTION
…sfeil knyttet til behandling og oppgave.

### Hvorfor er denne endringen nødvendig? ✨

Vanskelig å debugge oppgave uten hjelp fra noen med tilgang til gosys/saksbehandler-tilgang. 
Mulig vi kan utvide denne til en "lag ny oppgave hvis oppgave mangler" task. 

Testet i preprod (tilgang/toggle)  