### PR TITLE
Bugfiks: Vil sjekke om den opprinnelige oppgaven var feilregistrert før vi fer…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
@@ -54,7 +54,7 @@ class GjennoprettOppgavePåBehandlingTask(
     }
 
     private fun ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling: Behandling) {
-        val efOppgave :EFOppgave? = oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))
+        val efOppgave: EFOppgave? = oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))
         if (efOppgave != null) {
             ferdigstillGammelOppgave(efOppgave)
         }
@@ -64,7 +64,10 @@ class GjennoprettOppgavePåBehandlingTask(
         oppgaveRepository.update(efOppgave.copy(erFerdigstilt = true))
     }
 
-    private fun opprettNyOppgave(behandling: Behandling, erFeilregistrert: Boolean ) {
+    private fun opprettNyOppgave(
+        behandling: Behandling,
+        erFeilregistrert: Boolean,
+    ) {
         val beskrivelse: String =
             when (erFeilregistrert) {
                 true -> "Opprinnelig oppgave er feilregistrert. For å kunne utføre behandling har det blitt opprettet en ny oppgave."
@@ -97,6 +100,4 @@ class GjennoprettOppgavePåBehandlingTask(
         }
 }
 
-private fun Oppgave?.erFeilregistrert(): Boolean {
-    return this?.status == FEILREGISTRERT
-}
+private fun Oppgave?.erFeilregistrert(): Boolean = this?.status == FEILREGISTRERT

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
@@ -47,11 +47,12 @@ class GjennoprettOppgavePåBehandlingTask(
         logger.info("Gjenoppretter oppgave for behandling ${task.payload}")
         val behandling = behandligService.hentBehandling(UUID.fromString(task.payload))
         feilHvis(behandling.status.erFerdigbehandlet()) { "Behandling er ferdig behandlet" }
-
-        val opprinneligOppgave = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))
+        val erFeilregistrert = erOppgaveFeilregistrert(behandling)
         ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling)
-        opprettNyOppgave(behandling, opprinneligOppgave.erFeilregistrert())
+        opprettNyOppgave(behandling, erFeilregistrert)
     }
+
+    private fun erOppgaveFeilregistrert(behandling: Behandling) = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak)).erFeilregistrert()
 
     private fun ferdigstillReferanseTilIkkeeksisterendeEksternOppgave(behandling: Behandling) {
         val efOppgave: EFOppgave? = oppgaveRepository.findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandling.id, setOf(Oppgavetype.BehandleSak, Oppgavetype.GodkjenneVedtak, Oppgavetype.BehandleUnderkjentVedtak))

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveRepository.kt
@@ -28,6 +28,11 @@ interface OppgaveRepository :
         oppgavetype: Oppgavetype,
     ): List<Oppgave>?
 
+    fun findByBehandlingIdAndTypeIn(
+        behandlingId: UUID,
+        oppgavetype: Set<Oppgavetype>,
+    ): List<Oppgave>?
+
     fun findByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
         behandlingId: UUID,
         oppgavetype: Set<Oppgavetype>,

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
+import no.nav.familie.ef.sak.felles.domain.Endret
 import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
 import no.nav.familie.ef.sak.infrastruktur.config.OppgaveClientMock
 import no.nav.familie.ef.sak.infrastruktur.exception.IntegrasjonException
