### PR TITLE
Endepunkt som skal brukes av tilleggsstønader for å hente ut perioder med overgangsstønad og skolepenger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-validation-spring.version>5.0.5</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20240906070327_03089ba</kontrakter.version>
+        <kontrakter.version>3.0_20240910132054_758502e</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.18.1</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
@@ -9,6 +9,7 @@ import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderMedBeløpResponse
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
+import no.nav.familie.kontrakter.felles.ef.OvergangsstønadOgSkolepengerResponse
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -90,4 +91,18 @@ class EksternStønadsperioderController(
         }
         return Ressurs.success(perioderForBarnetrygdService.hentPerioderMedFullOvergangsstønad(request))
     }
+
+    /**
+     * Brukes av tilleggstønader, for å vurdere barnetilsyn-ytelse. Henter kun perioder med OS og SP.
+     */
+    @PostMapping("overgangsstonad-og-skolepenger")
+    fun hentPerioderMedOvergangsstonadOgSkolepenger(
+        @RequestBody request: EksternePerioderRequest,
+    ): Ressurs<OvergangsstønadOgSkolepengerResponse> =
+        try {
+            Ressurs.success(eksternStønadsperioderService.hentPerioderForOvergangsstønadOgSkolepenger(request))
+        } catch (e: Exception) {
+            secureLogger.error("Kunne ikke hente perioder for $request", e)
+            Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
+        }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/stønadsperiode/EksternStønadsperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/stønadsperiode/EksternStønadsperioderService.kt
@@ -6,8 +6,11 @@ import no.nav.familie.ef.sak.infotrygd.PeriodeService
 import no.nav.familie.kontrakter.felles.Datoperiode
 import no.nav.familie.kontrakter.felles.ef.EksternPeriode
 import no.nav.familie.kontrakter.felles.ef.EksternPeriodeMedBeløp
+import no.nav.familie.kontrakter.felles.ef.EksternPeriodeMedStønadstype
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
+import no.nav.familie.kontrakter.felles.ef.OvergangsstønadOgSkolepengerResponse
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -22,6 +25,31 @@ class EksternStønadsperioderService(
         val perioder = periodeService.hentPerioderFraEfOgInfotrygd(request.personIdent)
         val perioderFraITogEF = ArenaPeriodeUtil.slåSammenPerioderFraEfOgInfotrygd(request, perioder)
         return EksternePerioderResponse(perioderFraITogEF)
+    }
+
+    fun hentPerioderForOvergangsstønadOgSkolepenger(request: EksternePerioderRequest): OvergangsstønadOgSkolepengerResponse {
+        val perioderOS = periodeService.hentPerioderFraEf(setOf(request.personIdent), StønadType.OVERGANGSSTØNAD)
+        val perioderSP = periodeService.hentPerioderFraEf(setOf(request.personIdent), StønadType.SKOLEPENGER)
+
+        val eksternPeriodeMedStønadstypeOS =
+            perioderOS?.internperioder?.map {
+                EksternPeriodeMedStønadstype(
+                    it.stønadFom,
+                    it.stønadTom,
+                    StønadType.OVERGANGSSTØNAD,
+                )
+            } ?: emptyList()
+
+        val eksternPeriodeMedStønadstypeSP =
+            perioderSP?.internperioder?.map {
+                EksternPeriodeMedStønadstype(
+                    it.stønadFom,
+                    it.stønadTom,
+                    StønadType.SKOLEPENGER,
+                )
+            } ?: emptyList()
+
+        return OvergangsstønadOgSkolepengerResponse(request.personIdent, eksternPeriodeMedStønadstypeOS + eksternPeriodeMedStønadstypeSP)
     }
 
     fun hentPerioderForOvergangsstønad(request: EksternePerioderRequest): List<EksternPeriode> =

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/stønadsperiode/util/ArenaPeriodeUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/stønadsperiode/util/ArenaPeriodeUtil.kt
@@ -31,19 +31,20 @@ object ArenaPeriodeUtil {
                     tomDato = it.second.atEndOfMonth(),
                     datakilde = Datakilde.EF,
                 )
