### PR TITLE
Vil at saksbehandlere skal kunne migrere infotrygdsaker som ligger 5 …

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -290,10 +290,8 @@ class InfotrygdPeriodeValideringService(
     private fun utledÅrBakoverTillattVedMigrering(): Long {
         if (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE)) {
             return 7
-        } else if (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_5_ÅR_TILBAKE)) {
-            return 5
         }
-        return 3
+        return 5
     }
 
     private fun lagSakFeilinfo(sak: InfotrygdSak): String =

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
@@ -295,8 +295,8 @@ internal class MigreringServiceTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    internal fun `hentMigreringInfo - periode eldre enn 3 år - kan gå videre til journalføring`() {
-        val stønadsmåned = YearMonth.now().minusYears(3).minusMonths(1)
+    internal fun `hentMigreringInfo - periode eldre enn 5 år - kan gå videre til journalføring`() {
+        val stønadsmåned = YearMonth.now().minusYears(5).minusMonths(1)
         val periode =
             InfotrygdPeriodeTestUtil.lagInfotrygdPeriode(
                 stønadFom = stønadsmåned.atDay(1),
@@ -313,7 +313,7 @@ internal class MigreringServiceTest : OppslagSpringRunnerTest() {
 
         assertThat(migreringInfo.kanMigreres).isFalse
         assertThat(migreringInfo.kanGåVidereTilJournalføring).isTrue
-        assertThat(migreringInfo.årsak).contains("Kan ikke migrere når forrige utbetaling i infotrygd er mer enn 3 år tilbake")
+        assertThat(migreringInfo.årsak).contains("Kan ikke migrere når forrige utbetaling i infotrygd er mer enn 5 år tilbake")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
@@ -55,7 +55,7 @@ internal class InfotrygdPeriodeValideringServiceTest {
 
         @Test
         internal fun `skal kunne journalføre når det ikke trengs migrering - når personen har perioder langt bak i tiden`() {
-            val dato = YearMonth.now().minusYears(4)
+            val dato = YearMonth.now().minusYears(6)
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
                 infotrygdPerioderDto(
                     listOf(
@@ -121,8 +121,8 @@ internal class InfotrygdPeriodeValideringServiceTest {
     @Nested
     inner class ValiderHentPeriodeForMigrering {
         @Test
-        internal fun `Skal kaste feil hvis perioder er mer enn tre år tilbake i tid`() {
-            val dato = YearMonth.now().minusYears(4)
+        internal fun `Skal kaste feil hvis perioder er mer enn fem år tilbake i tid`() {
+            val dato = YearMonth.now().minusYears(6)
             every { infotrygdService.hentDtoPerioder(personIdent) } returns
                 infotrygdPerioderDto(
                     listOf(
@@ -140,7 +140,7 @@ internal class InfotrygdPeriodeValideringServiceTest {
                         OVERGANGSSTØNAD,
                     )
                 }.message
-            assertThat(message).contains("Kan ikke migrere når forrige utbetaling i infotrygd er mer enn 3 år tilbake i tid")
+            assertThat(message).contains("Kan ikke migrere når forrige utbetaling i infotrygd er mer enn 5 år tilbake i tid")
         }
 
         @Test


### PR DESCRIPTION
Vil at saksbehandlere skal kunne migrere infotrygdsaker som ligger 5 år tilbake i tid. Denne grensen har vært 3 år.

### Hvorfor er denne endringen nødvendig? ✨

Grensen på tre år var mer fornuftig for tre år siden. Nå bør 5 år være helt greit. 

Mulig sideeffekt - det er ikke mulig å opprette behandling dersom det finnes infotrygdsak nyere enn 5 år før man migrerer sak. Tidligere var denne grensen 3 år. utledÅrBakoverTillattVedMigrering brukes altså to steder til to ganske forskjellige ting. Vi kan vurdere å endre på dette. Lager forslag til oppgave i favro. 

Har snakket med H og L om dette og kommet fram til at dette er noe vi kan leve med nå. 

Se endringer i test: 'skal kunne journalføre når det ikke trengs migrering - når personen har perioder langt bak i tiden' for detaljer. 

_EDIT: PS sideeffekt: 
Vi sjekker dette på førstegangsbehandlinger, så vi vil ikke få problemer med revurderinger som allerede er opprettet med gammel grense (3 år)_ 

