### PR TITLE
Featuretoggle for automatisk behandling av tilbakekreving under 4x rettsgebyr

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -21,6 +21,7 @@ class FeatureToggleController(
             Toggle.OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST,
             Toggle.FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR,
             Toggle.FRONTEND_SATSENDRING,
+            Toggle.FRONTEND_TILBAKEKREVING_UNDER_4X_RETTSGEBYR,
             Toggle.HENLEGG_BEHANDLING_UTEN_OPPGAVE,
         )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -38,8 +38,10 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
         "familie.ef.sak.frontend-automatisk-utfylle-vilkar",
         "Operational - kun preprod",
     ),
-    FRONTEND_TILBAKEKREVING_UNDER_4X_RETTSGEBYR("familie.ef.sak.frontend.tilbakekreving-under-4x-rettsgebyr",
-        "Release"),
+    FRONTEND_TILBAKEKREVING_UNDER_4X_RETTSGEBYR(
+        "familie.ef.sak.frontend.tilbakekreving-under-4x-rettsgebyr",
+        "Release",
+    ),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT(
         "familie.ef.sak.automatiske-brev-innhenting-karakterutskrift",
         "Operational - sesongavhengig",

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -38,6 +38,8 @@ enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
         "familie.ef.sak.frontend-automatisk-utfylle-vilkar",
         "Operational - kun preprod",
     ),
+    FRONTEND_TILBAKEKREVING_UNDER_4X_RETTSGEBYR("familie.ef.sak.frontend.tilbakekreving-under-4x-rettsgebyr",
+        "Release"),
     AUTOMATISKE_BREV_INNHENTING_KARAKTERUTSKRIFT(
         "familie.ef.sak.automatiske-brev-innhenting-karakterutskrift",
         "Operational - sesongavhengig",


### PR DESCRIPTION
Featuretoggle som skal tas i bruk i frontend som skal vise valg om å automatisk behandle tilbakekreving dersom simulering gir feilutbetaling lavere enn 4x rettsgebyr.