### PR TITLE
Feiler når vi journalfører med bruker som avsender dersom brukerIdTyp…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringHelper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringHelper.kt
@@ -60,7 +60,7 @@ object JournalføringHelper {
     fun utledNyAvsender(nyAvsender: NyAvsender?, bruker: Bruker?): AvsenderMottaker? =
         when (nyAvsender?.erBruker) {
             null -> null
-            true -> AvsenderMottaker(id = nyAvsender.personIdent, idType = bruker?.type!!, navn = nyAvsender.navn!!)
+            true -> AvsenderMottaker(id = nyAvsender.personIdent, idType = BrukerIdType.FNR, navn = nyAvsender.navn!!)
             false -> AvsenderMottaker(id = null, idType = null, navn = nyAvsender.navn!!)
         }
 


### PR DESCRIPTION
…e er satt som aktørId. Vi setter alltid fnr som ident og må derfor sette dette som type

### Hvorfor er denne endringen nødvendig? ✨