### PR TITLE
Skal tåle at historisk pensjon er nede når vi oppretter behandlinger …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
@@ -40,7 +40,7 @@ class TidligereVedtaksperioderService(
         return TidligereVedtaksperioder(
             infotrygd = tidligereInnvilgetVedtak,
             sak = hentTidligereInnvilgedeVedtakEf(alleIdenter),
-            historiskPensjon = historiskPensjonService.hentHistoriskPensjon(aktivIdent, alleIdenter).harPensjonsdata,
+            historiskPensjon = historiskPensjonService.hentHistoriskPensjon(aktivIdent, alleIdenter).harPensjonsdata(),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon
 
 import no.nav.familie.http.client.AbstractRestClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -14,17 +15,29 @@ class HistoriskPensjonClient(
     private val historiskPensjonUri: URI,
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "pensjon") {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     private fun lagHarPensjonUri() =
         UriComponentsBuilder.fromUri(historiskPensjonUri).pathSegment("api/ensligForsoerger/harPensjonsdata")
             .build().toUri()
 
-    fun harPensjon(
+    val manglendeRespons = HistoriskPensjonResponse(false, "")
+
+    fun hentHistoriskPensjonStatusForIdent(
         aktivIdent: String,
         alleRelaterteFoedselsnummer: Set<String>,
-    ): HistoriskPensjonResponse {
-        return postForEntity(
-            lagHarPensjonUri(),
-            EnsligForsoergerRequest(aktivIdent, alleRelaterteFoedselsnummer),
-        )
+    ): HistoriskPensjonDto {
+        repeat(2) {
+            try {
+                return postForEntity<HistoriskPensjonResponse>(
+                    lagHarPensjonUri(),
+                    EnsligForsoergerRequest(aktivIdent, alleRelaterteFoedselsnummer),
+                ).tilDto()
+            } catch (e: Exception) {
+                logger.error("Kunne ikke kalle historisk pensjon for uthenting")
+                secureLogger.error("Kunne ikke kalle historisk pensjon for uthenting", e)
+            }
+        }
+        return HistoriskPensjonDto(HistoriskPensjonStatus.UKJENT, null)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon
 
-import java.net.URI
 import no.nav.familie.http.client.AbstractRestClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -8,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
 import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
 
 @Component
 class HistoriskPensjonClient(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonController.kt
@@ -19,14 +19,14 @@ class HistoriskPensjonController(
     @GetMapping("{fagsakPersonId}")
     fun hentHistoriskPensjon(
         @PathVariable fagsakPersonId: UUID,
-    ): Ressurs<HistoriskPensjonResponse> {
+    ): Ressurs<HistoriskPensjonDto> {
         return Ressurs.success(historiskPensjonService.hentHistoriskPensjon(fagsakPersonId))
     }
 
     @GetMapping("fagsak/{fagsakId}")
     fun hentHistoriskPensjonForFagsak(
         @PathVariable fagsakId: UUID,
-    ): Ressurs<HistoriskPensjonResponse> {
+    ): Ressurs<HistoriskPensjonDto> {
         return Ressurs.success(historiskPensjonService.hentHistoriskPensjonForFagsak(fagsakId))
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/HistoriskPensjonMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/HistoriskPensjonMock.kt
@@ -3,7 +3,8 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonResponse
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonStatus
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
@@ -16,7 +17,7 @@ class HistoriskPensjonMock {
     @Primary
     fun historiskPensjonClient(): HistoriskPensjonClient {
         val mockk = mockk<HistoriskPensjonClient>()
-        every { mockk.harPensjon(any(), any()) } returns HistoriskPensjonResponse(true, "")
+        every { mockk.hentHistoriskPensjonStatusForIdent(any(), any()) } returns HistoriskPensjonDto(HistoriskPensjonStatus.HAR_HISTORIKK, "")
         return mockk
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
@@ -16,8 +16,9 @@ import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonResponse
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonStatus
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakPerson
@@ -91,7 +92,7 @@ internal class TidligereVedtaksperioderServiceTest {
         every { personService.hentPersonIdenter(personIdent.ident) } returns
             PdlIdenter(listOf(PdlIdent(personIdent.ident, false)))
         every { historiskPensjonService.hentHistoriskPensjon(any(), any()) } returns
-            HistoriskPensjonResponse(false, "")
+            HistoriskPensjonDto(HistoriskPensjonStatus.HAR_IKKE_HISTORIKK, "")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClientTest.kt
@@ -1,0 +1,109 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.apache.hc.core5.http.ContentType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestOperations
+import java.net.URI
+
+class HistoriskPensjonClientTest {
+    companion object {
+        val server: WireMockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+        private val restOperations: RestOperations = RestTemplateBuilder().build()
+        lateinit var client: HistoriskPensjonClient
+
+        @BeforeAll
+        @JvmStatic
+        fun start() {
+            server.start()
+            client = HistoriskPensjonClient(URI.create(server.baseUrl()), restOperations)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun stop() {
+            server.stop()
+        }
+    }
+
+    @BeforeEach
+    fun configure() {
+        WireMock.configureFor(server.port())
+    }
+
+    @Test
+    fun `skal hente historisk pensjon status for person med historikk`() {
+        WireMock.stubFor(
+            queryForHistoriskPensjonForIdent.willReturn(
+                WireMock.aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.mimeType)
+                    .withBody(harHistoriskPensjonRespons),
+            ),
+        )
+
+        val response = client.hentHistoriskPensjonStatusForIdent("123456789", emptySet())
+        assertThat(response).isNotNull
+        assertThat(response.webAppUrl).isNotNull
+        assertThat(response.historiskPensjonStatus).isEqualTo(HistoriskPensjonStatus.HAR_HISTORIKK)
+    }
+
+    @Test
+    fun `skal hente historisk pensjon status med ukjent verdi dersom kallet feiler`() {
+        WireMock.stubFor(
+            queryForHistoriskPensjonForIdent.willReturn(
+                WireMock.aResponse()
+                    .withStatus(HttpStatus.INTERNAL_SERVER_ERROR.value()),
+            ),
+        )
+
+        val response = client.hentHistoriskPensjonStatusForIdent("123456789", emptySet())
+        assertThat(response).isNotNull
+        assertThat(response.webAppUrl).isNull()
+        assertThat(response.historiskPensjonStatus).isEqualTo(HistoriskPensjonStatus.UKJENT)
+    }
+
+    @Test
+    fun `skal hente historisk pensjon status for person uten historikk`() {
+        WireMock.stubFor(
+            queryForHistoriskPensjonForIdent.willReturn(
+                WireMock.aResponse()
+                    .withStatus(HttpStatus.OK.value())
+                    .withHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.mimeType)
+                    .withBody(harIkkeHistoriskPensjonRespons),
+            ),
+        )
+
+        val response = client.hentHistoriskPensjonStatusForIdent("123456789", emptySet())
+        assertThat(response).isNotNull
+        assertThat(response.webAppUrl).isNotNull
+        assertThat(response.historiskPensjonStatus).isEqualTo(HistoriskPensjonStatus.HAR_IKKE_HISTORIKK)
+    }
+
+    private val queryForHistoriskPensjonForIdent: MappingBuilder = WireMock.post(WireMock.urlPathEqualTo("/api/ensligForsoerger/harPensjonsdata"))
+
+    private val harHistoriskPensjonRespons =
+        """  
+        {
+          "harPensjonsdata": true,
+          "webAppUrl": "http://historisk-pensjon.nav.no/abc"
+        }
+    """
+    private val harIkkeHistoriskPensjonRespons =
+        """  
+        {
+          "harPensjonsdata": false,
+          "webAppUrl": "http://historisk-pensjon.nav.no/abc"
+        }
+    """
+}


### PR DESCRIPTION
…og henter ut info om stønadshistorikk for personer

### Hvorfor er denne endringen nødvendig? ✨

Ønsker å ikke "krasje" behandlingsløpet dersom historisk pensjon er nede eller utilgjengelig. Error-logging vil fange opp dette og sørge for at vi kan si ifra om nedetid. 