@@ -31,8 +32,14 @@ import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
-import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.BehandleSak
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.BehandleUnderkjentVedtak
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.GodkjenneVedtak
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.InnhentDokumentasjon
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.VurderHenvendelse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum.FEILREGISTRERT
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum.FERDIGSTILT
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -75,7 +82,7 @@ internal class OppgaveServiceTest {
         val oppgave =
             oppgave(
                 behandling = behandling(),
-                type = Oppgavetype.VurderHenvendelse,
+                type = VurderHenvendelse,
                 gsakOppgaveId = eksisterendeGsakOppgaveId,
             )
         mockFinnVurderHenvendelseOppgave(returnValue = oppgave)
@@ -83,7 +90,7 @@ internal class OppgaveServiceTest {
         val opprettOppgave =
             oppgaveService.opprettOppgave(
                 BEHANDLING_ID,
-                Oppgavetype.VurderHenvendelse,
+                VurderHenvendelse,
                 OppgaveSubtype.INNSTILLING_VEDRØRENDE_UTDANNING,
             )
 
@@ -100,7 +107,7 @@ internal class OppgaveServiceTest {
 
         oppgaveService.opprettOppgave(
             BEHANDLING_ID,
-            Oppgavetype.VurderHenvendelse,
+            VurderHenvendelse,
             OppgaveSubtype.INNSTILLING_VEDRØRENDE_UTDANNING,
         )
 
@@ -122,7 +129,7 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         mockOpprettOppgave(slot)
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, BehandleSak)
 
         assertThat(slot.captured.enhetsnummer).isEqualTo(ENHETSNUMMER)
         assertThat(slot.captured.saksId).isEqualTo(FAGSAK_EKSTERN_ID.toString())
@@ -140,7 +147,7 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         mockOpprettOppgave(slot)
         every { arbeidsfordelingService.hentNavEnhetId(any(), any()) } returns null
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, BehandleSak)
 
         verify(exactly = 2) { oppgaveClient.opprettOppgave(any()) }
     }
@@ -151,7 +158,7 @@ internal class OppgaveServiceTest {
         mockOpprettOppgave(slot)
         every { oppgaveClient.opprettOppgave(any()) } throws IntegrasjonException("En merkelig feil vi ikke kjenner til")
         assertThrows<IntegrasjonException> {
-            oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+            oppgaveService.opprettOppgave(BEHANDLING_ID, BehandleSak)
         }
     }
 
@@ -161,7 +168,7 @@ internal class OppgaveServiceTest {
         mockOpprettOppgave(slot)
 
         val beskrivelse = "Oppgave tekst her"
-        oppgaveService.opprettOppgave(behandlingId = BEHANDLING_ID, oppgavetype = Oppgavetype.GodkjenneVedtak, beskrivelse = beskrivelse)
+        oppgaveService.opprettOppgave(behandlingId = BEHANDLING_ID, oppgavetype = GodkjenneVedtak, beskrivelse = beskrivelse)
 
         assertThat(slot.captured.enhetsnummer).isEqualTo(ENHETSNUMMER)
         assertThat(slot.captured.mappeId).isNotNull
@@ -186,7 +193,7 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         every { oppgaveClient.opprettOppgave(capture(slot)) } returns GSAK_OPPGAVE_ID
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak, beskrivelse = "")
+        oppgaveService.opprettOppgave(BEHANDLING_ID, GodkjenneVedtak, beskrivelse = "")
 
         assertThat(slot.captured.enhetsnummer).isEqualTo("1234")
         assertThat(slot.captured.mappeId).isNull()
@@ -210,6 +217,46 @@ internal class OppgaveServiceTest {
     }
 
     @Test
