### PR TITLE
Oppgaveliste i gosys viser siste beskrivelse på oppgave uten metadata…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
@@ -19,7 +19,7 @@ object OppgaveUtil {
             try {
                 OffsetDateTime.parse(endretTidspunkt).until(OffsetDateTime.now(), ChronoUnit.SECONDS)
             } catch (e: Exception) {
-                logger.warn("Feilet parsing av endretTidspunkt=$endretTidspunkt for opgave=$oppgave")
+                logger.warn("Feilet parsing av endretTidspunkt=$endretTidspunkt for oppgave=$oppgave")
                 null
             }
         } else {
@@ -32,6 +32,6 @@ object OppgaveUtil {
 
     fun lagOpprettOppgavebeskrivelse(beskrivelse: String?): String {
         val beskrivelseEllerDefault = beskrivelse ?: "Oppgave opprettet"
-        return "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelseEllerDefault"
+        return "--- ${dagensDatoMedTidNorskFormat()} (familie-ef-sak) --- \n$beskrivelseEllerDefault"
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtilTest.kt
@@ -24,7 +24,7 @@ class OppgaveUtilTest {
     @Test
     fun `skal legge på beskrivelse hvis beskrivelse ikke er null`() {
         val beskrivelse = "Dette er tekst"
-        val forventetOppgavebeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelse"
+        val forventetOppgavebeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} (familie-ef-sak) --- \n$beskrivelse"
         val lagOpprettOppgavebeskrivelse = lagOpprettOppgavebeskrivelse(beskrivelse)
         assertThat(lagOpprettOppgavebeskrivelse).isEqualTo(forventetOppgavebeskrivelse)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/OppgaveServiceTest.kt
@@ -138,7 +138,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \nOppgave opprettet"
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} (familie-ef-sak) --- \nOppgave opprettet"
         assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }
 
@@ -178,7 +178,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n$beskrivelse"
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} (familie-ef-sak) --- \n$beskrivelse"
         assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }
 
@@ -203,7 +203,7 @@ internal class OppgaveServiceTest {
         assertThat(slot.captured.fristFerdigstillelse).isAfterOrEqualTo(LocalDate.now().plusDays(1))
         assertThat(slot.captured.aktivFra).isEqualTo(LocalDate.now())
         assertThat(slot.captured.tema).isEqualTo(Tema.ENF)
-        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} familie-ef-sak --- \n"
+        val forventetBeskrivelse = "--- ${dagensDatoMedTidNorskFormat()} (familie-ef-sak) --- \n"
 
         assertThat(slot.captured.beskrivelse).isEqualTo(forventetBeskrivelse)
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

(Tester i preprod/gosys sammen med M.S. før deploy )

Oppgaveliste i gosys viser siste beskrivelse på oppgave uten metadata dersom linje inneholder --- [noe] () ---

Legger derfor til "()" rundt familie-ef-sak.

