### PR TITLE
Endepunkt for sjekk på om det finnes flere tilbakekrevinger siste året ved feilutbetalinger under 4x rettsgebyr

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
@@ -54,6 +54,13 @@ class TilbakekrevingController(
         return Ressurs.success(tilbakekrevingService.finnesÅpenTilbakekrevingsBehandling(behandlingId))
     }
 
+    @GetMapping("/{behandlingId}/finnesFlereTilbakekrevingerValgtSisteÅr")
+    fun finnesFlereTilbakekrevingerValgtSisteÅr(
+        @PathVariable behandlingId: UUID,
+    ): Ressurs<Boolean> {
+        return Ressurs.success(tilbakekrevingService.finnesFlereTilbakekrevingerValgtSisteÅr(behandlingId))
+    }
+
     @GetMapping("/{behandlingId}")
     fun hentTilbakekreving(
         @PathVariable behandlingId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
@@ -58,6 +58,8 @@ class TilbakekrevingController(
     fun finnesFlereTilbakekrevingerValgtSisteÅr(
         @PathVariable behandlingId: UUID,
     ): Ressurs<Boolean> {
+        tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
+        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(tilbakekrevingService.finnesFlereTilbakekrevingerValgtSisteÅr(behandlingId))
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
@@ -20,6 +20,7 @@ interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, 
                 AND t.valg = 'OPPRETT_AUTOMATISK'
                 AND b.status = 'FERDIGSTILT' 
                 AND b.resultat NOT IN ('HENLAGT', 'AVSLÅTT')
+                AND b.vedtakstidspunkt > :etterTidspunkt
                 ;
          """,
     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
@@ -10,7 +10,6 @@ import java.util.UUID
 
 @Repository
 interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, InsertUpdateRepository<Tilbakekreving> {
-
     // language=PostgreSQL
     @Query(
         """SELECT COUNT(*) from behandling b
@@ -23,5 +22,8 @@ interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, 
                 AND b.vedtakstidspunkt > :etterTidspunkt;
          """,
     )
-    fun finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(personIdent: String, etterTidspunkt: LocalDate): Int
+    fun finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(
+        personIdent: String,
+        etterTidspunkt: LocalDate,
+    ): Int
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
@@ -3,8 +3,25 @@ package no.nav.familie.ef.sak.tilbakekreving
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
 import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekreving
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.util.UUID
 
 @Repository
-interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, InsertUpdateRepository<Tilbakekreving>
+interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, InsertUpdateRepository<Tilbakekreving> {
+
+    // language=PostgreSQL
+    @Query(
+        """SELECT COUNT(*) from behandling b
+                JOIN fagsak f on b.fagsak_id = f.id
+                JOIN person_ident pi ON pi.fagsak_person_id = f.fagsak_person_id
+                JOIN tilbakekreving t ON t.behandling_id = b.id
+            WHERE pi.ident = :personIdent 
+                AND b.status = 'FERDIGSTILT' 
+                AND b.resultat NOT IN ('HENLAGT', 'AVSLÅTT')
+                AND b.vedtakstidspunkt > :etterTidspunkt;
+         """,
+    )
+    fun finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(personIdent: String, etterTidspunkt: LocalDate): Int
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepository.kt
@@ -17,9 +17,10 @@ interface TilbakekrevingRepository : RepositoryInterface<Tilbakekreving, UUID>, 
                 JOIN person_ident pi ON pi.fagsak_person_id = f.fagsak_person_id
                 JOIN tilbakekreving t ON t.behandling_id = b.id
             WHERE pi.ident = :personIdent 
+                AND t.valg = 'OPPRETT_AUTOMATISK'
                 AND b.status = 'FERDIGSTILT' 
                 AND b.resultat NOT IN ('HENLAGT', 'AVSLÅTT')
-                AND b.vedtakstidspunkt > :etterTidspunkt;
+                ;
          """,
     )
     fun finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
@@ -29,6 +29,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling as TilbakekrevingBehandling
 
@@ -160,5 +161,12 @@ class TilbakekrevingService(
         behandlingService.hentBehandlingPåEksternId(kravgrunnlagsreferanse.toLong())
 
         tilbakekrevingClient.opprettManuellTilbakekreving(fagsak.eksternId, kravgrunnlagsreferanse, fagsak.stønadstype)
+    }
+
+    fun finnesFlereTilbakekrevingerValgtSisteÅr(behandlingId: UUID): Boolean {
+        val ident = behandlingService.hentAktivIdent(behandlingId)
+        val ettÅrTilbake = LocalDate.now().minusYears(1)
+        val antall = tilbakekrevingRepository.finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(ident, ettÅrTilbake)
+        return antall > 1
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingService.kt
@@ -29,7 +29,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
-import java.time.ZoneOffset
 import java.util.UUID
 import no.nav.familie.kontrakter.felles.tilbakekreving.Behandling as TilbakekrevingBehandling
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/PdlClientConfig.kt
@@ -137,6 +137,14 @@ class PdlClientConfig {
                 ),
             )
 
+        every { pdlClient.hentIdenterBolk(listOf("222", "111")) }
+            .returns(
+                mapOf(
+                    "111" to PdlIdent("222", false),
+                    "222" to PdlIdent("111", false),
+                ),
+            )
+
         return pdlClient
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/FagsakServiceTest.kt
@@ -76,7 +76,7 @@ internal class FagsakServiceTest : OppslagSpringRunnerTest() {
         }
 
         @Test
-        fun `skal returnere fagsaker med eksiterende peronIdent når det ikke finnes ny ident i pdl`() {
+        fun `skal returnere fagsaker med eksisterende peronIdent når det ikke finnes ny ident i pdl`() {
             val fagsakerMedOppdatertePersonIdenter =
                 fagsakService.fagsakerMedOppdatertePersonIdenter(
                     listOf(

--- a/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingRepositoryTest.kt
@@ -1,0 +1,82 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.tilbakekreving
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.fagsak.FagsakPersonRepository
+import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakPerson
+import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingRepository
+import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekreving
+import no.nav.familie.ef.sak.tilbakekreving.domain.Tilbakekrevingsvalg
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class TilbakekrevingRepositoryTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var tilbakekrevingRepository: TilbakekrevingRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var fagsakPersonRepository: FagsakPersonRepository
+
+    val forrigeÅr = LocalDate.now().minusYears(1)
+    val personIdent = "01010199999"
+
+    @Test
+    internal fun `finn tidligere tilbakekrevinger for bruker - skal finne for både OS og BT`() {
+        val fagsakPerson = fagsakPerson(identer = setOf(PersonIdent(personIdent)))
+        fagsakPersonRepository.insert(fagsakPerson)
+        val fagsakOS = fagsak(person = fagsakPerson)
+        testoppsettService.lagreFagsak(fagsakOS)
+        val fagsakBT = fagsak(stønadstype = StønadType.BARNETILSYN, person = fagsakPerson)
+        testoppsettService.lagreFagsak(fagsakBT)
+        val behandlingOS = behandlingRepository.insert(behandling(fagsakOS, BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET, vedtakstidspunkt = LocalDateTime.now()))
+        val behandlingBT = behandlingRepository.insert(behandling(fagsakBT, BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET, vedtakstidspunkt = LocalDateTime.now().minusMonths(11)))
+
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingOS.id, Tilbakekrevingsvalg.OPPRETT_AUTOMATISK, "varseltekst", "begrunnelse"))
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingBT.id, Tilbakekrevingsvalg.OPPRETT_AUTOMATISK, "varseltekst", "begrunnelse"))
+
+        val antallAutomatiskBehandledeTilbakekrevinger = tilbakekrevingRepository.finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(fagsakOS.hentAktivIdent(), forrigeÅr)
+        assertThat(antallAutomatiskBehandledeTilbakekrevinger).isEqualTo(2)
+    }
+
+    @Test
+    internal fun `finn tidligere tilbakekrevinger for bruker - ingen treff`() {
+        val fagsakPerson = fagsakPerson(identer = setOf(PersonIdent(personIdent)))
+        val fagsakPersonUtenforSøk = fagsakPerson(identer = setOf(PersonIdent("02020288888")))
+
+        val fagsakOS = fagsak(person = fagsakPerson)
+        val fagsakBT = fagsak(stønadstype = StønadType.BARNETILSYN, person = fagsakPerson)
+        val fagsakForPersonUtenforSøk = fagsak(person = fagsakPersonUtenforSøk)
+
+        fagsakPersonRepository.insert(fagsakPerson)
+        fagsakPersonRepository.insert(fagsakPersonUtenforSøk)
+
+        testoppsettService.lagreFagsak(fagsakOS)
+        testoppsettService.lagreFagsak(fagsakBT)
+        testoppsettService.lagreFagsak(fagsakForPersonUtenforSøk)
+
+        val behandlingOS = behandlingRepository.insert(behandling(fagsakOS, BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET, vedtakstidspunkt = LocalDateTime.now()))
+        val behandlingBT = behandlingRepository.insert(behandling(fagsakBT, BehandlingStatus.UTREDES, resultat = BehandlingResultat.INNVILGET)) // Må være Ferdigstilt for treff
+        val behandlingOS2 = behandlingRepository.insert(behandling(fagsakOS, BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.HENLAGT)) // Kan ikke være henlagt eller avslått for treff
+        val behandlingOS3 = behandlingRepository.insert(behandling(fagsakForPersonUtenforSøk, BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET)) // Annet fnr skal ikke gi treff
+
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingOS.id, Tilbakekrevingsvalg.OPPRETT_MED_VARSEL, "varseltekst", "begrunnelse")) // Må være opprett Automatisk for treff
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingBT.id, Tilbakekrevingsvalg.OPPRETT_AUTOMATISK, "varseltekst", "begrunnelse"))
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingOS2.id, Tilbakekrevingsvalg.OPPRETT_AUTOMATISK, "varseltekst", "begrunnelse"))
+        tilbakekrevingRepository.insert(Tilbakekreving(behandlingOS3.id, Tilbakekrevingsvalg.OPPRETT_AUTOMATISK, "varseltekst", "begrunnelse"))
+
+        val antallAutomatiskBehandledeTilbakekrevinger = tilbakekrevingRepository.finnAntallTilbakekrevingerValgtEtterGittDatoForPersonIdent(fagsakOS.hentAktivIdent(), forrigeÅr)
+        assertThat(antallAutomatiskBehandledeTilbakekrevinger).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig at det vises en warning dersom bruker har flere behandlinger som det er gjort et tilbakekrevingsvalg på det siste året, ved feilutbetalinger under 4x rettsgebyr, for å gi en heads-up til saksbehandler at det burde vurderes om behandlingen kan/burde behandles automatisk.

[Link til frontend-PR](https://github.com/navikt/familie-ef-sak-frontend/pull/2788)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20869)