### PR TITLE
Fix seks g per mnd

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
@@ -73,7 +73,7 @@ object Grunnbeløpsperioder {
             Grunnbeløp(
                 periode = Månedsperiode(YearMonth.parse("2024-05"), YearMonth.from(LocalDate.MAX)),
                 grunnbeløp = 124_028.toBigDecimal(),
-                perMnd = 10_335.toBigDecimal(),
+                perMnd = 10_336.toBigDecimal(),
                 gjennomsnittPerÅr = 122_225.toBigDecimal(),
             ),
             Grunnbeløp(

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.erSammenhengende
 import no.nav.familie.kontrakter.felles.harOverlappende
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 @Service
 class BeregningService {
@@ -84,9 +85,9 @@ class BeregningService {
     fun grunnbeløpsperiodeDTO(grunnbeløpParameter: Grunnbeløp): GrunnbeløpDTO {
         val periode = grunnbeløpParameter.periode
         val grunnbeløp = grunnbeløpParameter.grunnbeløp
-        val grunnbeløpMåned = grunnbeløpParameter.perMnd
-        val seksGangerGrunnbeløp = 6.toBigDecimal() * grunnbeløp
-        val seksGangerGrunnbeløpPerMåned = 6.toBigDecimal() * grunnbeløpMåned
+        val grunnbeløpMåned = grunnbeløp.divide(BigDecimal(12), 10, RoundingMode.HALF_UP)
+        val seksGangerGrunnbeløp = grunnbeløp.multiply(BigDecimal(6)).setScale(0, RoundingMode.HALF_UP)
+        val seksGangerGrunnbeløpPerMåned = grunnbeløpMåned.multiply(BigDecimal(6)).setScale(0, RoundingMode.HALF_UP)
         return GrunnbeløpDTO(
             periode = periode,
             grunnbeløp = grunnbeløp,

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -429,8 +429,8 @@ internal class BeregningServiceTest {
             )
         val grunnbeløpsperiodeDTO = beregningService.grunnbeløpsperiodeDTO(grunnbeløp)
 
-        val korrektSeksGrunnbeløpPerMnd = 62014.toBigDecimal()
+        val korrektSeksGangerGrunnbeløpPerMåned = 62014.toBigDecimal()
 
-        Assertions.assertEquals(korrektSeksGrunnbeløpPerMnd, grunnbeløpsperiodeDTO.seksGangerGrunnbeløpPerMåned)
+        Assertions.assertEquals(korrektSeksGangerGrunnbeløpPerMåned, grunnbeløpsperiodeDTO.seksGangerGrunnbeløpPerMåned)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.beregning
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
@@ -415,5 +416,21 @@ internal class BeregningServiceTest {
                 vedtaksperioder = vedtakperioder,
             )
         }
+    }
+
+    @Test
+    fun `grunnbeløpsperiodeDTO skal returnere korrekt grunnbeløp`() {
+        val G = 124028.toBigDecimal()
+        val grunnbeløp =
+            Grunnbeløp(
+                periode = Månedsperiode(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30)),
+                grunnbeløp = G,
+                perMnd = 10335.toBigDecimal(), // G 124028/12 = 10335.6666667
+            )
+        val grunnbeløpsperiodeDTO = beregningService.grunnbeløpsperiodeDTO(grunnbeløp)
+
+        val korrektSeksGrunnbeløpPerMnd = 62014.toBigDecimal()
+
+        Assertions.assertEquals(korrektSeksGrunnbeløpPerMnd, grunnbeløpsperiodeDTO.seksGangerGrunnbeløpPerMåned)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -420,12 +420,11 @@ internal class BeregningServiceTest {
 
     @Test
     fun `grunnbeløpsperiodeDTO skal returnere korrekt seks ganger grunnbeløp per måned`() {
-        val g = 124028.toBigDecimal()
         val grunnbeløp =
             Grunnbeløp(
                 periode = Månedsperiode(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30)),
-                grunnbeløp = g,
-                perMnd = 10335.toBigDecimal(), // G 124028/12 = 10335.6666667
+                grunnbeløp = 124028.toBigDecimal(),
+                perMnd = 10336.toBigDecimal(),
             )
         val grunnbeløpsperiodeDTO = beregningService.grunnbeløpsperiodeDTO(grunnbeløp)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -419,12 +419,12 @@ internal class BeregningServiceTest {
     }
 
     @Test
-    fun `grunnbeløpsperiodeDTO skal returnere korrekt grunnbeløp`() {
-        val G = 124028.toBigDecimal()
+    fun `grunnbeløpsperiodeDTO skal returnere korrekt seks ganger grunnbeløp per måned`() {
+        val g = 124028.toBigDecimal()
         val grunnbeløp =
             Grunnbeløp(
                 periode = Månedsperiode(LocalDate.of(2024, 5, 1), LocalDate.of(2025, 4, 30)),
-                grunnbeløp = G,
+                grunnbeløp = g,
                 perMnd = 10335.toBigDecimal(), // G 124028/12 = 10335.6666667
             )
         val grunnbeløpsperiodeDTO = beregningService.grunnbeløpsperiodeDTO(grunnbeløp)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Bruker ikke perMnd fra grunnbeløp for å gjøre utregning av seksGangerGrunnbeløpPerMåned da det kan bli feil utregning når beløpet er rundet ned. Gjør derfor utregning på grunnbeløp.