### PR TITLE
ekspanderer fagsakperson/utvidet endepunktet slik at det kan fjernes …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonController.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.fagsak
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.dto.FagsakPersonDto
-import no.nav.familie.ef.sak.fagsak.dto.FagsakPersonUtvidetDto
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
 import no.nav.familie.ef.sak.felles.util.FnrUtil.validerIdent
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
@@ -39,9 +38,9 @@ class FagsakPersonController(
         return Ressurs.success(
             FagsakPersonDto(
                 person.id,
-                overgangsstønad = fagsaker.overgangsstønad?.id,
-                barnetilsyn = fagsaker.barnetilsyn?.id,
-                skolepenger = fagsaker.skolepenger?.id,
+                overgangsstønad = fagsaker.overgangsstønad?.let { fagsakService.fagsakTilDto(it) },
+                barnetilsyn = fagsaker.barnetilsyn?.let { fagsakService.fagsakTilDto(it) },
+                skolepenger = fagsaker.skolepenger?.let { fagsakService.fagsakTilDto(it) },
             ),
         )
     }
@@ -49,12 +48,12 @@ class FagsakPersonController(
     @GetMapping("{fagsakPersonId}/utvidet")
     fun hentFagsakPersonUtvidet(
         @PathVariable fagsakPersonId: UUID,
-    ): Ressurs<FagsakPersonUtvidetDto> {
+    ): Ressurs<FagsakPersonDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val person = fagsakPersonService.hentPerson(fagsakPersonId)
         val fagsaker = fagsakService.finnFagsakerForFagsakPersonId(person.id)
         return Ressurs.success(
-            FagsakPersonUtvidetDto(
+            FagsakPersonDto(
                 person.id,
                 overgangsstønad = fagsaker.overgangsstønad?.let { fagsakService.fagsakTilDto(it) },
                 barnetilsyn = fagsaker.barnetilsyn?.let { fagsakService.fagsakTilDto(it) },

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/FagsakPersonDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/FagsakPersonDto.kt
@@ -4,16 +4,6 @@ import java.util.UUID
 
 class FagsakPersonDto(
     val id: UUID,
-    val overgangsstønad: UUID?,
-    val barnetilsyn: UUID?,
-    val skolepenger: UUID?,
-)
-
-/**
- * Inneholder id til fagsakPerson samt de ulike fagsakene til personen for å kunne vise opp på behandlingsoversikten
- */
-class FagsakPersonUtvidetDto(
-    val id: UUID,
     val overgangsstønad: FagsakDto?,
     val barnetilsyn: FagsakDto?,
     val skolepenger: FagsakDto?,

--- a/src/test/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/fagsak/FagsakPersonControllerTest.kt
@@ -23,7 +23,7 @@ internal class FagsakPersonControllerTest : OppslagSpringRunnerTest() {
         val barnetilsyn = testoppsettService.lagreFagsak(fagsak(person = person, stønadstype = StønadType.BARNETILSYN))
         val skolepenger = testoppsettService.lagreFagsak(fagsak(person = person, stønadstype = StønadType.SKOLEPENGER))
 
-        val fagsakPersonDto = testWithBrukerContext { fagsakPersonController.hentFagsakPersonUtvidet(person.id).getDataOrThrow() }
+        val fagsakPersonDto = testWithBrukerContext { fagsakPersonController.hentFagsakPerson(person.id).getDataOrThrow() }
 
         assertThat(fagsakPersonDto.overgangsstønad?.id).isEqualTo(overgangsstønad.id)
         assertThat(fagsakPersonDto.barnetilsyn?.id).isEqualTo(barnetilsyn.id)


### PR DESCRIPTION
…i påfølgende PR

### Hvorfor er denne endringen nødvendig? ✨
Etter [denne PRen](https://github.com/navikt/familie-ef-sak-frontend/pull/2848) brukes ikke default endepunktet lenger i FagsakPersonControlleren. Har gjort et søk [her](https://github.com/search?q=org%3Anavikt+fagsak-person&type=code&p=1)

Tanken er å skru om frontend til å bruke default endepunktet slik at vi kan fjerne /utvidet endepunktet i en påfølgende PR.