### PR TITLE
Ikke ta med etterbetaling i sjekk på om simuleringsresultat er ulikt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingOppryddingService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -86,10 +87,17 @@ class SimuleringService(
     fun erSimuleringsoppsummeringEndret(saksbehandling: Saksbehandling): Boolean {
         val lagretSimuleringsoppsummering = hentLagretSimuleringsoppsummering(saksbehandling.id)
         val nySimuleringoppsummering = simulerMedTilkjentYtelse(saksbehandling).oppsummering
-        return lagretSimuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(nySimuleringoppsummering)
-    }
+        val ulikFeilutbetaling = lagretSimuleringsoppsummering.feilutbetaling != nySimuleringoppsummering.feilutbetaling
+        if (ulikFeilutbetaling) {
+            secureLogger.warn(
+                "Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
+                    "lagretSimuleringsoppsummering: $lagretSimuleringsoppsummering \n" +
+                    "nySimuleringoppsummering: $nySimuleringoppsummering",
+            )
+        }
 
-    private fun Simuleringsoppsummering.harUlikEtterbetalingEllerFeilutbetaling(simuleringOppsummering: Simuleringsoppsummering): Boolean = this.etterbetaling != simuleringOppsummering.etterbetaling || this.feilutbetaling != simuleringOppsummering.feilutbetaling
+        return ulikFeilutbetaling
+    }
 
     private fun simulerMedTilkjentYtelse(saksbehandling: Saksbehandling): BeriketSimuleringsresultat {
         val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(saksbehandling.id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -87,8 +87,8 @@ class SimuleringService(
     fun erSimuleringsoppsummeringEndret(saksbehandling: Saksbehandling): Boolean {
         val lagretSimuleringsoppsummering = hentLagretSimuleringsoppsummering(saksbehandling.id)
         val nySimuleringoppsummering = simulerMedTilkjentYtelse(saksbehandling).oppsummering
-        val ulikFeilutbetaling = lagretSimuleringsoppsummering.feilutbetaling != nySimuleringoppsummering.feilutbetaling
-        if (ulikFeilutbetaling) {
+        val harUlikFeilutbetaling = lagretSimuleringsoppsummering.feilutbetaling != nySimuleringoppsummering.feilutbetaling
+        if (harUlikFeilutbetaling) {
             secureLogger.warn(
                 "Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
                     "lagretSimuleringsoppsummering: $lagretSimuleringsoppsummering \n" +
@@ -96,7 +96,7 @@ class SimuleringService(
             )
         }
 
-        return ulikFeilutbetaling
+        return harUlikFeilutbetaling
     }
 
     private fun simulerMedTilkjentYtelse(saksbehandling: Saksbehandling): BeriketSimuleringsresultat {

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringControllerTest.kt
@@ -61,26 +61,6 @@ internal class SimuleringControllerTest {
     }
 
     @Test
-    internal fun `simuleringsoppsummering skal være endret hvis etterbetaling har endret seg fra nedlagret simulering`() {
-        val lagretSimuleringoppsummering = lagSimuleringoppsummering()
-        val simuleringOppsummering = lagSimuleringoppsummering(etterbetaling = BigDecimal.ONE)
-
-        every { simuleringService.hentLagretSimmuleringsresultat(any()) } returns
-            BeriketSimuleringsresultat(
-                DetaljertSimuleringResultat(emptyList()),
-                lagretSimuleringoppsummering,
-            )
-        every { iverksettClient.simuler(any()) } returns
-            BeriketSimuleringsresultat(
-                DetaljertSimuleringResultat(emptyList()),
-                simuleringOppsummering,
-            )
-
-        val response: Ressurs<Boolean> = controller.erSimuleringsoppsummeringEndret(behandlingId)
-        assertThat(response.data).isTrue()
-    }
-
-    @Test
     internal fun `simuleringsoppsummering skal være endret hvis feilutbetaling har endret seg fra nedlagret simulering`() {
         val lagretSimuleringoppsummering = lagSimuleringoppsummering()
         val simuleringOppsummering = lagSimuleringoppsummering(feilutbetaling = BigDecimal.ONE)

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/SimuleringServiceTest.kt
@@ -171,17 +171,6 @@ internal class SimuleringServiceTest {
     }
 
     @Test
-    internal fun `erSimuleringsoppsummeringEndret - skal returnere true for ulik etterbetaling`() {
-        val saksbehandling = saksbehandling()
-        val lagretSimuleringsoppsummering = mockSimuleringsoppsummering(BigDecimal.TEN, BigDecimal.ZERO)
-        val nySimuleringsoppsummering = mockSimuleringsoppsummering(BigDecimal.ONE, BigDecimal.ZERO)
-
-        mockErSimuleringsoppsummeringEndret(lagretSimuleringsoppsummering, nySimuleringsoppsummering)
-
-        assertTrue { simuleringService.erSimuleringsoppsummeringEndret(saksbehandling) }
-    }
-
-    @Test
     internal fun `erSimuleringsoppsummeringEndret - skal returnere true for ulik feilutbetaling`() {
         val saksbehandling = saksbehandling()
         val lagretSimuleringsoppsummering = mockSimuleringsoppsummering(BigDecimal.TEN, BigDecimal.ONE)


### PR DESCRIPTION
Dette blir feil rundt utbetalingsdato for gjeldende måned. Det som var en vanlig ny utbetaling blir i ny simulering en etterbetaling
