### PR TITLE
skal vise valgfritt begrunnelsesfelt dersom bruker svarer nei på om s…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/TidligareVedtaksperioderRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/TidligareVedtaksperioderRegel.kt
@@ -18,11 +18,11 @@ class TidligareVedtaksperioderRegel : Vilkårsregel(
     vilkårType = VilkårType.TIDLIGERE_VEDTAKSPERIODER,
     regler = setOf(
         HAR_TIDLIGERE_MOTTATT_OVERGANSSTØNAD,
-        LEVER_IKKE_I_EKTESKAPLIGNENDE_FORHOLD,
+        HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING,
     ),
     hovedregler = regelIder(
         HAR_TIDLIGERE_MOTTATT_OVERGANSSTØNAD,
-        LEVER_IKKE_I_EKTESKAPLIGNENDE_FORHOLD,
+        HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING,
     ),
 ) {
 
@@ -60,12 +60,12 @@ class TidligareVedtaksperioderRegel : Vilkårsregel(
                 ),
             )
 
-        private val LEVER_IKKE_I_EKTESKAPLIGNENDE_FORHOLD =
+        private val HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING =
             RegelSteg(
                 regelId = RegelId.HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING,
                 svarMapping = jaNeiSvarRegel(
                     hvisJa = SluttSvarRegel.OPPFYLT_MED_PÅKREVD_BEGRUNNELSE,
-                    hvisNei = SluttSvarRegel.OPPFYLT,
+                    hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                 ),
             )
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/OppgaveClientMock.kt
@@ -56,7 +56,7 @@ class OppgaveClientMock {
 
         every { oppgaveClient.finnOppgaveMedId(any()) } answers {
             val oppgaveId = firstArg<Long>()
-            oppgaver[oppgaveId] ?: oppgave1.copy(id = oppgaveId)
+            oppgaver[oppgaveId] ?: oppgave1.copy(id = oppgaveId, tilordnetRessurs = SikkerhetContext.hentSaksbehandler())
         }
 
         every { oppgaveClient.finnMapper(any(), any()) } answers {

--- a/src/test/resources/regler/TIDLIGERE_VEDTAKSPERIODER.json
+++ b/src/test/resources/regler/TIDLIGERE_VEDTAKSPERIODER.json
@@ -22,7 +22,7 @@
           "regelId" : "SLUTT_NODE"
         },
         "NEI" : {
-          "begrunnelseType" : "UTEN",
+          "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
       }


### PR DESCRIPTION
…øker tidligere har mottatt andre stønader som har betydning

### Hvorfor er denne endringen nødvendig? ✨
Tillater meg også å hente ut innlogget saksbehandler dersom man kjører lokalt og prøver å hente en oppgave med en spesifikk oppgaveId. Tidligere mistet man redigeringsretten til behandlingen sin på grunn av ansvarlig-saksbehandler sjekken.

Tror ikke det er noe som behøves å patches her, da eldre behandlinger vil tilby bruker et valgfritt tekstfelt ved nei-svar. 

[favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17522)