### PR TITLE
Vil legge til en forvaltningskontroller for konsistensavstemming som o…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
@@ -1,0 +1,49 @@
+package no.nav.familie.ef.sak.forvaltning
+
+import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingPayload
+import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingTask
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.prosessering.internal.TaskService
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/forvaltning/konsistensavstemming")
+@ProtectedWithClaims(issuer = "azuread")
+class KonsistensavstemmingForvaltningController(
+    private val taskService: TaskService,
+    private val featureToggleService: FeatureToggleService,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping
+    fun kjørKonsistensavstemming() {
+        feilHvisIkke(erUtviklerMedVeilderrolle()) { "Kan kun kjøres av utvikler med veilederrolle" }
+        val triggerdato = LocalDate.now()
+        logger.info("Oppretter manuell tasks for konsistensavstemming for dato=$triggerdato")
+        taskService.saveAll(
+            listOf(
+                KonsistensavstemmingTask.opprettTask(
+                    KonsistensavstemmingPayload(StønadType.OVERGANGSSTØNAD, triggerdato),
+                    triggerdato.atTime(22, 0),
+                ),
+                KonsistensavstemmingTask.opprettTask(
+                    KonsistensavstemmingPayload(StønadType.BARNETILSYN, triggerdato),
+                    triggerdato.atTime(22, 20),
+                ),
+            ),
+        )
+    }
+
+    private fun erUtviklerMedVeilderrolle(): Boolean =
+        SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
@@ -1,9 +1,10 @@
-package no.nav.familie.ef.sak.oppgave
+package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.oppgave.LoggOppgaveMetadataTask
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PathVariable


### PR DESCRIPTION
…ppretter task for avstemming klokken 22 samme dag.

### Hvorfor er denne endringen nødvendig? ✨
Ref: melding på slack: 
>Det viser seg at det skulle vært kjørt konsistensavstemming også som er borte for oss. Kan dere kjøre denne også på nytt for BA, KS og EF?

https://nav-it.slack.com/archives/C01ESUV8V52/p1704793795377939?thread_ts=1704718586.028149&cid=C01ESUV8V52