### PR TITLE
Deaktiverer scheduler for barnetilsyn satsendring da det er uført for 2024

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
@@ -1,9 +1,11 @@
 package no.nav.familie.ef.sak.beregning.barnetilsyn.satsendring
 
 import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
+@Profile("!integrasjonstest")
 @Service
 class BarnetilsynSatsendringScheduler(val barnetilsynSatsendringService: BarnetilsynSatsendringService) {
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det blir opprettet tasker i prod som feiler og som ikke skal kjøres.