### PR TITLE
Sender med forrige ekstern id til iverksett slik at det kan sendes til behandlingsstatistikk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <felles.version>2.20240227113046_178d8bb</felles.version>
         <prosessering.version>2.20240214140223_83c31de</prosessering.version>
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20240403182559_640725f</kontrakter.version>
+        <kontrakter.version>3.0_20240405130633_ed41285</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.15.0</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.iverksett
 
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.barn.BarnService
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
 import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingsRepository
@@ -19,6 +20,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.simulering.hentSammenhengendePerioderMedFeilutbetaling
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingService
@@ -101,6 +103,7 @@ class IverksettingDtoMapper(
     private val brevmottakereRepository: BrevmottakereRepository,
     private val årsakRevurderingsRepository: ÅrsakRevurderingsRepository,
     private val oppgaverForOpprettelseService: OppgaverForOpprettelseService,
+    private val behandlingRepository: BehandlingRepository,
 ) {
 
     fun tilDto(saksbehandling: Saksbehandling, beslutter: String): IverksettDto {
@@ -263,19 +266,21 @@ class IverksettingDtoMapper(
     private fun mapBehandlingsdetaljer(
         saksbehandling: Saksbehandling,
         vilkårsvurderinger: List<Vilkårsvurdering>,
-    ) =
-        BehandlingsdetaljerDto(
+    ): BehandlingsdetaljerDto {
+        val forrigeBehandlingEksternId = saksbehandling.forrigeBehandlingId?.let { behandlingRepository.findByIdOrThrow(it).eksternId }
+        return BehandlingsdetaljerDto(
             behandlingId = saksbehandling.id,
             behandlingType = BehandlingType.valueOf(saksbehandling.type.name),
             behandlingÅrsak = saksbehandling.årsak,
             eksternId = saksbehandling.eksternId,
             vilkårsvurderinger = vilkårsvurderinger.map { it.tilIverksettDto() },
             forrigeBehandlingId = saksbehandling.forrigeBehandlingId,
+            forrigeBehandlingEksternId = forrigeBehandlingEksternId?.id,
             kravMottatt = saksbehandling.kravMottatt,
             årsakRevurdering = mapÅrsakRevurdering(saksbehandling),
             kategori = saksbehandling.kategori,
         )
-
+    }
     private fun mapÅrsakRevurdering(saksbehandling: Saksbehandling): ÅrsakRevurderingDto? =
         årsakRevurderingsRepository.findByIdOrNull(saksbehandling.id)
             ?.let { ÅrsakRevurderingDto(it.opplysningskilde, it.årsak) }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/OmregningServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.behandling.domain.EksternBehandlingId
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
@@ -238,6 +239,7 @@ internal class OmregningServiceTest : OppslagSpringRunnerTest() {
         val behandling = behandlingRepository.insert(
             behandling(
                 id = behandlingId,
+                eksternId = EksternBehandlingId(11),
                 fagsak = fagsak,
                 resultat = BehandlingResultat.INNVILGET,
                 status = BehandlingStatus.FERDIGSTILT,

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
@@ -9,10 +9,12 @@ import io.mockk.verify
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.behandling.domain.EksternBehandlingId
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.HenlagtÅrsak
 import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprettelseService
@@ -96,6 +98,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.YearMonth
+import java.util.Optional
 import java.util.UUID
 import no.nav.familie.kontrakter.ef.felles.BehandlingType as BehandlingTypeIverksett
 import no.nav.familie.kontrakter.ef.felles.RegelId as RegelIdIverksett
@@ -121,6 +124,7 @@ internal class IverksettingDtoMapperTest {
     private val barnMatcher = mockk<BarnMatcher>()
     private val årsakRevurderingsRepository = mockk<ÅrsakRevurderingsRepository>()
     private val oppgaverForOpprettelseService = mockk<OppgaverForOpprettelseService>()
+    private val behandlingRepository = mockk<BehandlingRepository>()
 
     private val iverksettingDtoMapper =
         IverksettingDtoMapper(
@@ -136,10 +140,14 @@ internal class IverksettingDtoMapperTest {
             brevmottakereRepository = brevmottakereRepository,
             årsakRevurderingsRepository = årsakRevurderingsRepository,
             oppgaverForOpprettelseService = oppgaverForOpprettelseService,
+            behandlingRepository = behandlingRepository,
         )
 
     private val fagsak = fagsak(fagsakpersoner(setOf("1")))
-    private val behandling = behandling(fagsak)
+    private val forrigeBehandlingId = UUID.fromString("73144d90-d238-41d2-833b-fc719dae23cc")
+    private val forrigeEksternBehandlingId = 22L
+    private val forrigeBehandling = behandling(fagsak = fagsak, id = forrigeBehandlingId, eksternId = EksternBehandlingId(forrigeEksternBehandlingId))
+    private val behandling = behandling(fagsak = fagsak, forrigeBehandlingId = forrigeBehandlingId)
     private val saksbehandling = saksbehandling(fagsak, behandling)
 
     @BeforeEach
@@ -160,6 +168,7 @@ internal class IverksettingDtoMapperTest {
             beskrivelse = "beskrivelse",
         )
         every { oppgaverForOpprettelseService.hentOppgaverForOpprettelseEllerNull(any()) } returns null
+        every { behandlingRepository.findById(any()) } returns Optional.of(forrigeBehandling)
     }
 
     @Test
@@ -365,7 +374,8 @@ internal class IverksettingDtoMapperTest {
         assertThat(behandling.behandlingId).isEqualTo(behandlingId)
         assertThat(behandling.behandlingType.name).isEqualTo(BehandlingType.FØRSTEGANGSBEHANDLING.name)
         assertThat(behandling.behandlingÅrsak).isEqualTo(BehandlingÅrsak.SØKNAD)
-        assertThat(behandling.forrigeBehandlingId).isEqualTo(UUID.fromString("73144d90-d238-41d2-833b-fc719dae23cc"))
+        assertThat(behandling.forrigeBehandlingId).isEqualTo(forrigeBehandlingId)
+        assertThat(behandling.forrigeBehandlingEksternId).isEqualTo(forrigeEksternBehandlingId)
         assertThat(behandling.eksternId).isEqualTo(1)
         assertThat(behandling.aktivitetspliktInntrefferDato).isNull() // Ikke i bruk?
         assertThat(behandling.kravMottatt).isEqualTo(LocalDate.of(2022, 3, 1))

--- a/src/test/resources/omregning/expectedIverksettDto.json
+++ b/src/test/resources/omregning/expectedIverksettDto.json
@@ -7,6 +7,7 @@
   "behandling": {
     "behandlingId": "08230110-9f26-4fa1-bdf5-1b5f1ea6f59d",
     "forrigeBehandlingId": "39c7dc82-adc1-43db-a6f9-64b8e4352ff6",
+    "forrigeBehandlingEksternId": 11,
     "eksternId": 2,
     "behandlingType": "REVURDERING",
     "behandlingÅrsak": "G_OMREGNING",


### PR DESCRIPTION
Datavarehus (behandlingsstatistikk) ønsker at det også sendes hendelser ved g-omregning. 
Løser dette med en egen task i iverksett. Manglet info om ekstern id for forrige behandling i iverksett, så sender dette over til iverksett. 

[Tilhørende PR i iverksett](https://github.com/navikt/familie-ef-iverksett/pull/916)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17409)