### PR TITLE
Log simuleringsresultat dersom det er ulikt simuleringsresultat i beslutter-steget

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingOppryddingService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -86,7 +87,13 @@ class SimuleringService(
     fun erSimuleringsoppsummeringEndret(saksbehandling: Saksbehandling): Boolean {
         val lagretSimuleringsoppsummering = hentLagretSimuleringsoppsummering(saksbehandling.id)
         val nySimuleringoppsummering = simulerMedTilkjentYtelse(saksbehandling).oppsummering
-        return lagretSimuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(nySimuleringoppsummering)
+        val harUlikEtterbetalingEllerFeilutbetaling = lagretSimuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(nySimuleringoppsummering)
+        if (harUlikEtterbetalingEllerFeilutbetaling) {
+            secureLogger.warn("Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
+                    "lagretSimuleringsoppsummering: $lagretSimuleringsoppsummering \n" +
+                    "nySimuleringoppsummering: $nySimuleringoppsummering")
+        }
+        return harUlikEtterbetalingEllerFeilutbetaling
     }
 
     private fun Simuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(simuleringOppsummering: Simuleringsoppsummering): Boolean = this.etterbetaling != simuleringOppsummering.etterbetaling || this.feilutbetaling != simuleringOppsummering.feilutbetaling

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -89,9 +89,11 @@ class SimuleringService(
         val nySimuleringoppsummering = simulerMedTilkjentYtelse(saksbehandling).oppsummering
         val harUlikEtterbetalingEllerFeilutbetaling = lagretSimuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(nySimuleringoppsummering)
         if (harUlikEtterbetalingEllerFeilutbetaling) {
-            secureLogger.warn("Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
+            secureLogger.warn(
+                "Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
                     "lagretSimuleringsoppsummering: $lagretSimuleringsoppsummering \n" +
-                    "nySimuleringoppsummering: $nySimuleringoppsummering")
+                    "nySimuleringoppsummering: $nySimuleringoppsummering",
+            )
         }
         return harUlikEtterbetalingEllerFeilutbetaling
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Debug feil i prod om at saksbehandlere får warning om ulik simuleringsresultat