### PR TITLE
Ta bort ersaksbehandler deprecated

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -51,9 +51,6 @@ object SikkerhetContext {
         return result
     }
 
-    @Deprecated("Bytt til _har_veileder_rolle eller tilsvarende")
-    fun erSaksbehandler(): Boolean = hentSaksbehandlerEllerSystembruker() != SYSTEM_FORKORTELSE
-
     fun hentSaksbehandlerEllerSystembruker() =
         Result.runCatching { SpringTokenValidationContextHolder().tokenValidationContext }
             .fold(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
-import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
@@ -75,7 +74,7 @@ class JournalpostClient(
     }
 
     private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
-        if (SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut journalposter som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
                 FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveClient.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
-import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -142,7 +141,7 @@ class OppgaveClient(
     }
 
     private fun kastApiFeilDersomUtviklerMedVeilederrolle() {
-        if (SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
+        if (featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)) {
             throw ApiFeil(
                 "Kan ikke hente ut oppgaver som utvikler med veilederrolle. Kontakt teamet dersom du har saksbehandlerrolle.",
                 HttpStatus.FORBIDDEN,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
@@ -88,5 +88,5 @@ class TilordnetRessursService(
     }
 
     private fun erUtviklerMedVeilderrolle(): Boolean =
-        SikkerhetContext.erSaksbehandler() && featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)
+        featureToggleService.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE)
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/integration/JournalpostClientTest.kt
@@ -87,7 +87,6 @@ internal class JournalpostClientTest {
             firstArg<Toggle>() != Toggle.UTVIKLER_MED_VEILEDERRROLLE
         }
         mockkObject(SikkerhetContext)
-        every { SikkerhetContext.erSaksbehandler() } returns true
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
@@ -169,7 +169,7 @@ internal class TilordnetRessursServiceTest {
 
         @Test
         internal fun `skal utlede at saksbehandlers rolle er INNLOGGET SAKSBEHANDLER`() {
-            val saksbehandler = saksbehandler(UUID.randomUUID(), "4499", "Skywalker", "Anakin", "NAV1234")
+            val saksbehandler = saksbehandler(UUID.randomUUID(), "Skywalker", "Anakin", "NAV1234")
             val oppgave = Oppgave(tilordnetRessurs = "NAV1234", tema = Tema.ENF)
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV1234") } returns saksbehandler
@@ -183,7 +183,7 @@ internal class TilordnetRessursServiceTest {
 
         @Test
         internal fun `skal utlede at saksbehandlers rolle er ANNEN SAKSBEHANDLER`() {
-            val saksbehandler = saksbehandler(UUID.randomUUID(), "4405", "Vader", "Darth", "NAV2345")
+            val saksbehandler = saksbehandler(UUID.randomUUID(), "Vader", "Darth", "NAV2345")
             val oppgave = Oppgave(tilordnetRessurs = "NAV2345", tema = Tema.ENF)
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV2345") } returns saksbehandler
@@ -219,7 +219,7 @@ internal class TilordnetRessursServiceTest {
 
         @Test
         internal fun `skal utlede at saksbehandlers rolle er UTVIKLER MED VEILEDERROLLE`() {
-            val saksbehandler = saksbehandler(UUID.randomUUID(), "4405", "Vader", "Darth", "NAV1234")
+            val saksbehandler = saksbehandler(UUID.randomUUID(), "Vader", "Darth", "NAV1234")
             val oppgave = Oppgave(tilordnetRessurs = "NAV1234")
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV1234") } returns saksbehandler
@@ -234,7 +234,7 @@ internal class TilordnetRessursServiceTest {
 
         @Test
         internal fun `skal utlede at saksbehandlers rolle er OPPGAVE_TILHØRER_IKKE_ENF`() {
-            val saksbehandler = saksbehandler(UUID.randomUUID(), "4405", "Vader", "Darth", "NAV2345")
+            val saksbehandler = saksbehandler(UUID.randomUUID(), "Vader", "Darth", "NAV2345")
             val oppgave = Oppgave(tilordnetRessurs = "NAV2345", tema = Tema.BAR)
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV2345") } returns saksbehandler
@@ -262,13 +262,12 @@ internal class TilordnetRessursServiceTest {
 
     private fun saksbehandler(
         azureId: UUID,
-        enhet: String,
         etternavn: String,
         fornavn: String,
         navIdent: String,
     ) = Saksbehandler(
         azureId = azureId,
-        enhet = enhet,
+        enhet = "4405",
         etternavn = etternavn,
         fornavn = fornavn,
         navIdent = navIdent,

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
@@ -33,7 +33,6 @@ internal class TilordnetRessursServiceTest {
     fun setUp() {
         mockkObject(SikkerhetContext)
         every { SikkerhetContext.hentSaksbehandler() } returns "NAV1234"
-        every { SikkerhetContext.erSaksbehandler() } returns true
         every { featureToggleService.isEnabled(any()) } returns false
     }
 
@@ -156,7 +155,6 @@ internal class TilordnetRessursServiceTest {
                 )
             } answers { efOppgave(firstArg<UUID>()) }
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()).copy(tilordnetRessurs = "NAV2345") }
-            every { SikkerhetContext.erSaksbehandler() } returns true
             every { featureToggleService.isEnabled(any()) } returns true
 
             val erSaksbehandlerEllerNull =
@@ -171,15 +169,15 @@ internal class TilordnetRessursServiceTest {
 
         @Test
         internal fun `skal utlede at saksbehandlers rolle er INNLOGGET SAKSBEHANDLER`() {
-            val saksbehandler = saksbehandler(UUID.randomUUID(), "4405", "Vader", "Darth", "NAV1234")
+            val saksbehandler = saksbehandler(UUID.randomUUID(), "4499", "Skywalker", "Anakin", "NAV1234")
             val oppgave = Oppgave(tilordnetRessurs = "NAV1234", tema = Tema.ENF)
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV1234") } returns saksbehandler
 
             val saksbehandlerDto = tilordnetRessursService.utledAnsvarligSaksbehandlerForOppgave(oppgave)
 
-            assertThat(saksbehandlerDto.fornavn).isEqualTo("Darth")
-            assertThat(saksbehandlerDto.etternavn).isEqualTo("Vader")
+            assertThat(saksbehandlerDto.fornavn).isEqualTo("Anakin")
+            assertThat(saksbehandlerDto.etternavn).isEqualTo("Skywalker")
             assertThat(saksbehandlerDto.rolle).isEqualTo(SaksbehandlerRolle.INNLOGGET_SAKSBEHANDLER)
         }
 
@@ -225,7 +223,6 @@ internal class TilordnetRessursServiceTest {
             val oppgave = Oppgave(tilordnetRessurs = "NAV1234")
 
             every { oppgaveClient.hentSaksbehandlerInfo("NAV1234") } returns saksbehandler
-            every { SikkerhetContext.erSaksbehandler() } returns true
             every { featureToggleService.isEnabled(any()) } returns true
 
             val saksbehandlerDto = tilordnetRessursService.utledAnsvarligSaksbehandlerForOppgave(oppgave)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når vi sjekker om vi skal gjøre kall mot oppgave og arkiv (journalpost), noe vi ikke ønsker å gjøre dersom det er utviklere som bruker systemet, sjekker vi også at innlogget bruker har en rolle i ef-sak. Det er ikke nødvendig å sjekke dette her og kan være med på å gjøre koden vanskeligere å lese. 

Ønsker derfor å fjerne "erSaksnehandler" koden (som også er deprecated). Det blir da tydeligere at vi ikke gjør kall mot oppgaver/journalposter hvis innlogget bruker er på liste (unleash) over brukere som ikke skal forsøke å hente slikt.

