### PR TITLE
Etter tilbakemelding fra saksbehandlere og Mirja: terminbarn skal ikk…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,14 +29,14 @@
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <java.version>21</java.version>
-        <kotlin.version>1.9.22</kotlin.version>
+        <kotlin.version>1.9.23</kotlin.version>
         <kotlin-coroutines.version>1.8.0</kotlin-coroutines.version>
         <springdoc.version>2.3.0</springdoc.version>
-        <mockk.version>1.13.9</mockk.version>
-        <felles.version>2.20240221121155_f43df94</felles.version>
+        <mockk.version>1.13.10</mockk.version>
+        <felles.version>2.20240227113046_178d8bb</felles.version>
         <prosessering.version>2.20240214140223_83c31de</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20240215101759_cea211f</kontrakter.version>
+        <kontrakter.version>3.0_20240307134842_b6c7d85</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.15.0</cucumber.version>
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.19.6</version>
+            <version>1.19.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.barn.BehandlingBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.AnnenForelderMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.DeltBostedDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseHjelper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Bostedsadresse
@@ -160,6 +161,8 @@ class BarnMedSamværMapper(
             forelder = pdlAnnenForelder?.let { tilAnnenForelderDto(it, annenForelderFnr, søkerAdresse) },
             dødsdato = matchetBarn.barn?.dødsfall?.gjeldende()?.dødsdato,
             fødselsdato = matchetBarn.barn?.fødsel?.gjeldende()?.fødselsdato,
+            folkeregisterpersonstatus = matchetBarn.barn?.folkeregisterpersonstatus?.gjeldende()
+                ?.let(Folkeregisterpersonstatus::fraPdl),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -117,6 +117,7 @@ data class BarnMedIdent(
     val fødsel: List<Fødsel>,
     val navn: Navn,
     val personIdent: String,
+    val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>?,
 )
 
 data class ForelderBarnRelasjon(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -36,6 +36,7 @@ object GrunnlagsdataMapper {
             deltBosted = pdlPersonForelderBarn.deltBosted,
             forelderBarnRelasjon = pdlPersonForelderBarn.forelderBarnRelasjon.mapForelderBarnRelasjon(),
             personIdent = personIdent,
+            folkeregisterpersonstatus = pdlPersonForelderBarn.folkeregisterpersonstatus,
         )
 
     fun mapAnnenForelder(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPerson.kt
@@ -133,6 +133,7 @@ data class PdlPersonForelderBarn(
     val forelderBarnRelasjon: List<ForelderBarnRelasjon>,
     @JsonProperty("foedsel") override val fødsel: List<Fødsel>,
     val navn: List<Navn>,
+    val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>,
 ) : PdlPerson
 
 data class PdlAnnenForelder(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -38,10 +38,9 @@ data class BarnMedSamværSøknadsgrunnlagDto(
     val nårFlyttetDereFraHverandre: LocalDate?,
     val hvorMyeErDuSammenMedAnnenForelder: String?,
     val beskrivSamværUtenBarn: String?,
-){
+) {
     fun erTerminbarn() = this.fødselTermindato != null
 }
-
 
 data class BarnMedSamværRegistergrunnlagDto(
     val id: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.vilkår.dto
 
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.DeltBostedDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.vilkår.regler.BarnForelderLangAvstandTilSøker
 import java.time.LocalDate
 import java.util.UUID
@@ -49,6 +50,7 @@ data class BarnMedSamværRegistergrunnlagDto(
     val forelder: AnnenForelderDto?,
     val dødsdato: LocalDate? = null,
     val fødselsdato: LocalDate?,
+    val folkeregisterpersonstatus: Folkeregisterpersonstatus?,
 )
 
 data class AnnenForelderDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -38,7 +38,10 @@ data class BarnMedSamværSøknadsgrunnlagDto(
     val nårFlyttetDereFraHverandre: LocalDate?,
     val hvorMyeErDuSammenMedAnnenForelder: String?,
     val beskrivSamværUtenBarn: String?,
-)
+){
+    fun erTerminbarn() = this.fødselTermindato != null
+}
+
 
 data class BarnMedSamværRegistergrunnlagDto(
     val id: UUID,
@@ -51,7 +54,9 @@ data class BarnMedSamværRegistergrunnlagDto(
     val dødsdato: LocalDate? = null,
     val fødselsdato: LocalDate?,
     val folkeregisterpersonstatus: Folkeregisterpersonstatus?,
-)
+) {
+    fun erBosatt() = this.folkeregisterpersonstatus == Folkeregisterpersonstatus.BOSATT
+}
 
 data class AnnenForelderDto(
     val navn: String?,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
@@ -45,7 +45,7 @@ class OppholdINorgeRegel : Vilkårsregel(
 
     fun harBarnaPersonstatusBosatt(metadata: HovedregelMetadata): Boolean {
         return metadata.vilkårgrunnlagDto.barnMedSamvær.all {
-            it.registergrunnlag.folkeregisterpersonstatus == BOSATT || it.søknadsgrunnlag.fødselTermindato != null
+            it.registergrunnlag.erBosatt() || it.søknadsgrunnlag.erTerminbarn()
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
@@ -43,7 +43,7 @@ class OppholdINorgeRegel : Vilkårsregel(
         return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
     }
 
-    fun harBarnaPersonstatusBosatt(metadata: HovedregelMetadata): Boolean {
+    fun harBarnaPersonstatusBosattEllerErTerminbarn(metadata: HovedregelMetadata): Boolean {
         return metadata.vilkårgrunnlagDto.barnMedSamvær.all {
             it.registergrunnlag.erBosatt() || it.søknadsgrunnlag.erTerminbarn()
         }
@@ -57,7 +57,7 @@ class OppholdINorgeRegel : Vilkårsregel(
         val harSøkerNorskStatsborger = medlemskap.registergrunnlag.statsborgerskap.any {
             it.land.lowercase() == STATSBORGERSTAT_VERDI_NORGE
         }
-        val harBarnaPersonstatusBosatt = harBarnaPersonstatusBosatt(metadata)
+        val harBarnaPersonstatusBosatt = harBarnaPersonstatusBosattEllerErTerminbarn(metadata)
 
         return erDigitalSøknad &&
             harSøkerNorskStatsborger &&

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegel.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus.BOSATT
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
@@ -35,7 +35,7 @@ class OppholdINorgeRegel : Vilkårsregel(
                 automatiskVurdertDelvilkår(
                     regelId = RegelId.BOR_OG_OPPHOLDER_SEG_I_NORGE,
                     svarId = SvarId.JA,
-                    begrunnelse = "Bruker og barn bor og oppholder seg i Norge.",
+                    begrunnelse = "Bruker og barn bor og oppholder seg i Norge og bruker er norsk statsborger",
                 ),
             )
         }
@@ -43,20 +43,27 @@ class OppholdINorgeRegel : Vilkårsregel(
         return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
     }
 
-    fun harAlleBarnSammeAdresseSomSøker(metadata: HovedregelMetadata): Boolean {
-        return metadata.vilkårgrunnlagDto.barnMedSamvær.all { it.registergrunnlag.harSammeAdresse == true }
+    fun harBarnaPersonstatusBosatt(metadata: HovedregelMetadata): Boolean {
+        return metadata.vilkårgrunnlagDto.barnMedSamvær.all {
+            it.registergrunnlag.folkeregisterpersonstatus == BOSATT || it.søknadsgrunnlag.fødselTermindato != null
+        }
     }
 
     fun oppfyllerVilkårForAutomatiskVurdering(metadata: HovedregelMetadata): Boolean {
         val erDigitalSøknad = metadata.behandling.årsak == BehandlingÅrsak.SØKNAD
-        val harBrukerSvartJaPåSpørsmålOmOppholdISøknad = metadata.vilkårgrunnlagDto.medlemskap.søknadsgrunnlag?.oppholderDuDegINorge == true
-        val harSøkerPersonstatusBosatt = metadata.vilkårgrunnlagDto.medlemskap.registergrunnlag.folkeregisterpersonstatus == Folkeregisterpersonstatus.BOSATT
-        val harAlleBarnSammeAdresseSomSøker = harAlleBarnSammeAdresseSomSøker(metadata)
+        val medlemskap = metadata.vilkårgrunnlagDto.medlemskap
+        val harBrukerSvartOppholderSegINorgeISøknad = medlemskap.søknadsgrunnlag?.oppholderDuDegINorge == true && medlemskap.søknadsgrunnlag.bosattNorgeSisteÅrene
+        val harSøkerPersonstatusBosatt = medlemskap.registergrunnlag.folkeregisterpersonstatus == BOSATT
+        val harSøkerNorskStatsborger = medlemskap.registergrunnlag.statsborgerskap.any {
+            it.land.lowercase() == STATSBORGERSTAT_VERDI_NORGE
+        }
+        val harBarnaPersonstatusBosatt = harBarnaPersonstatusBosatt(metadata)
 
         return erDigitalSøknad &&
-            harBrukerSvartJaPåSpørsmålOmOppholdISøknad &&
+            harSøkerNorskStatsborger &&
+            harBrukerSvartOppholderSegINorgeISøknad &&
             harSøkerPersonstatusBosatt &&
-            harAlleBarnSammeAdresseSomSøker
+            harBarnaPersonstatusBosatt
     }
 
     companion object {

--- a/src/main/resources/pdl/forelder_barn.graphql
+++ b/src/main/resources/pdl/forelder_barn.graphql
@@ -104,6 +104,13 @@ query($identer: [ID!]!){
                     historisk
                 }
             }
+            folkeregisterpersonstatus {
+                status
+                forenkletStatus
+                metadata {
+                    historisk
+                }
+            }
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/util/GrunnlagsdataUtil.kt
@@ -68,4 +68,5 @@ fun opprettBarnMedIdent(
         fødsel = listOfNotNull(fødsel),
         navn = Navn("", "", "", Metadata(false)),
         personIdent = personIdent,
+        folkeregisterpersonstatus = null,
     )

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/BarnMatcherTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/BarnMatcherTest.kt
@@ -177,5 +177,6 @@ internal class BarnMatcherTest {
             emptyList(),
             Navn("", "", "", Metadata(false)),
             fnr,
+            null,
         )
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlTestdata.kt
@@ -181,6 +181,7 @@ object PdlTestdata {
                         familierelasjon,
                         fødsel,
                         navn,
+                        listOf(Folkeregisterpersonstatus("bosatt", "", metadataGjeldende)),
                     ),
                 ),
             ),

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -461,6 +461,7 @@ fun barnMedIdent(fnr: String, navn: String, fødsel: Fødsel = fødsel(LocalDate
             ),
         ),
         personIdent = fnr,
+        null,
     )
 
 fun sivilstand(type: Sivilstandstype, gyldigFraOgMed: LocalDate = LocalDate.now(), metadata: Metadata = metadataGjeldende) =

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -149,6 +149,7 @@ internal class VurderingServiceTest {
                 ),
                 null,
                 null,
+                null,
             ),
             barnepass =
             BarnepassDto(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
@@ -70,7 +70,7 @@ class OppholdINorgeRegelTest {
     @Test
     fun `Skal automatisk oppfylle vilkår for søker uten eksisterende barn, men terminbarn`() {
         val terminbarnRegisterGrunnlag = mockk<BarnMedSamværRegistergrunnlagDto>()
-        every { terminbarnRegisterGrunnlag.folkeregisterpersonstatus } returns null
+        every { terminbarnRegisterGrunnlag.erBosatt() } returns false
         val terminbarnSøknadGrunnlag = terminbarnSøknadsgrunnlag()
         val terminbarn = BarnMedSamværDto(UUID.randomUUID(), terminbarnSøknadGrunnlag, terminbarnRegisterGrunnlag)
 
@@ -98,7 +98,7 @@ class OppholdINorgeRegelTest {
     @Test
     fun `Skal automatisk oppfylle vilkår for søker med eksisterende barn som er ok, og et terminbarn`() {
         val terminbarnRegisterGrunnlag = mockk<BarnMedSamværRegistergrunnlagDto>()
-        every { terminbarnRegisterGrunnlag.folkeregisterpersonstatus } returns null
+        every { terminbarnRegisterGrunnlag.erBosatt() } returns false
         val terminbarnSøknadGrunnlag = terminbarnSøknadsgrunnlag()
         val terminbarn = BarnMedSamværDto(UUID.randomUUID(), terminbarnSøknadGrunnlag, terminbarnRegisterGrunnlag)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
@@ -36,7 +36,7 @@ class OppholdINorgeRegelTest {
     }
 
     @Test
-    fun `Skal automatisk oppfylle vilkår om opphold i Norge når det er en digital søknad, søker er norsk statsborger, øker oppholder seg i Norge, har personstatus bosatt, og alle barn har personstatus bosatt`() {
+    fun `Skal automatisk oppfylle vilkår om opphold i Norge når det er en digital søknad, søker er norsk statsborger, søker oppholder seg i Norge, har personstatus bosatt, og alle barn har personstatus bosatt`() {
         val listDelvilkårsvurdering =
             OppholdINorgeRegel().initiereDelvilkårsvurdering(
                 hovedregelMetadataMock,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/OppholdINorgeRegelTest.kt
@@ -6,12 +6,15 @@ import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.OppholdINorgeRegel
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class OppholdINorgeRegelTest {
     private val hovedregelMetadataMock = mockk<HovedregelMetadata>()
@@ -33,7 +36,7 @@ class OppholdINorgeRegelTest {
     }
 
     @Test
-    fun `Skal automatisk oppfylle vilkår om opphold i Norge når det er en digital søknad, søker oppholder seg i Norge, har personstatus bosatt, og alle barn har samme adresse som søker`() {
+    fun `Skal automatisk oppfylle vilkår om opphold i Norge når det er en digital søknad, søker er norsk statsborger, øker oppholder seg i Norge, har personstatus bosatt, og alle barn har personstatus bosatt`() {
         val listDelvilkårsvurdering =
             OppholdINorgeRegel().initiereDelvilkårsvurdering(
                 hovedregelMetadataMock,
@@ -45,12 +48,88 @@ class OppholdINorgeRegelTest {
     }
 
     @Test
-    fun `Skal ikke ta stilling til vilkår når ikke alle barn har samme adresse som søker`() {
-        val barnUtenSammeAdresse =
-            barnMedSamværList.last().copy(
-                registergrunnlag = barnMedSamværList.last().registergrunnlag.copy(harSammeAdresse = false),
+    fun `Skal ikke ta stilling til vilkår når søker ikke er norsk statsborger`() {
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                medlemskap = medlemskapDto(land = "sverige"),
+                barnMedSamvær = barnMedSamværList,
             )
-        val barnMedSamværListe = listOf(barnMedSamværList.first(), barnUtenSammeAdresse)
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
+    }
+
+    @Test
+    fun `Skal automatisk oppfylle vilkår for søker uten eksisterende barn, men terminbarn`() {
+        val terminbarnRegisterGrunnlag = mockk<BarnMedSamværRegistergrunnlagDto>()
+        every { terminbarnRegisterGrunnlag.folkeregisterpersonstatus } returns null
+        val terminbarnSøknadGrunnlag = terminbarnSøknadsgrunnlag()
+        val terminbarn = BarnMedSamværDto(UUID.randomUUID(), terminbarnSøknadGrunnlag, terminbarnRegisterGrunnlag)
+
+        val barnMedSamværListe = listOf(terminbarn)
+
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                registergrunnlag = personaliaDto(),
+                medlemskap = medlemskapDto(),
+                barnMedSamvær = barnMedSamværListe,
+            )
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+    }
+
+    @Test
+    fun `Skal automatisk oppfylle vilkår for søker med eksisterende barn som er ok, og et terminbarn`() {
+        val terminbarnRegisterGrunnlag = mockk<BarnMedSamværRegistergrunnlagDto>()
+        every { terminbarnRegisterGrunnlag.folkeregisterpersonstatus } returns null
+        val terminbarnSøknadGrunnlag = terminbarnSøknadsgrunnlag()
+        val terminbarn = BarnMedSamværDto(UUID.randomUUID(), terminbarnSøknadGrunnlag, terminbarnRegisterGrunnlag)
+
+        val barnMedSamværListe = listOf(terminbarn) + barnMedSamværList
+
+        every {
+            hovedregelMetadataMock.vilkårgrunnlagDto
+        } returns
+            VilkårTestUtil.mockVilkårGrunnlagDto(
+                registergrunnlag = personaliaDto(),
+                medlemskap = medlemskapDto(),
+                barnMedSamvær = barnMedSamværListe,
+            )
+
+        val listDelvilkårsvurdering =
+            OppholdINorgeRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                null,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+    }
+
+    @Test
+    fun `Skal ikke ta stilling til vilkår når ett av barna ikke har personstatus som bosatt`() {
+        val barnUtenFolkeregisterPersonStatus =
+            barnMedSamværList.last().copy(
+                registergrunnlag = barnMedSamværList.last().registergrunnlag.copy(folkeregisterpersonstatus = null),
+            )
+        val barnMedSamværListe = listOf(barnMedSamværList.first(), barnUtenFolkeregisterPersonStatus)
 
         every {
             hovedregelMetadataMock.vilkårgrunnlagDto

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.regler.vilkår
 
-import io.mockk.mockk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Folkeregisterpersonstatus
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.InnflyttingDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
@@ -9,6 +8,7 @@ import no.nav.familie.ef.sak.vilkår.dto.AnnenForelderDto
 import no.nav.familie.ef.sak.vilkår.dto.AvstandTilSøkerDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværSøknadsgrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
 import no.nav.familie.ef.sak.vilkår.dto.LangAvstandTilSøker
 import no.nav.familie.ef.sak.vilkår.dto.MedlUnntakDto
@@ -67,7 +67,7 @@ fun barnMedSamværDto(
     harSammeAdresse: Boolean,
 ) = BarnMedSamværDto(
     barnId,
-    søknadsgrunnlag = mockk(relaxed = true),
+    søknadsgrunnlag = tomtSøknadsgrunnlag(),
     registergrunnlag =
     BarnMedSamværRegistergrunnlagDto(
         UUID.randomUUID(),
@@ -89,6 +89,7 @@ fun barnMedSamværDto(
         ),
         null,
         null,
+        Folkeregisterpersonstatus.BOSATT,
     ),
     barnepass =
     BarnepassDto(
@@ -97,4 +98,25 @@ fun barnMedSamværDto(
         barnepassordninger = listOf(),
         årsakBarnepass = null,
     ),
+)
+
+fun terminbarnSøknadsgrunnlag() = tomtSøknadsgrunnlag().copy(fødselTermindato = LocalDate.now().plusMonths(2))
+fun tomtSøknadsgrunnlag() = BarnMedSamværSøknadsgrunnlagDto(
+    UUID.randomUUID(),
+    fødselTermindato = null,
+    navn = null,
+    harSammeAdresse = null,
+    skalBoBorHosSøker = null,
+    forelder = null,
+    ikkeOppgittAnnenForelderBegrunnelse = null,
+    spørsmålAvtaleOmDeltBosted = null,
+    skalAnnenForelderHaSamvær = null,
+    harDereSkriftligAvtaleOmSamvær = null,
+    hvordanPraktiseresSamværet = null,
+    borAnnenForelderISammeHus = null,
+    borAnnenForelderISammeHusBeskrivelse = null,
+    harDereTidligereBoddSammen = null,
+    nårFlyttetDereFraHverandre = null,
+    hvorMyeErDuSammenMedAnnenForelder = null,
+    beskrivSamværUtenBarn = null,
 )

--- a/src/test/kotlin/testutil/PdlTestdataHelper.kt
+++ b/src/test/kotlin/testutil/PdlTestdataHelper.kt
@@ -106,6 +106,7 @@ object PdlTestdataHelper {
             forelderBarnRelasjon,
             listOfNotNull(fødsel),
             listOfNotNull(navn),
+            emptyList(),
         )
 
     fun fødsel(år: Int = 2018, måned: Int = 1, dag: Int = 1): Fødsel =

--- a/src/test/resources/json/barn.json
+++ b/src/test/resources/json/barn.json
@@ -69,6 +69,15 @@
                 ]
               }
             }
+          ],
+          "folkeregisterpersonstatus": [
+            {
+              "status": "bosatt",
+              "forenkletStatus": "bosattEtterFolkeregisterloven",
+              "metadata": {
+                "historisk": false
+              }
+            }
           ]
         }
       }

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -2158,6 +2158,35 @@
         "name" : "personIdent",
         "type" : "String",
         "nullable" : false
+      },
+      "folkeregisterpersonstatus" : {
+        "name" : "folkeregisterpersonstatus",
+        "type" : "Collection",
+        "fields" : {
+          "status" : {
+            "name" : "status",
+            "type" : "String",
+            "nullable" : false
+          },
+          "forenkletStatus" : {
+            "name" : "forenkletStatus",
+            "type" : "String",
+            "nullable" : false
+          },
+          "metadata" : {
+            "name" : "metadata",
+            "type" : "Object",
+            "fields" : {
+              "historisk" : {
+                "name" : "historisk",
+                "type" : "Boolean",
+                "nullable" : false
+              }
+            },
+            "nullable" : false
+          }
+        },
+        "nullable" : true
       }
     },
     "nullable" : false


### PR DESCRIPTION
…e sjekkes for adresse/bosted. Vi trenger ikke sjekke at mor/barn bor på samme adresse, men de må være bosatt. Ønsker å legge inn at bruker må være norsk statsborger for å sikre seg bort fra noen corner-caser med innflyttede borgere

### Hvorfor er denne endringen nødvendig? ✨

Ref: [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-19958)