### PR TITLE
Skal bruke fødsel-termindato i stedet for bruk av fødselsnummer ifm o…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.3</version>
+        <version>3.3.4</version>
     </parent>
     <repositories>
         <repository>
@@ -38,10 +38,10 @@
         <token-validation-spring.version>5.0.5</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20240913135049_042822f</kontrakter.version>
+        <kontrakter.version>3.0_20240919121839_57daa74</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
-        <cucumber.version>7.18.1</cucumber.version>
+        <cucumber.version>7.19.0</cucumber.version>
 
 
         <!--suppress UnresolvedMavenProperty  Ligger som secret i github-->

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -83,7 +83,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
 
     private fun opprettOppgaveForBarn(barn: List<BarnTilUtplukkForOppgave>): List<OpprettOppgaveForBarn> =
         barn.mapNotNull {
-            Alder.fromFødselsdato(fødselsdato(it))?.let { alder ->
+            Alder.fromFødselsdato(it.termindatoBarn)?.let { alder ->
                 OpprettOppgaveForBarn(
                     it.fødselsnummerBarn!!,
                     it.fødselsnummerSøker,
@@ -135,8 +135,6 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
                 }
             }
     }
-
-    private fun fødselsdato(barnTilUtplukkForOppgave: BarnTilUtplukkForOppgave): LocalDate? = barnTilUtplukkForOppgave.termindatoBarn
 
     private data class FødselsnummerOgAlder(
         val fødselsnummer: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -136,10 +136,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
             }
     }
 
-    private fun fødselsdato(barnTilUtplukkForOppgave: BarnTilUtplukkForOppgave): LocalDate? =
-        barnTilUtplukkForOppgave.termindatoBarn?.let {
-            it
-        }
+    private fun fødselsdato(barnTilUtplukkForOppgave: BarnTilUtplukkForOppgave): LocalDate? = barnTilUtplukkForOppgave.termindatoBarn
 
     private data class FødselsnummerOgAlder(
         val fødselsnummer: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -3,7 +3,6 @@ package no.nav.familie.ef.sak.iverksett.oppgaveforbarn
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.opplysninger.mapper.finnBesteMatchPåFødselsnummerForTermindato
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
-import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
@@ -138,8 +137,8 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
     }
 
     private fun fødselsdato(barnTilUtplukkForOppgave: BarnTilUtplukkForOppgave): LocalDate? =
-        barnTilUtplukkForOppgave.fødselsnummerBarn?.let {
-            Fødselsnummer(it).fødselsdato
+        barnTilUtplukkForOppgave.termindatoBarn?.let {
+            it
         }
 
     private data class FødselsnummerOgAlder(


### PR DESCRIPTION
…ppretting av oppfølgingsoppgaver for barn som har fylt året

### Hvorfor er denne endringen nødvendig? ✨

Vi trenger å fase ut utledningen av fødselsdato fra fødselsnummer. Vi starter med fødselsdatoer i forbindelse med oppfølgingsoppgaver for barn som har fylt år.

Dette er delvis et utkast akkurat nå, og testene er enda ikke tilpasset. Spørsmålet er: Kan vi bruke 'fødselTermindato' her, siden denne skal være koblet med fødselsdato fra PDL ? (se koblede behandling-register barn)

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22634