### PR TITLE
Vil legge til forvaltningsendepunkt for å kunne opprette oppgaver på …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
@@ -43,7 +43,7 @@ class GjennoprettOppgavePåBehandlingTask(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     override fun doTask(task: Task) {
-        logger.info("Henter oppgave for behandling ${task.payload}")
+        logger.info("Gjenoppretter oppgave for behandling ${task.payload}")
         val behandling = behandligService.hentBehandling(UUID.fromString(task.payload))
         feilHvis(behandling.status.erFerdigbehandlet()) { "Behandling er ferdig behandlet" }
         ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
@@ -1,0 +1,101 @@
+package no.nav.familie.ef.sak.forvaltning
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FATTER_VEDTAK
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FERDIGSTILT
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.IVERKSETTER_VEDTAK
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.OPPRETTET
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.SATT_PÅ_VENT
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.UTREDES
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.oppgave.OppgaveRepository
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
+import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum.FEILREGISTRERT
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.Properties
+import java.util.UUID
+
+typealias EFOppgave = no.nav.familie.ef.sak.oppgave.Oppgave
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = GjennoprettOppgavePåBehandlingTask.TYPE,
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+    beskrivelse = "Finn og logg metadata for oppgave knyttet til behandling",
+)
+class GjennoprettOppgavePåBehandlingTask(
+    private val tilordnetRessursService: TilordnetRessursService,
+    private val behandligService: BehandlingService,
+    private val oppgaveService: OppgaveService,
+    private val oppgaveRepository: OppgaveRepository,
+) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        logger.info("Henter oppgave for behandling ${task.payload}")
+        val behandling = behandligService.hentBehandling(UUID.fromString(task.payload))
+        feilHvis(behandling.status.erFerdigbehandlet()) { "Behandling er ferdig behandlet" }
+        ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling)
+        opprettNyOppgave(behandling)
+    }
+
+    private fun ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling: Behandling) {
+        val efOppgave = oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))
+        if (efOppgave != null) {
+            ferdigstillGammelOppgave(efOppgave)
+        }
+    }
+
+    private fun ferdigstillGammelOppgave(efOppgave: EFOppgave) {
+        oppgaveRepository.update(efOppgave.copy(erFerdigstilt = true))
+    }
+
+    private fun opprettNyOppgave(behandling: Behandling) {
+        val erFeilregistrert = erFeilregistrert(behandling)
+        val beskrivelse: String =
+            when (erFeilregistrert) {
+                true -> "Opprinnelig oppgave er feilregistrert. For å kunne utføre behandling har det blitt opprettet en ny oppgave."
+                false -> "Opprinnelig oppgave har blitt flyttet eller endret. For å kunne utføre behandling har det blitt opprettet en ny oppgave."
+            }
+        oppgaveService.opprettOppgave(behandling.id, finnOppgavetype(behandling), prioritet = OppgavePrioritet.HOY, beskrivelse = beskrivelse, fristFerdigstillelse = LocalDate.now())
+    }
+
+    private fun erFeilregistrert(behandling: Behandling): Boolean {
+        val opprinneligOppgave = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))
+        return opprinneligOppgave?.status == FEILREGISTRERT
+    }
+
+    private fun finnOppgavetype(behandling: Behandling) =
+        when (behandling.status) {
+            FATTER_VEDTAK -> Oppgavetype.GodkjenneVedtak
+            else -> Oppgavetype.BehandleSak
+        }
+
+    companion object {
+        const val TYPE = "GjennoprettOppgavePåBehandlingForvaltningsTask"
+
+        fun opprettTask(behandlingId: UUID): Task =
+            Task(
+                type = TYPE,
+                payload = behandlingId.toString(),
+                properties = Properties(),
+            )
+    }
+
+    private fun BehandlingStatus.erFerdigbehandlet(): Boolean =
+        when (this) {
+            FERDIGSTILT, IVERKSETTER_VEDTAK -> true
+            FATTER_VEDTAK, UTREDES, SATT_PÅ_VENT, OPPRETTET -> false
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -22,6 +23,24 @@ class OppgaveforvaltningsController(
     ) {
         tilgangService.validerHarForvalterrolle()
         val task = LoggOppgaveMetadataTask.opprettTask(behandlingId)
+        taskService.save(task)
+    }
+
+    @Operation(
+        description =
+            "Hvis en åpen behandling mangler oppgave kan vi bruke dette endepunktet for å lage en ny oppgave på behandlingen. \n\n" +
+                "Sjekk først om det finnes en oppgave for behandlingen. Dette kan du gjøre med forvaltningsendepunkt. \n\n" +
+                "Dersom vi finner en oppgave som er flyttet kan vi vurdere om denne oppgaven bør flyttes tilbake.\n\n" +
+                "Dersom det finnes en intern ef-oppgave (referanse), vil denne ferdigstilles før vi oppretter en ny oppgave.",
+        summary =
+            "Lag ny ekstern BehandleSak- eller GodkjenneVedtak-oppgave",
+    )
+    @PostMapping("gjenopprett-oppgave/behandling/{behandlingId}")
+    fun gjenopprettOppgaveForBehandling(
+        @PathVariable behandlingId: UUID,
+    ) {
+        tilgangService.validerHarForvalterrolle()
+        val task = GjennoprettOppgavePåBehandlingTask.opprettTask(behandlingId)
         taskService.save(task)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -51,6 +51,7 @@ class OppgaveService(
         beskrivelse: String? = null,
         mappeId: Long? = null, // Dersom denne er satt vil vi ikke prøve å finne mappe basert på oppgavens innhold
         prioritet: OppgavePrioritet = OppgavePrioritet.NORM,
+        fristFerdigstillelse: LocalDate? = null,
     ): Long {
         val oppgaveFinnesFraFør = getOppgaveFinnesFraFør(oppgavetype, vurderHenvendelseOppgaveSubtype, behandlingId)
         return if (oppgaveFinnesFraFør !== null) {
@@ -60,7 +61,7 @@ class OppgaveService(
                 opprettOppgaveUtenÅLagreIRepository(
                     behandlingId = behandlingId,
                     oppgavetype = oppgavetype,
-                    fristFerdigstillelse = null,
+                    fristFerdigstillelse = fristFerdigstillelse,
                     beskrivelse = lagOppgaveTekst(beskrivelse),
                     tilordnetNavIdent = tilordnetNavIdent,
                     mappeId = mappeId,

--- a/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTaskTest.kt
@@ -1,0 +1,77 @@
+package no.nav.familie.ef.sak.forvaltning
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.oppgave.OppgaveRepository
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class GjennoprettOppgavePåBehandlingTaskTest {
+    private val tilordnetRessursService: TilordnetRessursService = mockk<TilordnetRessursService>()
+    private val behandligService: BehandlingService = mockk<BehandlingService>()
+    private val oppgaveService: OppgaveService = mockk<OppgaveService>(relaxed = true)
+    private val oppgaveRepository: OppgaveRepository = mockk<OppgaveRepository>()
+
+    private val gjennoprettOppgavePåBehandlingTask = GjennoprettOppgavePåBehandlingTask(tilordnetRessursService = tilordnetRessursService, behandligService = behandligService, oppgaveService = oppgaveService, oppgaveRepository = oppgaveRepository)
+
+    @Test
+    fun `Ikke opprett oppgave hvis behandling er FERDIGSTILT`() {
+        val behandling = behandling(status = BehandlingStatus.FERDIGSTILT)
+        every { behandligService.hentBehandling(behandling.id) } returns behandling
+        val feil =
+            org.junit.jupiter.api.assertThrows<Feil> {
+                gjennoprettOppgavePåBehandlingTask.doTask(GjennoprettOppgavePåBehandlingTask.opprettTask(behandling.id))
+            }
+        assertThat(feil.message).isEqualTo("Behandling er ferdig behandlet")
+    }
+
+    @Test
+    fun `Ikke opprett oppgave hvis behandling er IVERKSETTER_VEDTAK`() {
+        val behandling = behandling(status = BehandlingStatus.IVERKSETTER_VEDTAK)
+        every { behandligService.hentBehandling(behandling.id) } returns behandling
+
+        val feil =
+            org.junit.jupiter.api.assertThrows<Feil> {
+                gjennoprettOppgavePåBehandlingTask.doTask(GjennoprettOppgavePåBehandlingTask.opprettTask(behandling.id))
+            }
+
+        assertThat(feil.message).isEqualTo("Behandling er ferdig behandlet")
+    }
+
+    @Test
+    fun `Opprett oppgave med henvisning til feilregistrert oppgave dersom dette er status på opprinnelig oppgave `() {
+        val forventetBeskrivelse = "Opprinnelig oppgave er feilregistrert. For å kunne utføre behandling har det blitt opprettet en ny oppgave."
+        val behandling = behandling()
+
+        every { behandligService.hentBehandling(behandling.id) } returns behandling
+        every { oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak)) } returns null
+        every { tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak)) } returns Oppgave(status = StatusEnum.FEILREGISTRERT)
+
+        gjennoprettOppgavePåBehandlingTask.doTask(GjennoprettOppgavePåBehandlingTask.opprettTask(behandling.id))
+
+        verify(exactly = 1) {
+            oppgaveService.opprettOppgave(
+                behandlingId = behandling.id,
+                oppgavetype = Oppgavetype.BehandleSak,
+                vurderHenvendelseOppgaveSubtype = any(),
+                tilordnetNavIdent = any(),
+                beskrivelse = forventetBeskrivelse,
+                mappeId = any(),
+                prioritet = OppgavePrioritet.HOY,
+                fristFerdigstillelse = LocalDate.now(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vil legge til forvaltningsendepunkt for å kunne opprette oppgaver på behandlinger som av en eller annen grunn ikke har oppgave lenger.

Ønsker å ferdigstille intern oppgave-referanse til den ikke-eksisterende oppgaven i oppgavesystemet.

testet i preprod med behandling på bruker: 
https://ensligmorellerfar.ansatt.dev.nav.no/person/60b9cc99-da3f-4f5e-b1d7-c6f506cb0c33/behandlinger

Fikk ikke imulert mm. 

