### PR TITLE
Skal gi fornuftig feilmelding dersom man beregner en behandling uten …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.beregning
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -11,6 +12,7 @@ import no.nav.familie.ef.sak.vedtak.dto.tilPerioder
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -50,7 +52,7 @@ class BeregningController(
         @PathVariable behandlingId: UUID,
     ): Ressurs<List<Beløpsperiode>> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        val vedtakForBehandling = vedtakService.hentVedtak(behandlingId)
+        val vedtakForBehandling = vedtakService.hentVedtakHvisEksisterer(behandlingId) ?: throw ApiFeil("Vedtak for behandling=$behandlingId finnes ikke", HttpStatus.BAD_REQUEST)
         if (vedtakForBehandling.resultatType === ResultatType.OPPHØRT) {
             throw Feil("Kan ikke vise fremtidige beløpsperioder for opphørt vedtak med id=$behandlingId")
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -116,7 +116,7 @@ class VedtakController(
         @PathVariable behandlingId: UUID,
     ): Ressurs<VedtakDto?> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(vedtakService.hentVedtakHvisEksisterer(behandlingId))
+        return Ressurs.success(vedtakService.hentVedtakDtoHvisEksisterer(behandlingId))
     }
 
     @GetMapping("fagsak/{fagsakId}/historikk/{fra}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakService.kt
@@ -36,6 +36,10 @@ class VedtakService(
         return vedtakRepository.findByIdOrThrow(behandlingId)
     }
 
+    fun hentVedtakHvisEksisterer(behandlingId: UUID): Vedtak? {
+        return vedtakRepository.findByIdOrNull(behandlingId)
+    }
+
     fun hentVedtaksresultat(behandlingId: UUID): ResultatType {
         return hentVedtak(behandlingId).resultatType
     }
@@ -45,10 +49,10 @@ class VedtakService(
     }
 
     fun hentVedtakDto(behandlingId: UUID): VedtakDto {
-        return hentVedtakHvisEksisterer(behandlingId) ?: error("Finner ikke vedtak for behandling=$behandlingId")
+        return hentVedtakDtoHvisEksisterer(behandlingId) ?: error("Finner ikke vedtak for behandling=$behandlingId")
     }
 
-    fun hentVedtakHvisEksisterer(behandlingId: UUID): VedtakDto? {
+    fun hentVedtakDtoHvisEksisterer(behandlingId: UUID): VedtakDto? {
         return vedtakRepository.findByIdOrNull(behandlingId)?.tilVedtakDto()
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerTest.kt
@@ -38,12 +38,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.web.client.exchange
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.UUID
-import org.springframework.http.HttpStatus
 
 class BeregningControllerTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -142,7 +142,6 @@ class BeregningControllerTest : OppslagSpringRunnerTest() {
         assertThat(beløpsperioderRevurdering?.first()?.deprecatedPeriode?.tildato).isEqualTo(LocalDate.of(2022, 6, 30))
         assertThat(beløpsperioderRevurdering?.first()?.beløp).isEqualTo(BigDecimal(12_000))
     }
-
 
     @Test
     internal fun `Skal kaste feil og returnere 400 dersom behandlingen ikke har et vedtak`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
@@ -57,7 +57,7 @@ internal class BeregningControllerUnitTest {
 
     @Test
     internal fun `skal kaste feil dersom vedtak har resultattypen OPPHØRT`() {
-        every { vedtakService.hentVedtak(any()) } returns
+        every { vedtakService.hentVedtakHvisEksisterer(any()) } returns
             Vedtak(
                 behandlingId = UUID.randomUUID(),
                 resultatType = ResultatType.OPPHØRT,

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/VedtakServiceTest.kt
@@ -123,7 +123,7 @@ internal class VedtakServiceTest : OppslagSpringRunnerTest() {
 
         vedtakService.lagreVedtak(vedtakDto, behandling.id, fagsak.stønadstype)
 
-        assertThat(vedtakService.hentVedtakHvisEksisterer(behandling.id)).usingRecursiveComparison().isEqualTo(vedtakDto)
+        assertThat(vedtakService.hentVedtakDtoHvisEksisterer(behandling.id)).usingRecursiveComparison().isEqualTo(vedtakDto)
     }
 
     @Test


### PR DESCRIPTION
…et vedtak. Dette skjer når man må nulle ut et vedtak etter å ha tatt en behandling av vent.

### Hvorfor er denne endringen nødvendig? ✨
En del støy i loggene pga 500-feil i disse situasjonene. Tenker 400 Bad Request er mer meningsbærende. Saksbehandler opplever ikke feilen. 