### PR TITLE
Limit på 150 ved uthenting av oppgaver gjør at vi henter de 150 NYEST…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/FinnOppgaveRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/dto/FinnOppgaveRequestDto.kt
@@ -52,7 +52,7 @@ data class FinnOppgaveRequestDto(
             aktivFomDato = null,
             aktivTomDato = null,
             mappeId = this.mappeId,
-            limit = 150,
+            limit = null,
             offset = 0,
         )
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/FinnOppgaveRequestDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/FinnOppgaveRequestDtoTest.kt
@@ -42,7 +42,7 @@ internal class FinnOppgaveRequestDtoTest {
         Assertions.assertThat(finnOppgaveRequest.opprettetTomTidspunkt).isEqualTo(LocalDateTime.of(2020, 1, 3, 0, 0, 0))
         Assertions.assertThat(finnOppgaveRequest.fristFomDato).isEqualTo(LocalDate.of(2020, 1, 2))
         Assertions.assertThat(finnOppgaveRequest.fristTomDato).isEqualTo(LocalDate.of(2020, 1, 2))
-        Assertions.assertThat(finnOppgaveRequest.limit).isEqualTo(150)
+        Assertions.assertThat(finnOppgaveRequest.limit).isNull()
         Assertions.assertThat(finnOppgaveRequest.offset).isEqualTo(0)
         Assertions.assertThat(finnOppgaveRequest.mappeId).isEqualTo(1234L)
     }


### PR DESCRIPTION
…E oppgavene, men hvis saksbehandler skal bruke vår oppgavebenk må vi vise frem de eldste. Usikker på hvordan dette påvirker ytelse

### Hvorfor er denne endringen nødvendig? ✨