### PR TITLE
presiserer logging for åpne behandlinger uten tilhørende oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -55,9 +55,9 @@ class BehandlingsoppgaveService(
     }
 
     private fun loggManglerOppgave(fagsakerMedÅpenBehandlingSomManglerOppgave: List<String>) {
-        logger.info("Fagsak med åpen behandling uten oppgave antall ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
+        logger.info("Antall fagsaker med åpen behandling uten tilhørende oppgave: ${fagsakerMedÅpenBehandlingSomManglerOppgave.size}")
         fagsakerMedÅpenBehandlingSomManglerOppgave.forEach {
-            logger.warn("Fagsaker med åpen behandling uten oppgave: $it")
+            logger.warn("Ekstern-fagsak-id for fagsak med åpen behandling uten tilhørende oppgave: $it")
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Synes ikke loggingen var helt entydig på hvilken id som ble skrevet ut, så presiserte teksten litt :) 