### PR TITLE
Fjerner å fra url og gjør om til standard url format for ef-sak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
@@ -54,7 +54,7 @@ class TilbakekrevingController(
         return Ressurs.success(tilbakekrevingService.finnesÅpenTilbakekrevingsBehandling(behandlingId))
     }
 
-    @GetMapping("/{behandlingId}/finnesFlereTilbakekrevingerValgtSisteÅr")
+    @GetMapping("/{behandlingId}/finnes-flere-tilbakekrevinger-valgt-siste-aar")
     fun finnesFlereTilbakekrevingerValgtSisteÅr(
         @PathVariable behandlingId: UUID,
     ): Ressurs<Boolean> {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Får feil i prod om at ressurs/endepunkt ikke finnes: `api/tilbakekreving/behandlinger/2b4d7e04-67b4-401e-8ad1-42a43321e30c/finnesFlereTilbakekrevingerValgtSiste%C3%85r`
Antar at dette har noe å gjøre med å i url, så erstatter denne med aa. Bare litt rart at det virker i preprod.

Slack-tråd: https://nav-it.slack.com/archives/C033WGAFAQ1/p1718262462032289