### PR TITLE
Validering av tier - kan ikke være null

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -37,6 +37,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14 # IF This is changed, all data will be lost. Read on nais.io how to upgrade
+        tier: db-f1-micro
         diskAutoresize: true
         cascadingDelete: false
         highAvailability: false


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨


Endringer i nais-validering av sqlInstances config. Feilmelding ved deploy (preprod) 
Error: Status: failure: nais.io/v1alpha1, Kind=Application, Namespace=teamfamilie, Name=familie-ef-sak: updating resource: Application.nais.io "familie-ef-sak" is invalid: [spec.gcp.sqlInstances[0].tier: Required value, : Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation] (total of 1 errors)

Setter til tidligere defaultverdi: db-f1-micro