### PR TITLE
Vil fjerne unødvendig beskrivelse på oppgaver vi oppretter

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
@@ -16,7 +16,6 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.iverksett.IverksettService
-import no.nav.familie.ef.sak.journalføring.JournalpostClient
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
@@ -79,7 +78,6 @@ class TestSaksbehandlingController(
     private val barnService: BarnService,
     private val taskService: TaskService,
     private val oppgaveService: OppgaveService,
-    private val journalpostClient: JournalpostClient,
     private val migreringService: MigreringService,
     private val vurderingService: VurderingService,
     private val vurderingStegService: VurderingStegService,
@@ -192,7 +190,7 @@ class TestSaksbehandlingController(
                     behandlingId = behandling.id,
                     oppgavetype = Oppgavetype.BehandleSak,
                     tilordnetNavIdent = SikkerhetContext.hentSaksbehandler(),
-                    beskrivelse = "Dummy-oppgave opprettet i ny løsning",
+                    beskrivelse = "Dummy-oppgave opprettet",
                 )
             taskService.save(
                 taskService.save(

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -3,10 +3,10 @@ package no.nav.familie.ef.sak.oppgave
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.ENHET_NR_NAY
+import no.nav.familie.ef.sak.oppgave.OppgaveUtil.lagOpprettOppgavebeskrivelse
 import no.nav.familie.ef.sak.oppgave.dto.UtdanningOppgaveDto
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
@@ -424,7 +424,4 @@ class OppgaveService(
             Oppgavetype.VurderHenvendelse -> false
             else -> error("Håndterer ikke behandlesAvApplikasjon for $oppgavetype")
         }
-
-    private fun lagOpprettOppgavebeskrivelse(beskrivelse: String?) =
-        "--- ${dagensDatoMedTidNorskFormat()} opprettet --- \n${beskrivelse.orEmpty()}"
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.oppgave
 import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.ENHET_NR_NAY
@@ -21,14 +22,11 @@ import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
-import java.net.URI
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.UUID
 import no.nav.familie.ef.sak.oppgave.Oppgave as EfOppgave
 
@@ -39,7 +37,6 @@ class OppgaveService(
     private val oppgaveRepository: OppgaveRepository,
     private val arbeidsfordelingService: ArbeidsfordelingService,
     private val cacheManager: CacheManager,
-    @Value("\${FRONTEND_OPPGAVE_URL}") private val frontendOppgaveUrl: URI,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -62,7 +59,7 @@ class OppgaveService(
                     behandlingId = behandlingId,
                     oppgavetype = oppgavetype,
                     fristFerdigstillelse = fristFerdigstillelse,
-                    beskrivelse = lagOppgaveTekst(beskrivelse),
+                    beskrivelse = lagOpprettOppgavebeskrivelse(beskrivelse),
                     tilordnetNavIdent = tilordnetNavIdent,
                     mappeId = mappeId,
                     prioritet = prioritet,
@@ -276,17 +273,6 @@ class OppgaveService(
 
     fun finnSisteOppgaveForBehandling(behandlingId: UUID): EfOppgave? = oppgaveRepository.findTopByBehandlingIdOrderBySporbarOpprettetTidDesc(behandlingId)
 
-    fun lagOppgaveTekst(beskrivelse: String? = null): String =
-        if (beskrivelse != null) {
-            beskrivelse + "\n"
-        } else {
-            ""
-        } +
-            "----- Opprettet av familie-ef-sak ${
-                LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
-            } --- \n" +
-            "$frontendOppgaveUrl" + "\n----- Oppgave må behandles i ny løsning"
-
     fun hentOppgaver(finnOppgaveRequest: FinnOppgaveRequest): FinnOppgaveResponseDto = oppgaveClient.hentOppgaver(finnOppgaveRequest)
 
     private fun finnBehandlingstema(stønadstype: StønadType): Behandlingstema =
@@ -438,4 +424,7 @@ class OppgaveService(
             Oppgavetype.VurderHenvendelse -> false
             else -> error("Håndterer ikke behandlesAvApplikasjon for $oppgavetype")
         }
+
+    private fun lagOpprettOppgavebeskrivelse(beskrivelse: String?) =
+        "--- ${dagensDatoMedTidNorskFormat()} opprettet --- \n${beskrivelse.orEmpty()}"
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.oppgave
 
+import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import org.slf4j.LoggerFactory
@@ -28,4 +29,9 @@ object OppgaveUtil {
 
     fun finnPersonidentForOppgave(oppgave: Oppgave): String? =
         oppgave.identer?.first { it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident
+
+    fun lagOpprettOppgavebeskrivelse(beskrivelse: String?): String {
+        val beskrivelseEllerDefault = beskrivelse ?: "Oppgave opprettet"
+        return "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelseEllerDefault"
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTaskTest.kt
@@ -40,7 +40,7 @@ internal class OpprettOppgaveTaskTest {
 
         opprettOppgaveTask.doTask(task)
         verifyOpprettOppgaveMedLagringKall(0)
-        verifyOpprettOppgaveUtenLagringKall(0)
+        verifyOpprettOppgaveUtenLagringKall()
     }
 
     @Test
@@ -57,13 +57,12 @@ internal class OpprettOppgaveTaskTest {
 
         opprettOppgaveTask.doTask(task)
         verifyOpprettOppgaveMedLagringKall(1)
-        verifyOpprettOppgaveUtenLagringKall(0)
+        verifyOpprettOppgaveUtenLagringKall()
     }
 
     @Test
     fun `skal lagre ned oppgave om oppgavetypen er vurder henvendelse`() {
         every { behandlingService.hentBehandling(behandlingId) } returns behandling(id = behandlingId, status = BehandlingStatus.UTREDES)
-        every { oppgaveService.lagOppgaveTekst(any()) } returns ""
 
         val task =
             OpprettOppgaveTask.opprettTask(
@@ -81,7 +80,7 @@ internal class OpprettOppgaveTaskTest {
         verify(exactly = opprettOppgaveKall) { oppgaveService.opprettOppgave(any(), any(), any(), any(), any()) }
     }
 
-    private fun verifyOpprettOppgaveUtenLagringKall(opprettOppgaveKall: Int) {
-        verify(exactly = opprettOppgaveKall) { oppgaveService.opprettOppgaveUtenÅLagreIRepository(any(), any(), any(), any(), any()) }
+    private fun verifyOpprettOppgaveUtenLagringKall() {
+        verify(exactly = 0) { oppgaveService.opprettOppgaveUtenÅLagreIRepository(any(), any(), any(), any(), any()) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ef.sak.oppgave
+
+import no.nav.familie.ef.sak.felles.util.DatoUtil.dagensDatoMedTid
+import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
+import no.nav.familie.ef.sak.oppgave.OppgaveUtil.lagOpprettOppgavebeskrivelse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.format.DateTimeFormatter
+
+class OppgaveUtilTest {
+    @Test
+    fun `skal legge på metadata med dato på riktig format`() {
+        val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse(null)
+        val datoMedRiktigFormat = dagensDatoMedTid().format(DateTimeFormatter.ofPattern("dd.MM.yyyy' 'HH:mm"))
+        assertThat(lagOpprettOppgavebeskrivelse).contains(datoMedRiktigFormat)
+    }
+
+    @Test
+    fun `skal legge på oppgave opprettet dersom beskrivelse er null`() {
+        val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse(null)
+        assertThat(lagOpprettOppgavebeskrivelse).contains("Oppgave opprettet")
+    }
+
+    @Test
+    fun `skal legge på beskrivelse hvis beskrivelse ikke er null`() {
+        val forventetOppgavebeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \nDette er tekst"
+        val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse("Dette er en tekst")
+        assertThat(lagOpprettOppgavebeskrivelse).isEqualTo(forventetOppgavebeskrivelse)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
@@ -23,8 +23,9 @@ class OppgaveUtilTest {
 
     @Test
     fun `skal legge på beskrivelse hvis beskrivelse ikke er null`() {
-        val forventetOppgavebeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \nDette er tekst"
-        val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse("Dette er en tekst")
+        val beskrivelse = "Dette er tekst"
+        val forventetOppgavebeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelse"
+        val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse(beskrivelse)
         assertThat(lagOpprettOppgavebeskrivelse).isEqualTo(forventetOppgavebeskrivelse)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -131,7 +131,8 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \nOppgave opprettet"
+        assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }
 
     @Test
@@ -159,7 +160,8 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         mockOpprettOppgave(slot)
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
+        val beskrivelse = "Oppgave tekst her"
+        oppgaveService.opprettOppgave(behandlingId = BEHANDLING_ID, oppgavetype = Oppgavetype.GodkjenneVedtak, beskrivelse = beskrivelse)
 
         assertThat(slot.captured.enhetsnummer).isEqualTo(ENHETSNUMMER)
         assertThat(slot.captured.mappeId).isNotNull
@@ -169,7 +171,8 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelse"
+        assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }
 
     @Test
@@ -183,7 +186,7 @@ internal class OppgaveServiceTest {
         val slot = slot<OpprettOppgaveRequest>()
         every { oppgaveClient.opprettOppgave(capture(slot)) } returns GSAK_OPPGAVE_ID
 
-        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak)
+        oppgaveService.opprettOppgave(BEHANDLING_ID, Oppgavetype.GodkjenneVedtak, beskrivelse = "")
 
         assertThat(slot.captured.enhetsnummer).isEqualTo("1234")
         assertThat(slot.captured.mappeId).isNull()
@@ -193,7 +196,9 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n"
+
+        assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
+import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
 import no.nav.familie.ef.sak.infrastruktur.config.OppgaveClientMock
 import no.nav.familie.ef.sak.infrastruktur.exception.IntegrasjonException
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.Alder
@@ -32,7 +33,6 @@ import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
-import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpServerErrorException
-import java.net.URI
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -62,7 +61,6 @@ internal class OppgaveServiceTest {
             oppgaveRepository,
             arbeidsfordelingService,
             cacheManager,
-            URI.create("https://ensligmorellerfar.intern.nav.no/oppgavebenk"),
         )
 
     @BeforeEach
@@ -133,7 +131,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains("https://ensligmorellerfar.intern.nav.no/oppgavebenk")
+        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
     }
 
     @Test
@@ -171,7 +169,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains("https://ensligmorellerfar.intern.nav.no/oppgavebenk")
+        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
     }
 
     @Test
@@ -195,7 +193,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        assertThat(slot.captured.beskrivelse).contains("https://ensligmorellerfar.intern.nav.no/oppgavebenk")
+        assertThat(slot.captured.beskrivelse).contains(dagensDatoMedTidNorskFormat())
     }
 
     @Test
@@ -489,7 +487,6 @@ internal class OppgaveServiceTest {
         private const val GSAK_OPPGAVE_ID = 12345L
         private val BEHANDLING_ID = UUID.fromString("1c4209bd-3217-4130-8316-8658fe300a84")
         private const val ENHETSNUMMER = "4489"
-        private const val ENHETSNAVN = "enhetsnavn"
         private const val FNR = "11223312345"
         private const val SAKSBEHANDLER_ID = "Z999999"
     }
@@ -509,5 +506,3 @@ private val fredagFrist = LocalDate.of(2021, 4, 2)
 private val mandagFrist = LocalDate.of(2021, 4, 5)
 private val tirsdagFrist = LocalDate.of(2021, 4, 6)
 private val onsdagFrist = LocalDate.of(2021, 4, 7)
-
-private val saksbehandler = Saksbehandler(UUID.randomUUID(), "Z999999", "Darth", "Vader", "4405")


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22077

Ending av oppgavebeskrivelse: 

Oppgavebenk
![image](https://github.com/user-attachments/assets/7cdfc5a1-fa5a-431e-8482-fd1fe223c138)

Gosys:
![image](https://github.com/user-attachments/assets/c049a2cc-a4e4-4a00-88b4-a630690b6f49)




**Forslag til oppgavebeskrivelse når vi oppretter oppgaver:**
Tidligere/nå :grimacing::
Opprinnelig oppgave er feilregistrert. For å kunne utføre behandling har det blitt opprettet en ny oppgave.
----- Opprettet av familie-ef-sak 2024-08-28T11:14 03.817774878 ---
https://ensligmorellerfar.intern.dev.nav.no/oppgavebenk
----- Oppgave må behandles i ny løsning
Forslag:
--- 28.08.2024 11:57 opprettet --- 
Tekst vi legger til her
(Evt en oppgave uten "ekstra tekst: " )
--- 28.08.2024 11:57 opprettet --- 

**Når gosys legger på historikk:
--- 28.08.2024 11:37 F_Z992991 E_Z992991 (Z992991, 1871) ---
Oppgaven er flyttet fra enhet 4489 til 1871, fra saksbehandler <ingen> til Z992991**


Trenger vi url til oppgavebenk?
Burde vi holde oss til gosys "format"
--- tid, hvem har endret ---
hva er endret 
--- 28.08.2024 11:37 familie-ef-sak ---
Oppgave opprettet

I forslag er også teksten vi legger til under tidspunkt, ikke over som vi har det nå. Dette er også likere måten Gosys gjør det på. 

