### PR TITLE
Håndter at det kan finnes flere ugyldige terminbarn per behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnService.kt
@@ -35,7 +35,7 @@ class ForberedOppgaverTerminbarnService(
             val pdlBarn = pdlBarn(fødselsnummerSøker)
             val ugyldigeTerminbarn = terminbarnPåSøknad.filterNot { it.match(pdlBarn) }
             lagreOgMapTilOppgaverForUgyldigeTerminbarn(ugyldigeTerminbarn, fødselsnummerSøker)
-        }.flatten()
+        }.flatten().toSet()
         logger.info("Fant ${oppgaver.size} oppgaver for ugyldige terminbarn.")
         oppgaver.forEach { oppgave ->
             logger.info("Laget oppgave for behandlingID=${oppgave.behandlingId} for ugyldige terminbarn")
@@ -46,7 +46,7 @@ class ForberedOppgaverTerminbarnService(
     private fun pdlBarn(fødselsnummerSøker: String): List<PdlPersonForelderBarn> =
         personService.hentPersonMedBarn(fødselsnummerSøker).barn.values.toList()
 
-    private fun opprettTaskerForOppgaver(oppgaver: List<OppgaveForBarn>) {
+    private fun opprettTaskerForOppgaver(oppgaver: Collection<OppgaveForBarn>) {
         oppgaver.forEach { taskService.save(OpprettOppgaveTerminbarnTask.opprettTask(it)) }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er feil i prod, hvor det er problemer med å lagre oppgave for ugyldig terminbarn fordi det finnes flere ugyldige terminbarn på en behandling. Det feiler med at man ikke får lagret duplikat task. Det holder å lage en oppgave pr person, selv om vedkommende har flere barn med ugyldige terminbarn.

Etter å ha snakket med Mirja er dette et symptom på et annet problem for saksbehandler har opprettet terminbarn tilbake i tid i stedet for at de har rekvirert d-nummer på barna. Tror ikke alle saksbehandlere har tilgang til å gjøre dette i dag, så Mirja og Lars skal ta det opp med avdelingsledere.