### PR TITLE
Fjern toggle som schedulerer deaktivering av brukere på mikrofrontend…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -19,7 +19,6 @@ class FeatureToggleService(val unleashService: UnleashService) {
 
 enum class Toggle(val toggleId: String, val beskrivelse: String? = null) {
     // Release
-    DEAKTIVERE_MIKROFRONTEND_FOR_INAKTIVE_BRUKERE("familie.ef.sak.deaktiver-mikrofrontend-for-inaktive-brukere"),
     OVERSENDE_BEGRUNNELSE_FOR_TILBAKEKREVING("familie-ef-sak.begrunnelse-for-tilbakekreving", "Release"),
 
     // Operational

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendScheduler.kt
@@ -1,8 +1,6 @@
 package no.nav.familie.ef.sak.minside
 
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
@@ -14,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional
 class DeaktiverMikrofrontendScheduler(
     val taskService: TaskService,
     val fagsakPersonService: FagsakPersonService,
-    val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -23,15 +20,11 @@ class DeaktiverMikrofrontendScheduler(
     fun opprettTaskForDeaktiveringAvMikrofrontend() {
         if (LeaderClient.isLeader() == true) {
             logger.info("Starter scheduler for å deaktivere mikrofrontend for brukere")
-            if (featureToggleService.isEnabled(Toggle.DEAKTIVERE_MIKROFRONTEND_FOR_INAKTIVE_BRUKERE)) {
-                val fagsakPersonIder = fagsakPersonService.finnFagsakpersonIderKlarForDeaktiveringAvMikrofrontend()
-                logger.info("Fant ${fagsakPersonIder.size} som skal deaktivere mikrofrontend for enslig forsørger")
-                fagsakPersonIder.forEach {
-                    val task = DeaktiverMikrofrontendTask.opprettTask(it)
-                    taskService.save(task)
-                }
-            } else {
-                logger.info("Featuretoggle er skrudd av - utfører ikke scheduler for deaktivering av mikrofrontend")
+            val fagsakPersonIder = fagsakPersonService.finnFagsakpersonIderKlarForDeaktiveringAvMikrofrontend()
+            logger.info("Fant ${fagsakPersonIder.size} som skal deaktivere mikrofrontend for enslig forsørger")
+            fagsakPersonIder.forEach {
+                val task = DeaktiverMikrofrontendTask.opprettTask(it)
+                taskService.save(task)
             }
         }
     }


### PR DESCRIPTION
…. Denne skal gå som normalt hver uke

### Hvorfor er denne endringen nødvendig? ✨

Husk å arkivere [denne](https://teamfamilie-unleash-web.nav.cloud.nais.io/projects/default/features/familie.ef.sak.deaktiver-mikrofrontend-for-inaktive-brukere) etter merge