-            }.filter { overlapper(request, it) }
+            }.filter { overlapper(request, it.fomDato, it.tomDato) }
     }
 
     private fun overlapper(
         request: EksternePerioderRequest,
-        periode: EksternPeriode,
+        eksternPeriodeFomDato: LocalDate,
+        eksternPeriodeTomDato: LocalDate,
     ): Boolean {
         val requestFom = request.fomDato ?: LocalDate.now() // Arena sender alltid fom/tom-datoer, burde endre kontraktet
         val requestTom = request.tomDato ?: LocalDate.now()
-        val range = periode.fomDato..periode.tomDato
+        val range = eksternPeriodeFomDato..eksternPeriodeTomDato
         return requestFom in range ||
             requestTom in range ||
-            (requestFom < periode.fomDato && requestTom > periode.tomDato) // omslutter
+            (requestFom < eksternPeriodeFomDato && requestTom > eksternPeriodeTomDato) // omslutter
     }
 
     private fun slåSammenÅrMåneder(måneder: MutableSet<YearMonth>): MutableList<Pair<YearMonth, YearMonth>> =

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
@@ -53,7 +53,7 @@ class PeriodeService(
         return slåSammenPerioder(perioderFraEf, perioderFraReplika)
     }
 
-    private fun hentPerioderFraEf(
+    fun hentPerioderFraEf(
         personIdenter: Set<String>,
         stønadstype: StønadType,
     ): EfInternPerioder? =

--- a/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
+import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
 import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
@@ -32,6 +33,7 @@ internal class PeriodeServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
     private val replikaClient = mockk<InfotrygdReplikaClient>()
+    private val vedtakService = mockk<VedtakService>()
 
     private val service =
         PeriodeService(
@@ -40,6 +42,7 @@ internal class PeriodeServiceTest {
             behandlingService = behandlingService,
             tilkjentYtelseService = tilkjentYtelseService,
             infotrygdService = InfotrygdService(replikaClient, personService),
+            vedtakService = vedtakService,
         )
 
     private val personIdent = "123"

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -43,6 +43,7 @@ import no.nav.familie.ef.sak.vedtak.domain.KontantstøtteWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodetypeBarnetilsyn
 import no.nav.familie.ef.sak.vedtak.domain.SamordningsfradragType
+import no.nav.familie.ef.sak.vedtak.domain.SkolepengerWrapper
 import no.nav.familie.ef.sak.vedtak.domain.TilleggsstønadWrapper
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
@@ -330,6 +331,7 @@ fun vedtak(
     år: Int = 2021,
     inntekter: InntektWrapper = InntektWrapper(listOf(inntektsperiode(år = år))),
     perioder: PeriodeWrapper = PeriodeWrapper(listOf(vedtaksperiode(år = år))),
+    skolepenger: SkolepengerWrapper? = null,
     samordningsfradragType: SamordningsfradragType? = null,
 ): Vedtak =
     Vedtak(
@@ -340,6 +342,7 @@ fun vedtak(
         avslåBegrunnelse = null,
         perioder = perioder,
         inntekter = inntekter,
+        skolepenger = skolepenger,
         saksbehandlerIdent = "VL",
         opprettetAv = "VL",
         opprettetTid = LocalDateTime.now(),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tilleggstønader trenger å vite om overgangsstønadsperioder og skolepengeperioder for å avgjøre om bruker skal ha deres barnetilsyn-stønad. Henter overgangsstønad fra ef-sak og infotrygd, mens skolepenger bare hentes ut fra ny løsning. Skolepenger-perioden hentes fra vedtak og ikke tilkjent ytelse som følge av behovet til tilleggstønader.

Behov meldt i slack: https://nav-it.slack.com/archives/G012YEK9YQ1/p1724059196190939

Tester i preprod før merge.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22408)