### PR TITLE
Legg til forvalterrolle

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -109,6 +109,8 @@ spec:
           - id: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
           - id: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
           - id: "928636f4-fd0d-4149-978e-a6fb68bb19de" # prosessering.rolle - (0000-GA-STDAPPS)
+          - id: "c62e908a-cf20-4ad0-b7b3-3ff6ca4bf38b" # teamfamilie-forvaltning
+
         extra:
           - "NAVident"
           - "azp_name"

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -102,6 +102,7 @@ spec:
           - id: "ad7b87a6-9180-467c-affc-20a566b0fec0" # 0000-GA-Strengt_Fortrolig_Adresse
           - id: "9ec6487d-f37a-4aad-a027-cd221c1ac32b" # 0000-GA-Fortrolig_Adresse
           - id: "e750ceb5-b70b-4d94-b4fa-9d22467b786b" # 0000-GA-Egne_ansatte
+          - id: "3d718ae5-f25e-47a4-b4b3-084a97604c1d" # teamfamilie-forvaltning
 
         extra:
           - "NAVident"

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
@@ -26,8 +26,6 @@ class InfotrygdForvaltningController(
     fun hentRapportÅpneSaker(): Ressurs<InfotrygdReplikaClient.ÅpnesakerRapport> {
         logger.info("Henter åpne saker fra infotrygd")
         feilHvisIkke(tilgangService.harForvalterrolle()) { "Må være forvalter for å hente ut rapport" }
-        logger.info("Henter åpne saker fra infotrygd - autentisert")
-
         return Ressurs.success(infotrygdService.hentÅpneSaker())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
@@ -1,0 +1,26 @@
+package no.nav.familie.ef.sak.forvaltning
+
+import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/forvaltning/infotrygd")
+@ProtectedWithClaims(issuer = "azuread")
+class InfotrygdForvaltningController(
+    private val infotrygdService: InfotrygdService,
+    private val tilgangService: TilgangService,
+) {
+
+    @GetMapping("rapport")
+    fun hentRapportÅpneSaker(): Ressurs<InfotrygdReplikaClient.ÅpnesakerRapport> {
+        feilHvisIkke(tilgangService.harForvalterrolle()) { "Må være forvalter for å hente ut rapport" }
+        return Ressurs.success(infotrygdService.hentÅpneSaker())
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -18,9 +20,14 @@ class InfotrygdForvaltningController(
     private val tilgangService: TilgangService,
 ) {
 
+    val logger: Logger = LoggerFactory.getLogger(javaClass)
+
     @GetMapping("rapport")
     fun hentRapportÅpneSaker(): Ressurs<InfotrygdReplikaClient.ÅpnesakerRapport> {
+        logger.info("Henter åpne saker fra infotrygd")
         feilHvisIkke(tilgangService.harForvalterrolle()) { "Må være forvalter for å hente ut rapport" }
+        logger.info("Henter åpne saker fra infotrygd - autentisert")
+
         return Ressurs.success(infotrygdService.hentÅpneSaker())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
@@ -1,9 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
-import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,15 +15,12 @@ import java.util.UUID
 @ProtectedWithClaims(issuer = "azuread")
 class OppgaveforvaltningsController(
     private val taskService: TaskService,
-    private val featureToggleService: FeatureToggleService,
+    private val tilgangService: TilgangService,
 ) {
     @PostMapping("behandling/{behandlingId}")
     fun loggOppgavemetadataFor(@PathVariable behandlingId: UUID) {
-        feilHvisIkke(erUtviklerMedVeilderrolle()) { "Kan kun kjøres av utvikler med veilederrolle" }
+        feilHvisIkke(tilgangService.harForvalterrolle()) { "Må være forvalter for å bruke forvaltningsendepunkt" }
         val task = LoggOppgaveMetadataTask.opprettTask(behandlingId)
         taskService.save(task)
     }
-
-    private fun erUtviklerMedVeilderrolle(): Boolean =
-        SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdController.kt
@@ -2,14 +2,10 @@ package no.nav.familie.ef.sak.infotrygd
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
-import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -21,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 class InfotrygdController(
     private val tilgangService: TilgangService,
     private val infotrygdService: InfotrygdService,
-    private val featureToggleService: FeatureToggleService,
 ) {
 
     @PostMapping("perioder")
@@ -34,13 +29,5 @@ class InfotrygdController(
     fun hentSaker(@RequestBody personIdent: PersonIdentDto): Ressurs<InfotrygdSakResponse> {
         tilgangService.validerTilgangTilPersonMedBarn(personIdent.personIdent, AuditLoggerEvent.ACCESS)
         return Ressurs.success(infotrygdService.hentSaker(personIdent.personIdent))
-    }
-
-    @GetMapping("rapport")
-    fun hentRapportÅpneSaker(): Ressurs<InfotrygdReplikaClient.ÅpnesakerRapport> {
-        feilHvis(!featureToggleService.isEnabled(toggle = Toggle.TILLAT_HENT_UT_INFOTRYGD_RAPPORT)) {
-            "Rapport ikke tilgjengelig - toggle ikke enablet for bruker"
-        }
-        return Ressurs.success(infotrygdService.hentÅpneSaker())
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RolleConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RolleConfig.kt
@@ -17,4 +17,6 @@ class RolleConfig(
     val kode7: String,
     @Value("\${rolle.egenAnsatt}")
     val egenAnsatt: String,
+    @Value("\${rolle.forvalter}")
+    val forvalter: String,
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -45,6 +45,7 @@ object SikkerhetContext {
         return result
     }
 
+    @Deprecated("Bytt til _har_veileder_rolle eller tilsvarende")
     fun erSaksbehandler(): Boolean = hentSaksbehandlerEllerSystembruker() != SYSTEM_FORKORTELSE
 
     fun hentSaksbehandlerEllerSystembruker() =
@@ -104,7 +105,7 @@ object SikkerhetContext {
         return rollerForBruker.contains(minimumsrolle)
     }
 
-    fun harRolle(rolle: String): Boolean {
-        return hentGrupperFraToken().contains(rolle)
+    fun harRolle(rolleId: String): Boolean {
+        return hentGrupperFraToken().contains(rolleId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -106,6 +106,9 @@ object SikkerhetContext {
     }
 
     fun harRolle(rolleId: String): Boolean {
+
+        secureLogger.info("Sjekker rolleId: $rolleId mot roller: ${hentGrupperFraToken()}")
+
         return hentGrupperFraToken().contains(rolleId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -106,9 +106,6 @@ object SikkerhetContext {
     }
 
     fun harRolle(rolleId: String): Boolean {
-
-        secureLogger.info("Sjekker rolleId: $rolleId mot roller: ${hentGrupperFraToken()}")
-
         return hentGrupperFraToken().contains(rolleId)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
@@ -183,7 +183,7 @@ class TilgangService(
         return SikkerhetContext.harTilgangTilGittRolle(rolleConfig, minimumsrolle)
     }
 
-    fun harForvalterrolle(): Boolean = SikkerhetContext.harRolle(rolleConfig.forvalter)
+    fun harForvalterrolle() = SikkerhetContext.harRolle(rolleConfig.forvalter)
 
     fun harEgenAnsattRolle(): Boolean =
         hentGrupperFraToken().contains(rolleConfig.egenAnsatt)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
@@ -183,6 +183,8 @@ class TilgangService(
         return SikkerhetContext.harTilgangTilGittRolle(rolleConfig, minimumsrolle)
     }
 
+    fun harForvalterrolle(): Boolean = SikkerhetContext.harRolle(rolleConfig.forvalter)
+
     fun harEgenAnsattRolle(): Boolean =
         hentGrupperFraToken().contains(rolleConfig.egenAnsatt)
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,7 @@ rolle:
   kode6: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
+  forvalter: "c62e908a-cf20-4ad0-b7b3-3ff6ca4bf38b" # teamfamilie-forvaltning
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS 928636f4-fd0d-4149-978e-a6fb68bb19de
 KAFKA_BROKERS: hostname:1234

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -285,6 +285,7 @@ rolle:
   kode6: "ad7b87a6-9180-467c-affc-20a566b0fec0" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "9ec6487d-f37a-4aad-a027-cd221c1ac32b" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "e750ceb5-b70b-4d94-b4fa-9d22467b786b" # 0000-GA-Egne_ansatte
+  forvalter: "3d718ae5-f25e-47a4-b4b3-084a97604c1d" # teamfamilie-forvaltning
 
 prosessering.rolle: "87190cf3-b278-457d-8ab7-1a5c55a9edd7" # Gruppen teamfamilie
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/TilgangServiceTest.kt
@@ -42,7 +42,7 @@ internal class TilgangServiceTest {
     private val cacheManager = ConcurrentMapCacheManager()
     private val kode6Gruppe = "kode6"
     private val kode7Gruppe = "kode7"
-    private val rolleConfig = RolleConfig("", "", "", kode6 = kode6Gruppe, kode7 = kode7Gruppe, "")
+    private val rolleConfig = RolleConfig("", "", "", kode6 = kode6Gruppe, kode7 = kode7Gruppe, "", "")
     private val tilgangService =
         TilgangService(
             personopplysningerIntegrasjonerClient = personopplysningerIntegrajsonerClient,

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -36,6 +36,7 @@ rolle:
   kode6: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
   kode7: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   egenAnsatt: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
+  forvalter: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS
 
 prosessering.rolle: "928636f4-fd0d-4149-978e-a6fb68bb19de" # 0000-GA-STDAPPS
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker å bruke forvalterrolle for å autentisere kall mot forvaltningsendepunkt. Fjerner bruk av toggle for å gjøre dette. 

Flytter også endepunkt "infotrygd-rapport" til forvaltnings pakke. 

Testet i preprod og lokalt. Fungerer. 

(Del 1 i oppgave : Forenkle autentisering i swagger og bruk swagger for å kjøre forvaltningsoppgaver. ) 
----

Ta kontakt med meg dersom du trenger rolle forvalter-rolle på din bruker i prod, eller en ida-bruker i preprod. Legges til gruppe i portalz:

Preprod: krever trygdeetate-bruker-innlogging
https://portal.azure.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Properties/groupId/c62e908a-cf20-4ad0-b7b3-3ff6ca4bf38b

Prod: 
https://portal.azure.com/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Members/groupId/3d718ae5-f25e-47a4-b4b3-084a97604c1d
