### PR TITLE
Inntektskontroll: Filtrerer bort brukere uten utbetalingsbeløp

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -169,6 +169,7 @@ interface BehandlingRepository : RepositoryInterface<Behandling, UUID>, InsertUp
                                JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
              WHERE ty.id = aty.tilkjent_ytelse
                AND ty.behandling_id = gib.id
+               AND aty.belop > 0
                AND aty.stonad_tom >= 'now'::timestamp)
         EXCEPT
         (SELECT pi.ident


### PR DESCRIPTION
Det vil ikke resultere i noen ny behandling (revurdering / tilbakekreving) for de som ikke får noe utbetalt.