### PR TITLE
Tabellene behandling_ekstern og fagsak_ekstern er tatt ut av drift et…

### DIFF
--- a/src/main/resources/db/migration/V146__fjern_behandling_og_fagsak_ekstern_tabeller.sql
+++ b/src/main/resources/db/migration/V146__fjern_behandling_og_fagsak_ekstern_tabeller.sql
@@ -1,0 +1,6 @@
+---- Må flytte sequencene som brukes for å generere eksternId ut av tabellene fagsak_ekstern og behandling_ekstern før sletting - hvis ikke forsvinner de i dragsuget ---
+ALTER SEQUENCE behandling_ekstern_id_seq OWNED BY NONE;
+ALTER SEQUENCE fagsak_ekstern_id_seq OWNED BY NONE;
+
+DROP TABLE fagsak_ekstern;
+DROP TABLE behandling_ekstern;


### PR DESCRIPTION
…ter at de ble innlemmet i fagsak og behandling-tabellene. Vi må derimot hekte av sekvensene vi har brukt i preprod og prod slik at disse ikke slettes i dragsuget av tabellslettingen.

### Hvorfor er denne endringen nødvendig? ✨

Ref [favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20823)