### PR TITLE
Vil fjerne falske positive warnings (på alle ferdigstilte behandlinger)

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -125,9 +125,6 @@ class OppgaveController(
             behandlingId,
             setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak, Oppgavetype.GodkjenneVedtak),
         )
-        when (oppgave) {
-            null -> logger.warn("Finner ikke oppgave for behandlingId=$behandlingId")
-        }
 
         return Ressurs.success(tilordnetRessursService.utledAnsvarligSaksbehandlerForOppgave(oppgave))
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi prøver å hente oppgave for ferdigstilte behandlinger - da finner vi ingen oppgave. Dette er kanskje unødvendig, men ikke "feil". Fjerner warning logging.