### PR TITLE
Automatisk vurdering av vilkår om opphold i Norge

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
@@ -30,18 +30,7 @@ class OppholdINorgeRegel : Vilkårsregel(
             return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
         }
 
-        val erDigitalSøknad = metadata.behandling.årsak == BehandlingÅrsak.SØKNAD
-        val harBrukerSvartJaPåSpørsmålOmOppholdISøknad = metadata.vilkårgrunnlagDto.medlemskap.søknadsgrunnlag?.oppholderDuDegINorge == true
-        val harSøkerPersonstatusBosatt = metadata.vilkårgrunnlagDto.medlemskap.registergrunnlag.folkeregisterpersonstatus == Folkeregisterpersonstatus.BOSATT
-        val harAlleBarnSammeAdresseSomSøker = harAlleBarnSammeAdresseSomSøker(metadata)
-
-        val skalAutomatiskVudereVilkår =
-            erDigitalSøknad &&
-                harBrukerSvartJaPåSpørsmålOmOppholdISøknad &&
-                harSøkerPersonstatusBosatt &&
-                harAlleBarnSammeAdresseSomSøker
-
-        if (skalAutomatiskVudereVilkår) {
+        if (oppfyllerVilkårForAutomatiskVurdering(metadata)) {
             return listOf(
                 automatiskVurdertDelvilkår(
                     regelId = RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE,
@@ -56,6 +45,18 @@ class OppholdINorgeRegel : Vilkårsregel(
 
     fun harAlleBarnSammeAdresseSomSøker(metadata: HovedregelMetadata): Boolean {
         return metadata.vilkårgrunnlagDto.barnMedSamvær.all { it.registergrunnlag.harSammeAdresse == true }
+    }
+
+    fun oppfyllerVilkårForAutomatiskVurdering(metadata: HovedregelMetadata): Boolean {
+        val erDigitalSøknad = metadata.behandling.årsak == BehandlingÅrsak.SØKNAD
+        val harBrukerSvartJaPåSpørsmålOmOppholdISøknad = metadata.vilkårgrunnlagDto.medlemskap.søknadsgrunnlag?.oppholderDuDegINorge == true
+        val harSøkerPersonstatusBosatt = metadata.vilkårgrunnlagDto.medlemskap.registergrunnlag.folkeregisterpersonstatus == Folkeregisterpersonstatus.BOSATT
+        val harAlleBarnSammeAdresseSomSøker = harAlleBarnSammeAdresseSomSøker(metadata)
+
+        return erDigitalSøknad &&
+            harBrukerSvartJaPåSpørsmålOmOppholdISøknad &&
+            harSøkerPersonstatusBosatt &&
+            harAlleBarnSammeAdresseSomSøker
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
@@ -1,6 +1,10 @@
 package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.NesteRegel
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.RegelSteg
@@ -9,12 +13,51 @@ import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import java.util.UUID
 
 class OppholdINorgeRegel : Vilkårsregel(
     vilkårType = VilkårType.LOVLIG_OPPHOLD,
     regler = setOf(BOR_OG_OPPHOLDER_SEG_I_NORGE, OPPHOLD_UNNTAK),
     hovedregler = regelIder(BOR_OG_OPPHOLDER_SEG_I_NORGE),
 ) {
+    override fun initiereDelvilkårsvurdering(
+        metadata: HovedregelMetadata,
+        resultat: Vilkårsresultat,
+        barnId: UUID?,
+    ): List<Delvilkårsvurdering> {
+        if (resultat != Vilkårsresultat.IKKE_TATT_STILLING_TIL) {
+            return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
+        }
+
+        val erDigitalSøknad = metadata.behandling.årsak == BehandlingÅrsak.SØKNAD
+        val harBrukerSvartJaPåSpørsmålOmOppholdISøknad = metadata.vilkårgrunnlagDto.medlemskap.søknadsgrunnlag?.oppholderDuDegINorge == true
+        val harSøkerPersonstatusBosatt = metadata.vilkårgrunnlagDto.medlemskap.registergrunnlag.folkeregisterpersonstatus == Folkeregisterpersonstatus.BOSATT
+        val harAlleBarnSammeAdresseSomSøker = harAlleBarnSammeAdresseSomSøker(metadata)
+
+        val skalAutomatiskVudereVilkår =
+            erDigitalSøknad &&
+                harBrukerSvartJaPåSpørsmålOmOppholdISøknad &&
+                harSøkerPersonstatusBosatt &&
+                harAlleBarnSammeAdresseSomSøker
+
+        if (skalAutomatiskVudereVilkår) {
+            return listOf(
+                automatiskVurdertDelvilkår(
+                    regelId = RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE,
+                    svarId = SvarId.JA,
+                    begrunnelse = "Bruker og barn bor og oppholder seg i Norge.",
+                ),
+            )
+        }
+
+        return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
+    }
+
+    fun harAlleBarnSammeAdresseSomSøker(metadata: HovedregelMetadata): Boolean {
+        return metadata.vilkårgrunnlagDto.barnMedSamvær.all { it.registergrunnlag.harSammeAdresse == true }
+    }
+
     companion object {
         private val OPPHOLD_UNNTAK =
             RegelSteg(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/ForutgåendeMedlemskapTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/ForutgåendeMedlemskapTest.kt
@@ -5,16 +5,10 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.InnflyttingDto
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.UtflyttingDto
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
-import no.nav.familie.ef.sak.vilkår.dto.MedlUnntakDto
-import no.nav.familie.ef.sak.vilkår.dto.MedlemskapDto
-import no.nav.familie.ef.sak.vilkår.dto.MedlemskapRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.MedlemskapSøknadsgrunnlagDto
-import no.nav.familie.ef.sak.vilkår.dto.PersonaliaDto
-import no.nav.familie.ef.sak.vilkår.dto.StatsborgerskapDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.ForutgåendeMedlemskapRegel
 import org.assertj.core.api.Assertions
@@ -227,33 +221,4 @@ class ForutgåendeMedlemskapTest {
 
         Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
     }
-
-    private fun medlemskapDto(
-        land: String = "norge",
-        folkeregisterpersonstatus: Folkeregisterpersonstatus = Folkeregisterpersonstatus.BOSATT,
-        innflytting: List<InnflyttingDto> = emptyList(),
-        utflytting: List<UtflyttingDto> = emptyList(),
-        søknadsgrunnlag: MedlemskapSøknadsgrunnlagDto? = null,
-    ) = MedlemskapDto(
-        søknadsgrunnlag = søknadsgrunnlag,
-        registergrunnlag =
-        MedlemskapRegistergrunnlagDto(
-            nåværendeStatsborgerskap = listOf(),
-            statsborgerskap = listOf(StatsborgerskapDto(land = land, null, null)),
-            oppholdstatus = emptyList(),
-            bostedsadresse = emptyList(),
-            innflytting = innflytting,
-            utflytting = utflytting,
-            folkeregisterpersonstatus = folkeregisterpersonstatus,
-            medlUnntak = MedlUnntakDto(emptyList()),
-        ),
-    )
-
-    private fun personaliaDto(fødeland: String = "NOR") =
-        PersonaliaDto(
-            navn = NavnDto(fornavn = "Ola", null, etternavn = "etternavn", visningsnavn = "visningsnavn"),
-            personIdent = "111111111",
-            bostedsadresse = null,
-            fødeland = fødeland,
-        )
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
@@ -32,7 +33,7 @@ class OppholdINorgeRegelTest {
     }
 
     @Test
-    fun `Skal automatisk vurdere opphold i Norge når det er en digital søknad, søker oppholder seg i Norge, har personstatus bosatt, og alle barn har samme adresse som søker`() {
+    fun `Skal automatisk oppfylle vilkår om opphold i Norge når det er en digital søknad, søker oppholder seg i Norge, har personstatus bosatt, og alle barn har samme adresse som søker`() {
         val listDelvilkårsvurdering =
             OppholdINorgeRegel().initiereDelvilkårsvurdering(
                 hovedregelMetadataMock,
@@ -95,6 +96,26 @@ class OppholdINorgeRegelTest {
         } returns
             VilkårTestUtil.mockVilkårGrunnlagDto(
                 medlemskap = medlemskapDto(oppholderDuDegINorge = false),
+                barnMedSamvær = barnMedSamværList,
+            )
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+    }
+
+    @Test
+    fun `Skal ikke ta stilling til vilkår når søker har personstatus utflyttet`() {
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                medlemskap = medlemskapDto(folkeregisterpersonstatus = Folkeregisterpersonstatus.UTFLYTTET),
                 barnMedSamvær = barnMedSamværList,
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
@@ -1,0 +1,110 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.vilkår.OppholdINorgeRegel
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OppholdINorgeRegelTest {
+    private val hovedregelMetadataMock = mockk<HovedregelMetadata>()
+
+    val barnMedSamværList = barnMedSamværListe(2)
+
+    @BeforeEach
+    fun setup() {
+        val behandling = behandling()
+        every { hovedregelMetadataMock.behandling } returns behandling
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                registergrunnlag = personaliaDto(),
+                medlemskap = medlemskapDto(),
+                barnMedSamvær = barnMedSamværList,
+            )
+    }
+
+    @Test
+    fun `Skal automatisk vurdere opphold i Norge når det er en digital søknad, søker oppholder seg i Norge, har personstatus bosatt, og alle barn har samme adresse som søker`() {
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+    }
+
+    @Test
+    fun `Skal ikke ta stilling til vilkår når ikke alle barn har samme adresse som søker`() {
+        val barnUtenSammeAdresse =
+            barnMedSamværList.last().copy(
+                registergrunnlag = barnMedSamværList.last().registergrunnlag.copy(harSammeAdresse = false),
+            )
+        val barnMedSamværListe = listOf(barnMedSamværList.first(), barnUtenSammeAdresse)
+
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                registergrunnlag = personaliaDto(),
+                medlemskap = medlemskapDto(),
+                barnMedSamvær = barnMedSamværListe,
+            )
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+    }
+
+    @Test
+    fun `Skal ikke ta stilling til vilkår når søknaden ikke er digital`() {
+        val behandling = behandling(årsak = BehandlingÅrsak.PAPIRSØKNAD)
+
+        every {
+            hovedregelMetadataMock.behandling
+        } returns behandling
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+    }
+
+    @Test
+    fun `Skal ikke ta stilling til vilkår når søker har svart nei på spørsmål om opphold i Norge i søknaden`() {
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                medlemskap = medlemskapDto(oppholderDuDegINorge = false),
+                barnMedSamvær = barnMedSamværList,
+            )
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
@@ -1,0 +1,100 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
+
+import io.mockk.mockk
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.InnflyttingDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.UtflyttingDto
+import no.nav.familie.ef.sak.vilkår.dto.AnnenForelderDto
+import no.nav.familie.ef.sak.vilkår.dto.AvstandTilSøkerDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
+import no.nav.familie.ef.sak.vilkår.dto.LangAvstandTilSøker
+import no.nav.familie.ef.sak.vilkår.dto.MedlUnntakDto
+import no.nav.familie.ef.sak.vilkår.dto.MedlemskapDto
+import no.nav.familie.ef.sak.vilkår.dto.MedlemskapRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.MedlemskapSøknadsgrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.PersonaliaDto
+import no.nav.familie.ef.sak.vilkår.dto.StatsborgerskapDto
+import java.time.LocalDate
+import java.util.UUID
+
+fun medlemskapDto(
+    land: String = "norge",
+    folkeregisterpersonstatus: Folkeregisterpersonstatus = Folkeregisterpersonstatus.BOSATT,
+    innflytting: List<InnflyttingDto> = emptyList(),
+    utflytting: List<UtflyttingDto> = emptyList(),
+    oppholderDuDegINorge: Boolean = true,
+    søknadsgrunnlag: MedlemskapSøknadsgrunnlagDto =
+        MedlemskapSøknadsgrunnlagDto(
+            bosattNorgeSisteÅrene = true,
+            oppholderDuDegINorge = oppholderDuDegINorge,
+            utenlandsopphold = emptyList(),
+        ),
+) = MedlemskapDto(
+    søknadsgrunnlag = søknadsgrunnlag,
+    registergrunnlag =
+    MedlemskapRegistergrunnlagDto(
+        nåværendeStatsborgerskap = listOf(),
+        statsborgerskap = listOf(StatsborgerskapDto(land = land, null, null)),
+        oppholdstatus = emptyList(),
+        bostedsadresse = emptyList(),
+        innflytting = innflytting,
+        utflytting = utflytting,
+        folkeregisterpersonstatus = folkeregisterpersonstatus,
+        medlUnntak = MedlUnntakDto(emptyList()),
+    ),
+)
+
+fun personaliaDto(fødeland: String = "NOR") =
+    PersonaliaDto(
+        navn = NavnDto(fornavn = "Ola", null, etternavn = "etternavn", visningsnavn = "visningsnavn"),
+        personIdent = "111111111",
+        bostedsadresse = null,
+        fødeland = fødeland,
+    )
+
+fun barnMedSamværListe(
+    antall: Int = 2,
+    harSammeAdresse: Boolean = true,
+) = (1..antall).map {
+    barnMedSamværDto(harSammeAdresse = harSammeAdresse)
+}
+
+fun barnMedSamværDto(
+    barnId: UUID = UUID.randomUUID(),
+    harSammeAdresse: Boolean,
+) = BarnMedSamværDto(
+    barnId,
+    søknadsgrunnlag = mockk(relaxed = true),
+    registergrunnlag =
+    BarnMedSamværRegistergrunnlagDto(
+        UUID.randomUUID(),
+        "navn",
+        "fnr",
+        harSammeAdresse = harSammeAdresse,
+        emptyList(),
+        false,
+        AnnenForelderDto(
+            "navn",
+            "fnr2",
+            LocalDate.now().minusYears(23),
+            true,
+            "Norge",
+            "Vei 1B",
+            null,
+            null,
+            AvstandTilSøkerDto(null, LangAvstandTilSøker.UKJENT),
+        ),
+        null,
+        null,
+    ),
+    barnepass =
+    BarnepassDto(
+        barnId,
+        skalHaBarnepass = true,
+        barnepassordninger = listOf(),
+        årsakBarnepass = null,
+    ),
+)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Skal automatisk vurdere inngangsvilkår for opphold når:
            - Digital søknad
            - Bruker har svart JA på spørsmålet "Oppholder du og barnet/barna dere i Norge?" i søknaden
            - Bruker og alle barn må ha Personstatus "Bosatt"

- Bruker mye av det samme testoppsettet som forutgående medlemskap, har derfor lagt funksjoner i en utilsfil som begge bruker, for å ikke gjenta koden.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18498)
