### PR TITLE
skal sende med samordningsfradragstype fra forrige vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -119,15 +119,6 @@ class VedtakController(
         return Ressurs.success(vedtakService.hentVedtakDtoHvisEksisterer(behandlingId))
     }
 
-    @GetMapping("fagsak/{fagsakId}/historikk/{fra}")
-    fun hentVedtak(
-        @PathVariable fagsakId: UUID,
-        @PathVariable fra: YearMonth,
-    ): Ressurs<InnvilgelseOvergangsstønad> {
-        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(vedtakHistorikkService.hentVedtakForOvergangsstønadFraDato(fagsakId, fra))
-    }
-
     @GetMapping("{behandlingId}/historikk/{fra}")
     fun hentVedtakForBehandling(
         @PathVariable behandlingId: UUID,

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -149,7 +149,7 @@ class StepDefinitions {
         )
 
     private val vedtakHistorikkService =
-        VedtakHistorikkService(fagsakService, andelsHistorikkService, barnService, mockFeatureToggleService())
+        VedtakHistorikkService(fagsakService, andelsHistorikkService, barnService, behandlingService, vedtakService)
 
     private lateinit var stønadstype: StønadType
     private val behandlingIdsToAktivitetArbeid = mutableMapOf<UUID, SvarId?>()
@@ -187,6 +187,7 @@ class StepDefinitions {
                 saksbehandlinger[behandlingId] ?: error("Finner ikke behandling=$behandlingId ($behandlingIdInt)")
             pair.second
         }
+        every { behandlingService.hentBehandling(any()) } answers { behandling() }
         every { vedtakService.hentVedtak(any()) } answers { lagredeVedtak.single { it.behandlingId == firstArg() } }
         justRun { barnService.validerBarnFinnesPåBehandling(any(), any()) }
         mockBarnRepository()
@@ -406,7 +407,7 @@ class StepDefinitions {
         saksbehandlinger = mapBehandlinger()
 
         if (stønadstype == StønadType.OVERGANGSSTØNAD) {
-            // Skriver over inntekt hvis inntekter er definiert
+            // Skriver over inntekt hvis inntekter er definert
             gittVedtak =
                 gittVedtak.map {
                     it.copy(inntekter = inntekter[it.behandlingId] ?: it.inntekter)

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/bisys/BisysBarnetilsynServiceTest.kt
@@ -464,6 +464,8 @@ fun lagAndelHistorikkDto(
     behandlingBarn: List<BehandlingBarn> = emptyList(),
     beløp: Int = 1,
     endring: HistorikkEndring? = null,
+    aktivitet: AktivitetType? = null,
+    periodeType: VedtaksperiodeType? = null,
 ): AndelHistorikkDto =
     AndelHistorikkDto(
         behandlingId = UUID.randomUUID(),
@@ -486,9 +488,9 @@ fun lagAndelHistorikkDto(
                 ),
                 null,
             ).copy(barn = behandlingBarn.map { it.id }),
-        aktivitet = null,
+        aktivitet = aktivitet,
         aktivitetArbeid = null,
-        periodeType = null,
+        periodeType = periodeType,
         erSanksjon = false,
         sanksjonsårsak = null,
         endring = endring,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -42,6 +42,7 @@ import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
 import no.nav.familie.ef.sak.vedtak.domain.KontantstøtteWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodetypeBarnetilsyn
+import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
 import no.nav.familie.ef.sak.vedtak.domain.TilleggsstønadWrapper
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
@@ -329,6 +330,7 @@ fun vedtak(
     år: Int = 2021,
     inntekter: InntektWrapper = InntektWrapper(listOf(inntektsperiode(år = år))),
     perioder: PeriodeWrapper = PeriodeWrapper(listOf(vedtaksperiode(år = år))),
+    samordningsfradragType: SamordningsfradragType? = null,
 ): Vedtak =
     Vedtak(
         behandlingId = behandlingId,
@@ -341,6 +343,7 @@ fun vedtak(
         saksbehandlerIdent = "VL",
         opprettetAv = "VL",
         opprettetTid = LocalDateTime.now(),
+        samordningsfradragType = samordningsfradragType,
     )
 
 fun vedtakBarnetilsyn(

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakHistorikkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/VedtakHistorikkServiceTest.kt
@@ -1,0 +1,101 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.vedtak
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.barn.BarnService
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingType
+import no.nav.familie.ef.sak.ekstern.bisys.lagAndelHistorikkDto
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.vedtak
+import no.nav.familie.ef.sak.tilkjentytelse.AndelsHistorikkService
+import no.nav.familie.ef.sak.vedtak.VedtakService
+import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
+import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
+import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
+import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
+import no.nav.familie.ef.sak.vedtak.dto.ResultatType
+import no.nav.familie.ef.sak.vedtak.dto.tilVedtak
+import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.YearMonth
+import kotlin.test.assertIs
+
+class VedtakHistorikkServiceTest {
+    private val fagsakService = mockk<FagsakService>()
+    private val andelsHistorikkService = mockk<AndelsHistorikkService>()
+    private val barnService = mockk<BarnService>()
+    private val behandlingService = mockk<BehandlingService>()
+    private val vedtakService = mockk<VedtakService>()
+
+    private val vedtakHistorikkService = VedtakHistorikkService(fagsakService, andelsHistorikkService, barnService, behandlingService, vedtakService)
+
+    @BeforeEach
+    internal fun setUp() {
+        every { andelsHistorikkService.hentHistorikk(any(), any()) } returns
+            listOf(lagAndelHistorikkDto(tilOgMed = LocalDate.of(2024, 12, 1), aktivitet = AktivitetType.BARN_UNDER_ETT_ÅR, periodeType = VedtaksperiodeType.HOVEDPERIODE))
+    }
+
+    @Test
+    internal fun `førstegangsbehandling, OS - skal sette null som samordningsfradragstype`() {
+        val fagsakOS = fagsak(stønadstype = StønadType.OVERGANGSSTØNAD)
+        val førstegangsbehandling = behandling(fagsakOS, type = BehandlingType.FØRSTEGANGSBEHANDLING, forrigeBehandlingId = null)
+
+        every { fagsakService.hentFagsakForBehandling(førstegangsbehandling.id) } returns fagsakOS
+        every { behandlingService.hentBehandling(førstegangsbehandling.id) } returns førstegangsbehandling
+
+        val vedtak = vedtakHistorikkService.hentVedtakFraDato(førstegangsbehandling.id, YearMonth.now())
+        assertThat(vedtak.resultatType).isEqualTo(ResultatType.INNVILGE)
+        assertThat(vedtak._type).isEqualTo("InnvilgelseOvergangsstønad")
+        assertIs<InnvilgelseOvergangsstønad>(vedtak)
+
+        val innvilgelse = vedtak.tilVedtak(førstegangsbehandling.id, StønadType.OVERGANGSSTØNAD)
+        assertThat(innvilgelse.samordningsfradragType).isNull()
+    }
+
+    @Test
+    internal fun `revurdering, OS - skal hente med samordningsfradragstype fra den forrige behandlingen`() {
+        val fagsakOS = fagsak(stønadstype = StønadType.OVERGANGSSTØNAD)
+        val førstegangsbehandling = behandling(fagsakOS, type = BehandlingType.FØRSTEGANGSBEHANDLING, forrigeBehandlingId = null)
+        val revurdering = behandling(fagsakOS, type = BehandlingType.REVURDERING, forrigeBehandlingId = førstegangsbehandling.id)
+        val førstegangsvedtak = vedtak(behandlingId = førstegangsbehandling.id, samordningsfradragType = SamordningsfradragType.UFØRETRYGD)
+
+        every { fagsakService.hentFagsakForBehandling(revurdering.id) } returns fagsakOS
+        every { behandlingService.hentBehandling(revurdering.id) } returns revurdering
+        every { vedtakService.hentVedtak(førstegangsbehandling.id) } returns førstegangsvedtak
+
+        val vedtak = vedtakHistorikkService.hentVedtakFraDato(revurdering.id, YearMonth.now())
+        assertThat(vedtak.resultatType).isEqualTo(ResultatType.INNVILGE)
+        assertThat(vedtak._type).isEqualTo("InnvilgelseOvergangsstønad")
+        assertIs<InnvilgelseOvergangsstønad>(vedtak)
+
+        val innvilgelse = vedtak.tilVedtak(revurdering.id, StønadType.OVERGANGSSTØNAD)
+        assertThat(innvilgelse.samordningsfradragType).isEqualTo(SamordningsfradragType.UFØRETRYGD)
+    }
+
+    @Test
+    internal fun `revurdering, OS - skal hente null som samordningsfradragstype fra den forrige behandlingen`() {
+        val fagsakOS = fagsak(stønadstype = StønadType.OVERGANGSSTØNAD)
+        val førstegangsbehandling = behandling(fagsakOS, type = BehandlingType.FØRSTEGANGSBEHANDLING, forrigeBehandlingId = null)
+        val revurdering = behandling(fagsakOS, type = BehandlingType.REVURDERING, forrigeBehandlingId = førstegangsbehandling.id)
+        val førstegangsvedtak = vedtak(behandlingId = førstegangsbehandling.id, samordningsfradragType = null)
+
+        every { fagsakService.hentFagsakForBehandling(revurdering.id) } returns fagsakOS
+        every { behandlingService.hentBehandling(revurdering.id) } returns revurdering
+        every { vedtakService.hentVedtak(førstegangsbehandling.id) } returns førstegangsvedtak
+
+        val vedtak = vedtakHistorikkService.hentVedtakFraDato(revurdering.id, YearMonth.now())
+        assertThat(vedtak.resultatType).isEqualTo(ResultatType.INNVILGE)
+        assertThat(vedtak._type).isEqualTo("InnvilgelseOvergangsstønad")
+        assertIs<InnvilgelseOvergangsstønad>(vedtak)
+
+        val innvilgelse = vedtak.tilVedtak(revurdering.id, StønadType.OVERGANGSSTØNAD)
+        assertThat(innvilgelse.samordningsfradragType).isEqualTo(null)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12388)
Ønsker å sende med samordningsfradragstypen fra det forrige vedtaket på vedtak-og-beregning siden. Venter med å merge denne til i kveld siden sletting av endepunktet i vedtakscontrolleren er en breaking change
