### PR TITLE
skal kun tildelde oppgave til saksbehandler dersom saksbehandleren ik…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -182,12 +182,19 @@ class OppgaveService(
         gsakOppgaveId: Long,
         saksbehandler: String,
         versjon: Int? = null,
-    ): Long =
-        oppgaveClient.fordelOppgave(
-            gsakOppgaveId,
-            saksbehandler,
-            versjon,
-        )
+    ): Long {
+        val oppgave = hentOppgave(gsakOppgaveId)
+
+        return if (oppgave.tilordnetRessurs == saksbehandler) {
+            gsakOppgaveId
+        } else {
+            oppgaveClient.fordelOppgave(
+                gsakOppgaveId,
+                saksbehandler,
+                versjon,
+            )
+        }
+    }
 
     fun tilbakestillFordelingPåOppgave(
         gsakOppgaveId: Long,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -272,10 +272,22 @@ internal class OppgaveServiceTest {
 
         every { oppgaveClient.fordelOppgave(capture(oppgaveSlot), capture(saksbehandlerSlot)) } returns GSAK_OPPGAVE_ID
 
-        oppgaveService.fordelOppgave(GSAK_OPPGAVE_ID, SAKSBEHANDLER_ID)
+        val id = oppgaveService.fordelOppgave(GSAK_OPPGAVE_ID, SAKSBEHANDLER_ID)
 
         assertThat(GSAK_OPPGAVE_ID).isEqualTo(oppgaveSlot.captured)
         assertThat(SAKSBEHANDLER_ID).isEqualTo(saksbehandlerSlot.captured)
+        assertThat(id).isEqualTo(GSAK_OPPGAVE_ID)
+        verify(exactly = 1) { oppgaveClient.fordelOppgave(any(), any(), any()) }
+    }
+
+    @Test
+    fun `Fordel oppgave skal ikke tildele oppgave til saksbehandler dersom saksbehandler allerde er tildelt oppgaven`() {
+        every { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID) } returns lagEksternTestOppgave(SAKSBEHANDLER_ID)
+
+        val id = oppgaveService.fordelOppgave(GSAK_OPPGAVE_ID, SAKSBEHANDLER_ID)
+
+        assertThat(id).isEqualTo(GSAK_OPPGAVE_ID)
+        verify(exactly = 0) { oppgaveClient.fordelOppgave(any(), any(), any()) }
     }
 
     @Test
@@ -461,9 +473,9 @@ internal class OppgaveServiceTest {
 
     private fun lagTestOppgave(): Oppgave = Oppgave(behandlingId = BEHANDLING_ID, type = Oppgavetype.BehandleSak, gsakOppgaveId = GSAK_OPPGAVE_ID)
 
-    private fun lagEksternTestOppgave(): no.nav.familie.kontrakter.felles.oppgave.Oppgave =
+    private fun lagEksternTestOppgave(tilordnetRessurs: String? = null): no.nav.familie.kontrakter.felles.oppgave.Oppgave =
         no.nav.familie.kontrakter.felles.oppgave
-            .Oppgave(id = GSAK_OPPGAVE_ID)
+            .Oppgave(id = GSAK_OPPGAVE_ID, tilordnetRessurs = tilordnetRessurs)
 
     private fun lagFinnOppgaveResponseDto(): FinnOppgaveResponseDto =
         FinnOppgaveResponseDto(


### PR DESCRIPTION
…ke allerede er tildelt oppgaven

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21534)

Denne oppgaven legger til en sjekk før man fordeler oppgaver. Dersom saksbehandleren som prøver å ta oppgaven til seg allerede er tilordnet oppgaven, da skal man ikke gjøre tildelingen på nytt.