### PR TITLE
Det er ikke farlig om en sak har flere identer i infotrygd ved migrer…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -267,12 +267,8 @@ class InfotrygdPeriodeValideringService(
         personIdent: String,
     ) {
         sakerForOvergangsstønad.find { it.personIdent != personIdent }?.let {
-            throw MigreringException(
-                "Finnes sak med annen personIdent for personen. ${lagSakFeilinfo(it)} " +
-                    "personIdent=${it.personIdent}. " +
-                    "Disse sakene må oppdateres med aktivt fnr i Infotrygd",
-                MigreringExceptionType.FLERE_IDENTER,
-            )
+            logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd")
+            secureLogger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
@@ -400,8 +400,8 @@ internal class MigreringServiceTest : OppslagSpringRunnerTest() {
 
         val migreringInfo = migreringService.hentMigreringInfo(fagsak.fagsakPersonId)
 
-        assertThat(migreringInfo.kanMigreres).isFalse
-        assertThat(migreringInfo.årsak).contains("Finnes sak med annen personIdent for personen")
+        assertThat(migreringInfo.kanMigreres).isTrue
+        assertThat(migreringInfo.årsak).isNull()
     }
 
     @Test


### PR DESCRIPTION
…ing - det viktige er at oppdrag er oppdatert med nyeste, og da vil simuleringen feile dersom dette ikke samsvarer

### Hvorfor er denne endringen nødvendig? ✨