+    fun `Finn oppgave sist endret i familie-ef-sak`() {
+        val oppgaveList = oppgaveList() // Ny, eldre og eldst
+
+        every {
+            oppgaveRepository.findByBehandlingIdAndTypeIn(
+                BEHANDLING_ID,
+                setOf(BehandleSak, GodkjenneVedtak, BehandleUnderkjentVedtak),
+            )
+        } returns oppgaveList
+
+        every { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID) } returns lagEksternTestOppgave().copy(status = FEILREGISTRERT)
+        every { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID_2) } returns lagEksternTestOppgave().copy(status = FERDIGSTILT)
+        every { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID_3) } returns lagEksternTestOppgave().copy(status = FERDIGSTILT)
+
+        val oppgave = oppgaveService.finnBehandlingsoppgaveSistEndretIEFSak(BEHANDLING_ID)
+
+        // skal finne nyeste oppgave som er feilregistrert
+        assertThat(oppgave!!.status).isEqualTo(FEILREGISTRERT)
+
+        verify(exactly = 0) { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID_3) }
+        verify(exactly = 0) { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID_2) }
+        verify(exactly = 1) { oppgaveClient.finnOppgaveMedId(GSAK_OPPGAVE_ID) }
+    }
+
+    private fun oppgaveList(): List<Oppgave> {
+        val testOppgave1 = lagTestOppgave(GSAK_OPPGAVE_ID)
+        val testOppgave2 = lagTestOppgave(GSAK_OPPGAVE_ID_2)
+        val testOppgave3 = lagTestOppgave(GSAK_OPPGAVE_ID_3)
+
+        val sporbarNyest = testOppgave1.sporbar.copy(endret = Endret(endretAv = "123", endretTid = LocalDateTime.now().minusDays(1)))
+        val sporbarMellom = testOppgave2.sporbar.copy(endret = Endret(endretAv = "123", endretTid = LocalDateTime.now().minusDays(2)))
+        val sporbarGammel = testOppgave3.sporbar.copy(endret = Endret(endretAv = "123", endretTid = LocalDateTime.now().minusDays(3)))
+
+        val ny = testOppgave1.copy(sporbar = sporbarNyest)
+        val mellom = testOppgave2.copy(sporbar = sporbarMellom)
+        val gammel = testOppgave3.copy(sporbar = sporbarGammel)
+        return listOf(mellom, ny, gammel)
+    }
+
+    @Test
     fun `Skal hente oppgaver gitt en filtrering`() {
         every { oppgaveClient.hentOppgaver(any()) } returns lagFinnOppgaveResponseDto()
         val respons = oppgaveService.hentOppgaver(FinnOppgaveRequest(tema = Tema.ENF))
@@ -227,7 +274,7 @@ internal class OppgaveServiceTest {
         val slot = slot<Long>()
         every { oppgaveClient.ferdigstillOppgave(capture(slot)) } just runs
 
-        oppgaveService.ferdigstillBehandleOppgave(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.ferdigstillBehandleOppgave(BEHANDLING_ID, BehandleSak)
         assertThat(slot.captured).isEqualTo(GSAK_OPPGAVE_ID)
     }
 
@@ -241,7 +288,7 @@ internal class OppgaveServiceTest {
         assertThatThrownBy {
             oppgaveService.ferdigstillBehandleOppgave(
                 BEHANDLING_ID,
-                Oppgavetype.BehandleSak,
+                BehandleSak,
             )
         }.hasMessage("Finner ikke oppgave for behandling $BEHANDLING_ID")
             .isInstanceOf(java.lang.IllegalStateException::class.java)
@@ -252,7 +299,7 @@ internal class OppgaveServiceTest {
         every {
             oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(any(), any())
         } returns null
-        oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(BEHANDLING_ID, BehandleSak)
     }
 
     @Test
@@ -264,7 +311,7 @@ internal class OppgaveServiceTest {
         val slot = slot<Long>()
         every { oppgaveClient.ferdigstillOppgave(capture(slot)) } just runs
 
-        oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(BEHANDLING_ID, Oppgavetype.BehandleSak)
+        oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(BEHANDLING_ID, BehandleSak)
         assertThat(slot.captured).isEqualTo(GSAK_OPPGAVE_ID)
     }
 
@@ -340,8 +387,8 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         mockOpprettOppgave(slot)
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, GodkjenneVedtak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, GodkjenneVedtak)
 
         verify(exactly = 1) { oppgaveClient.finnMapper(any(), any()) }
     }
@@ -358,7 +405,7 @@ internal class OppgaveServiceTest {
 
         oppgaveService.opprettOppgave(
             behandlingId,
-            Oppgavetype.InnhentDokumentasjon,
+            InnhentDokumentasjon,
             null,
             Alder.ETT_ÅR.oppgavebeskrivelse,
         )
@@ -391,7 +438,7 @@ internal class OppgaveServiceTest {
         internal fun `skal ignorere feil fra ferdigstillOppgave hvis den er feilregistrert og vi skal ignorere feilregistrert`() {
             every { oppgaveClient.ferdigstillOppgave(any()) } throws feilregistrertException
 
-            oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), Oppgavetype.BehandleSak, true)
+            oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), BehandleSak, true)
 
             verify(exactly = 1) { oppgaveRepository.update(any()) }
         }
@@ -401,7 +448,7 @@ internal class OppgaveServiceTest {
             every { oppgaveClient.ferdigstillOppgave(any()) } throws feilregistrertException
 
             assertThatThrownBy {
-                oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), Oppgavetype.BehandleSak, false)
+                oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), BehandleSak, false)
             }.isInstanceOf(RessursException::class.java)
 
             verify(exactly = 0) { oppgaveRepository.update(any()) }
