### PR TITLE
Vil slette tilbakekrevingsvalg hvis urelevant

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingService.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.ef.sak.tilbakekreving
+
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.simulering.SimuleringsresultatRepository
+import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekrevingsvalg
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+@Service
+class TilbakekrevingOppryddingService(
+    private val tilbakekrevingRepository: TilbakekrevingRepository,
+    private val simuleringsresultatRepository: SimuleringsresultatRepository,
+    private val behandlingRepository: BehandlingRepository,
+) {
+    fun slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(
+        behandlingId: UUID,
+        nySimuleringsoppsummering: Simuleringsoppsummering,
+    ) {
+        if (nySimuleringsoppsummering.harIngenFeilutbetaling()) {
+            slettTilbakekrevingsvalg(behandlingId)
+        } else {
+            val oppsummering = hentLagretSimmuleringsresultat(behandlingId)
+            if (oppsummering != null && nySimuleringsoppsummering.harUlikeBeløp(oppsummering)) {
+                slettTilbakekrevingsvalgUnder4rettsgebyr(behandlingId)
+            }
+        }
+    }
+
+    private fun slettTilbakekrevingsvalgUnder4rettsgebyr(behandlingId: UUID) {
+        val tilbakekreving = tilbakekrevingRepository.findByIdOrThrow(behandlingId)
+        if (tilbakekreving.valg == Tilbakekrevingsvalg.OPPRETT_AUTOMATISK) {
+            slettTilbakekrevingsvalg(behandlingId)
+        }
+    }
+
+    private fun hentLagretSimmuleringsresultat(behandlingId: UUID): Simuleringsoppsummering? {
+        val simuleringsresultat = simuleringsresultatRepository.findByIdOrNull(behandlingId)
+        return simuleringsresultat?.beriketData?.oppsummering
+    }
+
+    private fun Simuleringsoppsummering.harIngenFeilutbetaling() = this.feilutbetaling.toLong() == 0L
+
+    private fun Simuleringsoppsummering.harUlikeBeløp(oppsummering: Simuleringsoppsummering): Boolean {
+        return this.feilutbetaling != oppsummering.feilutbetaling || this.etterbetaling != oppsummering.etterbetaling
+    }
+
+    fun slettTilbakekrevingsvalg(behandlingId: UUID) {
+        val behandling = behandlingRepository.findByIdOrThrow(behandlingId)
+        feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
+            "Kan ikke slette tilbakekrevingsvalg for behandling=$behandlingId da den er låst"
+        }
+        tilbakekrevingRepository.deleteById(behandlingId)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingService.kt
@@ -31,8 +31,8 @@ class TilbakekrevingOppryddingService(
     }
 
     private fun slettTilbakekrevingsvalgUnder4rettsgebyr(behandlingId: UUID) {
-        val tilbakekreving = tilbakekrevingRepository.findByIdOrThrow(behandlingId)
-        if (tilbakekreving.valg == Tilbakekrevingsvalg.OPPRETT_AUTOMATISK) {
+        val tilbakekreving = tilbakekrevingRepository.findByIdOrNull(behandlingId)
+        if (tilbakekreving != null && tilbakekreving.valg == Tilbakekrevingsvalg.OPPRETT_AUTOMATISK) {
             slettTilbakekrevingsvalg(behandlingId)
         }
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingServiceTest.kt
@@ -74,7 +74,6 @@ class TilbakekrevingOppryddingServiceTest() {
 
     @Test
     internal fun `Skal ikke slette tilbakekreving dersom tilbakekrevingsvalg ikke er OPPRETT AUTOMATISK`() {
-
         mockHentLagretTilbakekreving(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_MED_VARSEL)
 
         oppryddingService.slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(UUID.randomUUID(), simuleringsoppsummering)
@@ -104,12 +103,12 @@ class TilbakekrevingOppryddingServiceTest() {
 
     private fun mockHentLagretTilbakekreving(tilbakekrevingsvalg: Tilbakekrevingsvalg) {
         every { tilbakekrevingRepository.findByIdOrThrow(any()) } returns
-                Tilbakekreving(
-                    behandlingId = UUID.randomUUID(),
-                    valg = tilbakekrevingsvalg,
-                    varseltekst = "forventetVarseltekst",
-                    begrunnelse = "ingen",
-                )
+            Tilbakekreving(
+                behandlingId = UUID.randomUUID(),
+                valg = tilbakekrevingsvalg,
+                varseltekst = "forventetVarseltekst",
+                begrunnelse = "ingen",
+            )
     }
 
     private fun mockHentLagretSimuleringsresultat(feilutbetaltBeløp: Int) {
@@ -119,10 +118,10 @@ class TilbakekrevingOppryddingServiceTest() {
                     behandlingId = UUID.randomUUID(),
                     data = DetaljertSimuleringResultat(emptyList()),
                     beriketData =
-                    BeriketSimuleringsresultat(
-                        mockk(),
-                        simuleringsoppsummering.copy(feilutbetaling = BigDecimal(feilutbetaltBeløp)),
-                    ),
+                        BeriketSimuleringsresultat(
+                            mockk(),
+                            simuleringsoppsummering.copy(feilutbetaling = BigDecimal(feilutbetaltBeløp)),
+                        ),
                 ),
             )
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingOppryddingServiceTest.kt
@@ -1,0 +1,118 @@
+package no.nav.familie.ef.sak.tilbakekreving
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.simulering.Simuleringsresultat
+import no.nav.familie.ef.sak.simulering.SimuleringsresultatRepository
+import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekreving
+import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekrevingsvalg
+import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
+import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.repository.findByIdOrNull
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+class TilbakekrevingOppryddingServiceTest() {
+    val simuleringsresultatRepository = mockk<SimuleringsresultatRepository>()
+    val tilbakekrevingRepository = mockk<TilbakekrevingRepository>(relaxed = true)
+    val behandlingRepository = mockk<BehandlingRepository>()
+    val oppryddingService = TilbakekrevingOppryddingService(tilbakekrevingRepository = tilbakekrevingRepository, simuleringsresultatRepository = simuleringsresultatRepository, behandlingRepository = behandlingRepository)
+
+    val behandling = behandling(fagsak = fagsak())
+
+    val simuleringsoppsummering =
+        Simuleringsoppsummering(
+            perioder = listOf(),
+            fomDatoNestePeriode = null,
+            etterbetaling = BigDecimal.valueOf(5000),
+            feilutbetaling = BigDecimal.valueOf(40_000),
+            fom = LocalDate.of(2021, 1, 1),
+            tomDatoNestePeriode = null,
+            forfallsdatoNestePeriode = null,
+            tidSimuleringHentet = LocalDate.of(2021, 11, 1),
+            tomSisteUtbetaling = LocalDate.of(2021, 10, 31),
+        )
+
+    @BeforeEach
+    fun setUp() {
+        mockhentBehandling()
+    }
+
+    @Test
+    internal fun `Skal slette tilbakekreving dersom det ikke er feilutbetaling i ny simulering`() {
+        mockHentLagretSimuleringsresultat(feilutbetaltBeløp = 1234)
+        mockHentLagretTilbakekreving(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_UTEN_VARSEL)
+        val nySimuleringsoppsummering = simuleringsoppsummering.copy(feilutbetaling = BigDecimal.ZERO)
+        oppryddingService.slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(UUID.randomUUID(), nySimuleringsoppsummering)
+
+        verify(exactly = 1) { tilbakekrevingRepository.deleteById(any()) }
+    }
+
+    @Test
+    internal fun `Skal slette tilbakekreving dersom feilutbetalt beløp er endret og tilbakekrevingsvalg var OPPRETT AUTOMATISK`() {
+        mockHentLagretSimuleringsresultat(feilutbetaltBeløp = 1234)
+        mockHentLagretTilbakekreving(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_AUTOMATISK)
+
+        oppryddingService.slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(UUID.randomUUID(), simuleringsoppsummering)
+
+        verify(exactly = 1) { tilbakekrevingRepository.deleteById(any()) }
+    }
+
+    @Test
+    internal fun `Skal ikke slette tilbakekreving dersom tilbakekrevingsvalg ikke er OPPRETT AUTOMATISK`() {
+        mockHentLagretSimuleringsresultat(feilutbetaltBeløp = 1234)
+        mockHentLagretTilbakekreving(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_MED_VARSEL)
+
+        oppryddingService.slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(UUID.randomUUID(), simuleringsoppsummering)
+
+        verify(exactly = 0) { tilbakekrevingRepository.deleteById(any()) }
+    }
+
+    @Test
+    internal fun `Skal ikke slette tilbakekreving dersom feilutbetalt beløp ikke er endret og tilbakekrevingsvalg var OPPRETT AUTOMATISK`() {
+        mockHentLagretSimuleringsresultat(feilutbetaltBeløp = simuleringsoppsummering.feilutbetaling.toInt())
+        mockHentLagretTilbakekreving(tilbakekrevingsvalg = Tilbakekrevingsvalg.OPPRETT_AUTOMATISK)
+
+        oppryddingService.slettTilbakekrevingsvalgHvisIngenFeilutbetalingEllerForskjelligBeløp(UUID.randomUUID(), simuleringsoppsummering)
+
+        verify(exactly = 0) { tilbakekrevingRepository.deleteById(any()) }
+    }
+
+    private fun mockhentBehandling() {
+        every { behandlingRepository.findByIdOrThrow(any()) } returns behandling
+    }
+
+    private fun mockHentLagretTilbakekreving(tilbakekrevingsvalg: Tilbakekrevingsvalg) {
+        every { tilbakekrevingRepository.findByIdOrThrow(any()) } returns
+            Tilbakekreving(
+                behandlingId = UUID.randomUUID(),
+                valg = tilbakekrevingsvalg,
+                varseltekst = "forventetVarseltekst",
+                begrunnelse = "ingen",
+            )
+    }
+
+    private fun mockHentLagretSimuleringsresultat(feilutbetaltBeløp: Int) {
+        every { simuleringsresultatRepository.findByIdOrNull(any()) }
+            .returns(
+                Simuleringsresultat(
+                    behandlingId = UUID.randomUUID(),
+                    data = DetaljertSimuleringResultat(emptyList()),
+                    beriketData =
+                        BeriketSimuleringsresultat(
+                            mockk(),
+                            simuleringsoppsummering.copy(feilutbetaling = BigDecimal(feilutbetaltBeløp)),
+                        ),
+                ),
+            )
+    }
+}


### PR DESCRIPTION
Vil slette tilbakekrevingsvalg dersom vi i 
1. nyeste simulering ikke har noen feilutbetaling, eller 
2. dersom beløp i gammel/ny er forskjellig og tilbakekrevingsvalg er "automatisk behandle under fire rettsgebyr".

### Hvorfor er denne endringen nødvendig? ✨

Dersom vi ikke sletter tilbakekrevingsvalg kan to ting skje: 

1. Vi gjør et valg - "under 4 rg". Går tilbake til vedtak. Endrer så det blir større feilutbetaling. Resultat: vi kan nå gå videre fra simuleringsfanen uten å gjøre noe simulieringsvalg. Dette valget vises ikke da det ikke skal være mulig å opprette tilbakekreving med dette valget dersom beløpet er høyere enn 4rg. 
2. Dersom vi i "nyeste simulering" ikke får feilutbetalig vil vi fortsatt sende tilbakekrevings(valg) videre til iverksetting. Dette vil ikke føre til noen feil, men det logges mye og historikk på behandlingen vil se litt rar ut.   

---- 

Diskuterer gjerne om vi bør slette? Er dette historikk som er spennende? 
