### PR TITLE
Lokal kjøring av ef-sak fungerer ikke ettersom EnableMockOauth2Server…

### DIFF
--- a/src/test/kotlin/ApplicationLocal.kt
+++ b/src/test/kotlin/ApplicationLocal.kt
@@ -1,16 +1,14 @@
 package no.nav.familie.ef.sak
 
 import no.nav.familie.ef.sak.database.DbContainerInitializer
-import no.nav.familie.ef.sak.infrastruktur.config.ApplicationConfig
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.springframework.boot.builder.SpringApplicationBuilder
 
-@SpringBootApplication(exclude = [ErrorMvcAutoConfiguration::class])
-class ApplicationLocal
+@EnableMockOAuth2Server
+class ApplicationLocal : ApplicationLocalSetup()
 
 fun main(args: Array<String>) {
-    SpringApplicationBuilder(ApplicationConfig::class.java)
+    SpringApplicationBuilder(ApplicationLocal::class.java)
         .initializers(DbContainerInitializer())
         .profiles(
             "local",

--- a/src/test/kotlin/ApplicationLocalPostgres.kt
+++ b/src/test/kotlin/ApplicationLocalPostgres.kt
@@ -1,12 +1,11 @@
 package no.nav.familie.ef.sak
 
-import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
+import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.springframework.boot.builder.SpringApplicationBuilder
 import java.util.Properties
 
-@SpringBootApplication(exclude = [ErrorMvcAutoConfiguration::class])
-class ApplicationLocalPostgres
+@EnableMockOAuth2Server
+class ApplicationLocalPostgres : ApplicationLocalSetup()
 
 fun main(args: Array<String>) {
     val properties = Properties()

--- a/src/test/kotlin/ApplicationLocalSetup.kt
+++ b/src/test/kotlin/ApplicationLocalSetup.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ef.sak
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
+
+@SpringBootApplication(exclude = [ErrorMvcAutoConfiguration::class])
+class ApplicationLocalSetup

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -56,7 +56,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
-@SpringBootTest(classes = [ApplicationLocal::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = [ApplicationLocalSetup::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(
     "integrasjonstest",
     "mock-arbeidssøker",


### PR DESCRIPTION
… ikke blir injectet ved oppstart. For at testene skal kjøre må felles setup-config på tvers av lokal kjøring og tester trekkes ut som egen fil - og @EnableMockOauth2Server må settes eksplisitt i tester og lokal kjøring

### Hvorfor er denne endringen nødvendig? ✨
Ef sak kjører ikke lokalt uten denne endringen