### PR TITLE
Hente godkjenne vedtak oppgaver

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -23,6 +23,7 @@ class FeatureToggleController(
             Toggle.FRONTEND_SATSENDRING,
             Toggle.FRONTEND_TILBAKEKREVING_UNDER_4X_RETTSGEBYR,
             Toggle.HENLEGG_BEHANDLING_UTEN_OPPGAVE,
+            Toggle.FRONTED_VIS_TILDEL_OPPGAVE_BEHANDLING,
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -43,6 +43,10 @@ enum class Toggle(
         "familie.ef.sak.automatiske-brev-innhenting-aktivitetsplikt",
         "Operational - sesongavhengig",
     ),
+    FRONTED_VIS_TILDEL_OPPGAVE_BEHANDLING(
+        "familie.ef.sak.frontend-tildel-oppgave-knapp",
+        "Operational - kun preprod",
+    ),
 
     // Permission
     MIGRERING_BARNETILSYN("familie.ef.sak.migrering.barnetilsyn", "Permission"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursService.kt
@@ -41,7 +41,7 @@ class TilordnetRessursService(
 
     fun hentIkkeFerdigstiltOppgaveForBehandling(
         behandlingId: UUID,
-        oppgavetyper: Set<Oppgavetype> = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak),
+        oppgavetyper: Set<Oppgavetype> = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak, Oppgavetype.GodkjenneVedtak),
     ): Oppgave? =
         hentEFOppgaveSomIkkeErFerdigstilt(behandlingId, oppgavetyper)
             ?.let { oppgaveClient.finnOppgaveMedId(it.gsakOppgaveId) }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
@@ -47,7 +47,7 @@ internal class TilordnetRessursServiceTest {
             every {
                 oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
                     any(),
-                    oppgaveTyper,
+                    oppgaveTyperMedGodkjenneVedtak,
                 )
             } answers { efOppgave(firstArg<UUID>()) }
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()) }
@@ -64,7 +64,7 @@ internal class TilordnetRessursServiceTest {
             every {
                 oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
                     any(),
-                    oppgaveTyper,
+                    oppgaveTyperMedGodkjenneVedtak,
                 )
             } returns null
             every { oppgaveClient.finnOppgaveMedId(any()) } answers { oppgave(firstArg<Long>()) }
@@ -270,7 +270,8 @@ internal class TilordnetRessursServiceTest {
     )
 
     companion object {
-        private val oppgaveTyper = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak, Oppgavetype.GodkjenneVedtak)
+        private val oppgaveTyper = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak)
+        private val oppgaveTyperMedGodkjenneVedtak = oppgaveTyper + Oppgavetype.GodkjenneVedtak
 
         private val saksbehandler = Saksbehandler(UUID.randomUUID(), "Z999999", "Darth", "Vader", "4405")
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/TilordnetRessursServiceTest.kt
@@ -270,7 +270,7 @@ internal class TilordnetRessursServiceTest {
     )
 
     companion object {
-        private val oppgaveTyper = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak)
+        private val oppgaveTyper = setOf(Oppgavetype.BehandleSak, Oppgavetype.BehandleUnderkjentVedtak, Oppgavetype.GodkjenneVedtak)
 
         private val saksbehandler = Saksbehandler(UUID.randomUUID(), "Z999999", "Darth", "Vader", "4405")
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker at hentIkkeFerdigstiltOppgaveForBehandling også skal hente oppgaver hvis de er av typen GodkjenneVedtak slik at en oppgave kan tildeles fra behandling.

Lagt til feature toggle for å vise tildel oppgave på behandling