### PR TITLE
Legger til kildeskatt på lønn som følge av at en bruker ikke kunne bl…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
@@ -20,7 +20,7 @@ data class PensjonsgivendeInntektForSkatteordning(
 enum class Skatteordning {
     FASTLAND,
     SVALBARD,
-    KILDESKATT_PAA_LOENN
+    KILDESKATT_PAA_LOENN,
 }
 
 data class SummertSkattegrunnlag(

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
@@ -20,6 +20,7 @@ data class PensjonsgivendeInntektForSkatteordning(
 enum class Skatteordning {
     FASTLAND,
     SVALBARD,
+    KILDESKATT_PAA_LOENN
 }
 
 data class SummertSkattegrunnlag(


### PR DESCRIPTION
…i slått opp på inntekt fordi vedkommende hadde kildeskatt på lønn.

Kildeskatt på lønn er en skatteordning for utenlandske arbeidstakere med kortere arbeidsopphold i Norge, og første året arbeidstakeren er skattemessig bosatt i Norge. Avklarer med Mirja og Lars hvordan dette skal se ut i frontend.

Jeg venter nok med å merge denne til det er avklart en grei løsning for hvordan dette skal vises i frontend, slik at saksbehandler ikke bare ser 0 i inntekt uten feilmelding, når det finnes det inntekt som er kildeskatt på lønn.