### PR TITLE
Skal ikke hente unødige data for å mappe ut personopplysninger fra re…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/karakterutskrift/SendKarakterutskriftBrevTilIverksettTask.kt
@@ -79,7 +79,7 @@ class SendKarakterutskriftBrevTilIverksettTask(
     }
 
     private fun validerHarIkkeVergemål(ident: String, opggave: Oppgave) {
-        val personopplysninger = personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(ident)
+        val personopplysninger = personopplysningerService.hentPersonopplysningerFraRegister(ident)
         val harVerge = personopplysninger.vergemål.isNotEmpty()
         feilHvis(harVerge) {
             "Kan ikke automatisk sende brev for oppgaveId=${opggave.id}. Brev om innhenting av karakterutskrift skal ikke sendes automatisk fordi bruker har vergemål. Saken må følges opp manuelt og tasken kan avvikshåndteres."

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdService
 import no.nav.familie.ef.sak.felles.util.Timer.loggTid
 import no.nav.familie.ef.sak.kontantstøtte.KontantstøtteService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Personopplysninger
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapAnnenForelder
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.GrunnlagsdataMapper.mapBarn
@@ -50,20 +51,12 @@ class GrunnlagsdataRegisterService(
         )
     }
 
-    fun hentGrunnlagsdataUtenVedtakshitorikkFraRegister(personIdent: String): GrunnlagsdataDomene {
+    fun hentPersonopplysninger(personIdent: String): Personopplysninger {
         val grunnlagsdataFraPdl = hentGrunnlagsdataFraPdl(personIdent, emptyList())
-        val medlUnntak = personopplysningerIntegrasjonerClient.hentMedlemskapsinfo(personIdent)
-        val harAvsluttetArbeidsforhold = arbeidsforholdService.finnesAvsluttetArbeidsforholdSisteAntallMåneder(personIdent)
-
-        val harKontantstøttePerioder = kontantstøtteService.finnesKontantstøtteUtbetalingerPåBruker(personIdent).finnesUtbetaling
-        return GrunnlagsdataDomene(
+        return Personopplysninger(
             søker = mapSøker(grunnlagsdataFraPdl.søker, grunnlagsdataFraPdl.andrePersoner),
             annenForelder = mapAnnenForelder(grunnlagsdataFraPdl.barneForeldre, emptyMap()),
-            medlUnntak = medlUnntak,
             barn = mapBarn(grunnlagsdataFraPdl.barn),
-            tidligereVedtaksperioder = null,
-            harAvsluttetArbeidsforhold = harAvsluttetArbeidsforhold,
-            harKontantstøttePerioder = harKontantstøttePerioder,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Personopplysninger
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -109,9 +110,9 @@ class GrunnlagsdataService(
         }
     }
 
-    fun hentGrunnlagsdataUtenTidligereVedtakshistorikk(personIdent: String): GrunnlagsdataDomene {
+    fun hentPersonopplysninger(personIdent: String): Personopplysninger {
         return loggTid {
-            grunnlagsdataRegisterService.hentGrunnlagsdataUtenVedtakshitorikkFraRegister(personIdent)
+            grunnlagsdataRegisterService.hentPersonopplysninger(personIdent)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -34,7 +34,7 @@ class PersonopplysningerController(
     @GetMapping("/behandling/{behandlingId}")
     fun personopplysninger(@PathVariable behandlingId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(personopplysningerService.hentPersonopplysninger(behandlingId))
+        return Ressurs.success(personopplysningerService.hentPersonopplysningerForBehandling(behandlingId))
     }
 
     @GetMapping("/behandling/{behandlingId}/endringer")
@@ -47,7 +47,7 @@ class PersonopplysningerController(
     fun personopplysningerFraFagsakPersonId(@PathVariable fagsakPersonId: UUID): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
-        return Ressurs.success(personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(aktivIdent))
+        return Ressurs.success(personopplysningerService.hentPersonopplysningerFraRegister(aktivIdent))
     }
 
     @PostMapping("/nav-kontor")

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -35,7 +35,7 @@ class PersonopplysningerService(
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hentPersonopplysninger(behandlingId: UUID): PersonopplysningerDto {
+    fun hentPersonopplysningerForBehandling(behandlingId: UUID): PersonopplysningerDto {
         val personIdent = behandlingService.hentAktivIdent(behandlingId)
         val søkerIdenter = personService.hentPersonIdenter(personIdent)
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdata(behandlingId)
@@ -48,7 +48,7 @@ class PersonopplysningerService(
         )
     }
 
-    fun finnEndringerIPersonopplysninger(
+    fun finnEndringerIPersonopplysningerForBehandling(
         behandling: Saksbehandling,
         tidligereGrunnlagsdata: GrunnlagsdataMedMetadata,
         nyGrunnlagsdata: GrunnlagsdataMedMetadata,
@@ -72,18 +72,16 @@ class PersonopplysningerService(
     }
 
     @Cacheable("personopplysninger", cacheManager = "shortCache")
-    fun hentPersonopplysningerUtenVedtakshistorikk(personIdent: String): PersonopplysningerDto {
-        val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdataUtenTidligereVedtakshistorikk(personIdent)
+    fun hentPersonopplysningerFraRegister(personIdent: String): PersonopplysningerDto {
+        val grunnlagsdata = grunnlagsdataService.hentPersonopplysninger(personIdent)
         val egenAnsatt = egenAnsatt(personIdent)
         val identerFraPdl = personService.hentPersonIdenter(personIdent)
 
         return personopplysningerMapper.tilPersonopplysninger(
-            GrunnlagsdataMedMetadata(
-                grunnlagsdata,
-                opprettetTidspunkt = LocalDateTime.now(),
-            ),
-            egenAnsatt,
-            identerFraPdl,
+            grunnlagsdata = grunnlagsdata,
+            grunnlagsdataOpprettet = LocalDateTime.now(),
+            egenAnsatt = egenAnsatt,
+            søkerIdenter = identerFraPdl,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -75,6 +75,14 @@ data class GrunnlagsdataDomene(
     val tidligereVedtaksperioder: TidligereVedtaksperioder?,
     val harAvsluttetArbeidsforhold: Boolean?,
     val harKontantstøttePerioder: Boolean?,
+) {
+    fun tilPersonopplysninger() = Personopplysninger(søker = this.søker, annenForelder = this.annenForelder, barn = this.barn)
+}
+
+data class Personopplysninger(
+    val søker: Søker,
+    val annenForelder: List<AnnenForelderMedIdent>,
+    val barn: List<BarnMedIdent>,
 )
 
 data class Søker(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerService.kt
@@ -39,7 +39,7 @@ class EndringerIPersonOpplysningerService(
         val nyGrunnlagsdata = hentOppdatertGrunnlagsdata(behandling, grunnlagsdata)
             ?: return EndringerIPersonopplysningerDto(grunnlagsdata.oppdaterteDataHentetTid, Endringer())
 
-        val endringer = personopplysningerService.finnEndringerIPersonopplysninger(
+        val endringer = personopplysningerService.finnEndringerIPersonopplysningerForBehandling(
             behandling,
             grunnlagsdata.tilGrunnlagsdataMedMetadata(),
             nyGrunnlagsdata,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.AnnenForelderMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Personopplysninger
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Søker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.AdresseDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Adressebeskyttelse
@@ -25,6 +26,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Component
 class PersonopplysningerMapper(
@@ -34,11 +36,11 @@ class PersonopplysningerMapper(
 ) {
 
     fun tilPersonopplysninger(
-        grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
+        grunnlagsdata: Personopplysninger,
+        grunnlagsdataOpprettet: LocalDateTime,
         egenAnsatt: Boolean,
         søkerIdenter: PdlIdenter,
     ): PersonopplysningerDto {
-        val grunnlagsdata = grunnlagsdataMedMetadata.grunnlagsdata
         val søker = grunnlagsdata.søker
         val annenForelderMap = grunnlagsdata.annenForelder.associateBy { it.personIdent }
 
@@ -81,7 +83,7 @@ class PersonopplysningerMapper(
                     søkerIdenter.identer(),
                     søker.bostedsadresse,
                     annenForelderMap,
-                    grunnlagsdataMedMetadata.opprettetTidspunkt.toLocalDate(),
+                    grunnlagsdataOpprettet.toLocalDate(),
                 )
             }.sortedBy { it.fødselsdato },
             innflyttingTilNorge = innflyttingUtflyttingMapper.mapInnflytting(søker.innflyttingTilNorge),
@@ -90,6 +92,17 @@ class PersonopplysningerMapper(
             vergemål = mapVergemål(søker),
         )
     }
+
+    fun tilPersonopplysninger(
+        grunnlagsdataMedMetadata: GrunnlagsdataMedMetadata,
+        egenAnsatt: Boolean,
+        søkerIdenter: PdlIdenter,
+    ): PersonopplysningerDto = tilPersonopplysninger(
+        grunnlagsdata = grunnlagsdataMedMetadata.grunnlagsdata.tilPersonopplysninger(),
+        grunnlagsdataOpprettet = grunnlagsdataMedMetadata.opprettetTidspunkt,
+        egenAnsatt = egenAnsatt,
+        søkerIdenter = søkerIdenter,
+    )
 
     private fun mapOmråde(område: String): String {
         return when (område) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/karakterutskrift/KarakterutskriftBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/karakterutskrift/KarakterutskriftBrevTaskTest.kt
@@ -44,7 +44,7 @@ internal class KarakterutskriftBrevTaskTest {
 
     @BeforeEach
     fun setUp() {
-        every { personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(any<String>()) } returns mockk {
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any<String>()) } returns mockk {
             every { vergemål } returns emptyList()
         }
     }
@@ -92,7 +92,7 @@ internal class KarakterutskriftBrevTaskTest {
         )
         every { behandlingService.finnesBehandlingForFagsak(any()) } returns true
         every { fagsakService.finnFagsaker(any()) } returns listOf(fagsak())
-        every { personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk(any<String>()) } returns mockk {
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any<String>()) } returns mockk {
             every { vergemål } returns listOf(mockk())
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerServiceTest.kt
@@ -60,7 +60,7 @@ internal class EndringerIPersonOpplysningerServiceTest {
             assertThat(endringer.endringer.harEndringer).isFalse
 
             verify(exactly = 1) { grunnlagsdataService.hentFraRegister(any()) }
-            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysninger(any(), any(), any()) }
+            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysningerForBehandling(any(), any(), any()) }
             verify(exactly = 1) {
                 grunnlagsdataService.oppdaterEndringer(
                     coWithArg {
@@ -78,7 +78,7 @@ internal class EndringerIPersonOpplysningerServiceTest {
             assertThat(endringer.endringer.harEndringer).isTrue
 
             verify(exactly = 1) { grunnlagsdataService.hentFraRegister(any()) }
-            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysninger(any(), any(), any()) }
+            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysningerForBehandling(any(), any(), any()) }
             verify(exactly = 1) {
                 grunnlagsdataService.oppdaterEndringer(
                     coWithArg {
@@ -103,7 +103,7 @@ internal class EndringerIPersonOpplysningerServiceTest {
 
             assertThat(endringer.endringer.harEndringer).isTrue
 
-            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysninger(any(), any(), any()) }
+            verify(exactly = 1) { personopplysningerService.finnEndringerIPersonopplysningerForBehandling(any(), any(), any()) }
             verify(exactly = 0) { grunnlagsdataService.oppdaterEndringer(any()) }
             verify(exactly = 0) { grunnlagsdataService.hentFraRegister(any()) }
         }
@@ -116,7 +116,7 @@ internal class EndringerIPersonOpplysningerServiceTest {
 
             assertThat(endringer.endringer.harEndringer).isFalse
 
-            verify(exactly = 0) { personopplysningerService.finnEndringerIPersonopplysninger(any(), any(), any()) }
+            verify(exactly = 0) { personopplysningerService.finnEndringerIPersonopplysningerForBehandling(any(), any(), any()) }
             verify(exactly = 0) { grunnlagsdataService.oppdaterEndringer(any()) }
             verify(exactly = 0) { grunnlagsdataService.hentFraRegister(any()) }
         }
@@ -139,7 +139,7 @@ internal class EndringerIPersonOpplysningerServiceTest {
     private fun mockPersonopplysninger(harEndringer: Boolean) {
         val endringer = Endringer(folkeregisterpersonstatus = Endring(harEndringer = harEndringer))
         every {
-            personopplysningerService.finnEndringerIPersonopplysninger(
+            personopplysningerService.finnEndringerIPersonopplysningerForBehandling(
                 any(),
                 any(),
                 any(),

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -104,18 +104,18 @@ internal class PersonopplysningerServiceTest {
                 emptyList(),
                 emptyList(),
             )
-        val søker = personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("01010172272")
+        val søker = personopplysningerService.hentPersonopplysningerFraRegister("01010172272")
         assertThat(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(søker))
             .isEqualToIgnoringWhitespace(readFile("/json/personopplysningerDto.json"))
     }
 
     @Test
     internal fun `skal cache egenAnsatt når man kaller med samme ident`() {
-        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("1")
-        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("1")
+        personopplysningerService.hentPersonopplysningerFraRegister("1")
+        personopplysningerService.hentPersonopplysningerFraRegister("1")
         verify(exactly = 1) { egenAnsattClient.egenAnsatt(any()) }
 
-        personopplysningerService.hentPersonopplysningerUtenVedtakshistorikk("2")
+        personopplysningerService.hentPersonopplysningerFraRegister("2")
         verify(exactly = 2) { egenAnsattClient.egenAnsatt(any()) }
     }
 


### PR DESCRIPTION
…gister. Tidligere hentet vi kontantstøtte, medlunntak, vedtaksperioder osv. Det er kun søker, barn og annen forelder fra PDL som er av interesse for personopplysninger

### Hvorfor er denne endringen nødvendig? ✨