### PR TITLE
Bugfix: Vil håndtere null-perioder på tom-infotrygdperioder.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/kontantstøtte/KontantstøtteClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/kontantstøtte/KontantstøtteClient.kt
@@ -35,22 +35,18 @@ data class HentUtbetalingsinfoKontantstøtteRequest(
 data class HentUtbetalingsinfoKontantstøtte(
     val infotrygdPerioder: List<KontantstøtteInfotrygdPeriode>,
     val ksSakPerioder: List<KsSakPeriode>,
-) {
-    fun finnesUtbetalinger(): Boolean {
-        return infotrygdPerioder.isNotEmpty() || ksSakPerioder.isNotEmpty()
-    }
-}
+)
 
 data class KontantstøtteInfotrygdPeriode(
     val fomMåned: YearMonth,
-    val tomMåned: YearMonth,
+    val tomMåned: YearMonth?,
     val beløp: Int,
     val barna: List<String>,
 )
 
 data class KsSakPeriode(
     val fomMåned: YearMonth,
-    val tomMåned: YearMonth,
+    val tomMåned: YearMonth?,
     val barn: KsBarn,
 )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/kontantstøtte/KontantstøtteClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/kontantstøtte/KontantstøtteClientTest.kt
@@ -77,7 +77,7 @@ class KontantstøtteClientTest {
         "infotrygdPerioder": [
           {
             "fomMåned": "2022-09",
-            "tomMåned": "2022-10",
+ 
             "beløp": 1000,
             "barna": [
               "01010199999"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bugfix: Vil håndtere null-perioder på tom-infotrygdperioder.
Setter også ks-sakperioder (toMåned) til nullable (samme som brukt i ks-sak endepunkt).