@@ -412,7 +459,7 @@ internal class OppgaveServiceTest {
             every { oppgaveClient.ferdigstillOppgave(any()) } throws annenException
 
             assertThatThrownBy {
-                oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), Oppgavetype.BehandleSak, true)
+                oppgaveService.ferdigstillOppgaveHvisOppgaveFinnes(UUID.randomUUID(), BehandleSak, true)
             }.isInstanceOf(RessursException::class.java)
 
             verify(exactly = 0) { oppgaveRepository.update(any()) }
@@ -426,7 +473,7 @@ internal class OppgaveServiceTest {
             every {
                 oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(any(), any())
             } returns null
-            val ferdigstiltOppgave = oppgaveService.settEfOppgaveTilFerdig(BEHANDLING_ID, Oppgavetype.BehandleSak)
+            val ferdigstiltOppgave = oppgaveService.settEfOppgaveTilFerdig(BEHANDLING_ID, BehandleSak)
 
             verify(exactly = 1) { oppgaveRepository.findByBehandlingIdAndTypeAndErFerdigstiltIsFalse(any(), any()) }
             verify(exactly = 0) { oppgaveRepository.update(any()) }
@@ -440,7 +487,7 @@ internal class OppgaveServiceTest {
             } returns lagTestOppgave()
             every { oppgaveRepository.update(any()) } returns lagTestOppgave().copy(erFerdigstilt = true)
 
-            val ferdigstiltOppgave = oppgaveService.settEfOppgaveTilFerdig(BEHANDLING_ID, Oppgavetype.BehandleSak)
+            val ferdigstiltOppgave = oppgaveService.settEfOppgaveTilFerdig(BEHANDLING_ID, BehandleSak)
             assertThat(ferdigstiltOppgave).isNotNull
             assertThat(ferdigstiltOppgave?.behandlingId).isEqualTo(BEHANDLING_ID)
             assertThat(ferdigstiltOppgave?.erFerdigstilt).isTrue()
@@ -474,7 +521,7 @@ internal class OppgaveServiceTest {
             identer = setOf(PersonIdent(ident = FNR)),
         )
 
-    private fun lagTestOppgave(): Oppgave = Oppgave(behandlingId = BEHANDLING_ID, type = Oppgavetype.BehandleSak, gsakOppgaveId = GSAK_OPPGAVE_ID)
+    private fun lagTestOppgave(gsakOppgaveId: Long = GSAK_OPPGAVE_ID): Oppgave = Oppgave(behandlingId = BEHANDLING_ID, type = BehandleSak, gsakOppgaveId = gsakOppgaveId)
 
     private fun lagEksternTestOppgave(tilordnetRessurs: String? = null): no.nav.familie.kontrakter.felles.oppgave.Oppgave =
         no.nav.familie.kontrakter.felles.oppgave
@@ -490,6 +537,8 @@ internal class OppgaveServiceTest {
         private val FAGSAK_ID = UUID.fromString("1242f220-cad3-4640-95c1-190ec814c91e")
         private const val FAGSAK_EKSTERN_ID = 98765L
         private const val GSAK_OPPGAVE_ID = 12345L
+        private const val GSAK_OPPGAVE_ID_2 = 54321L
+        private const val GSAK_OPPGAVE_ID_3 = 98765L
         private val BEHANDLING_ID = UUID.fromString("1c4209bd-3217-4130-8316-8658fe300a84")
         private const val ENHETSNUMMER = "4489"
         private const val FNR = "11223312345"


### PR DESCRIPTION
…digstiller og mister tilgang til data (gitt måten vi henter ut oppgave på) .

### Hvorfor er denne endringen nødvendig? ✨

Bugfiks: 
Vi brukte feil oppgavebeskrivelse hvis opprinnelig oppgave var feilregistrert. 
Problem - før vi sjekket status ferdigstilte jeg oppgavereferanse i ef til oppgaven. 

Denne feilen ble ikke ikke fanget opp av unittest (alt for mye mockking). Ville blitt fanget opp av en integrasjonstest, men jeg mener det er litt mye å bruke cpu på en slik forvaltningsrutine. Hva tenker dere? Her kan jeg lett overtales til å bytte mening. 

Har testet i preprod og fått bedre resultat med denne versjonen av koden: 

![image](https://github.com/user-attachments/assets/36567407-0f9a-4a6f-a447-56cac1e97ba7)


 