### PR TITLE
Endepunkt for tilleggsstønader: Hent perioder for ytelser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-validation-spring.version>5.0.5</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20241004134208_2962899</kontrakter.version>
+        <kontrakter.version>3.0_20241009100044_c0fcd51</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.20.0</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
@@ -6,10 +6,11 @@ import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.ef.EksternePerioderForStønadstyperRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderMedBeløpResponse
+import no.nav.familie.kontrakter.felles.ef.EksternePerioderMedStønadstypeResponse
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
-import no.nav.familie.kontrakter.felles.ef.OvergangsstønadOgSkolepengerResponse
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -98,9 +99,23 @@ class EksternStønadsperioderController(
     @PostMapping("overgangsstonad-og-skolepenger")
     fun hentPerioderMedOvergangsstonadOgSkolepenger(
         @RequestBody request: EksternePerioderRequest,
-    ): Ressurs<OvergangsstønadOgSkolepengerResponse> =
+    ): Ressurs<EksternePerioderMedStønadstypeResponse> =
         try {
             Ressurs.success(eksternStønadsperioderService.hentPerioderForOvergangsstønadOgSkolepenger(request))
+        } catch (e: Exception) {
+            secureLogger.error("Kunne ikke hente perioder for $request", e)
+            Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
+        }
+
+    /**
+     * Brukes av tilleggstønader, for å vurdere barnetilsyn-ytelse. Trenger noen ganger å filtrere vekk barnetilsyn.
+     */
+    @PostMapping("perioder-for-ytelser")
+    fun hentPerioderForYtelser(
+        @RequestBody request: EksternePerioderForStønadstyperRequest,
+    ): Ressurs<EksternePerioderMedStønadstypeResponse> =
+        try {
+            Ressurs.success(eksternStønadsperioderService.hentPerioderForYtelser(request))
         } catch (e: Exception) {
             secureLogger.error("Kunne ikke hente perioder for $request", e)
             Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/PeriodeService.kt
@@ -56,6 +56,15 @@ class PeriodeService(
         return slåSammenPerioder(perioderFraEf, perioderFraReplika)
     }
 
+    fun hentPerioderForBarnetilsynFraEfOgInfotrygd(personIdent: String): List<InternPeriode> {
+        val personIdenter = personService.hentPersonIdenter(personIdent).identer()
+        val perioderFraReplika =
+            infotrygdService.hentSammenslåttePerioderSomInternPerioder(personIdenter).barnetilsyn
+        val perioderFraEf = hentPerioderFraEf(personIdenter, StønadType.BARNETILSYN)
+
+        return slåSammenPerioder(perioderFraEf, perioderFraReplika)
+    }
+
     fun hentPeriodeFraVedtakForSkolepenger(personIdent: String): List<EksternPeriodeMedStønadstype> {
         val personIdenter = personService.hentPersonIdenter(personIdent).identer()
         val skoleårsperioder =

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/EksternStønadsperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/EksternStønadsperioderServiceTest.kt
@@ -28,6 +28,7 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.ef.Datakilde
 import no.nav.familie.kontrakter.felles.ef.EksternPeriode
+import no.nav.familie.kontrakter.felles.ef.EksternePerioderForStønadstyperRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderRequest
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions.assertThat
@@ -157,6 +158,36 @@ internal class EksternStønadsperioderServiceTest {
         mockPdl()
         mockNyLøsning(efSakPeriode.atDay(1), efSakPeriode.atEndOfMonth())
         val perioder = service.hentPerioderForOvergangsstønadOgSkolepenger(EksternePerioderRequest(ident)).perioder
+
+        assertThat(perioder).hasSize(2)
+        assertThat(perioder.first().fomDato).isEqualTo(efSakPeriode.atDay(1))
+        assertThat(perioder.first().tomDato).isEqualTo(efSakPeriode.atEndOfMonth())
+        assertThat(perioder.first().stønadstype).isEqualTo(StønadType.OVERGANGSSTØNAD)
+
+        assertThat(perioder.last().fomDato).isEqualTo(of(2023, 8, 1))
+        assertThat(perioder.last().tomDato).isEqualTo(of(2024, 6, 30))
+        assertThat(perioder.last().stønadstype).isEqualTo(StønadType.SKOLEPENGER)
+    }
+
+    @Test
+    internal fun `finn perioder gitt OS som stønadstype`() {
+        val efSakPeriode = YearMonth.of(2021, 3)
+        mockPdl()
+        mockNyLøsning(efSakPeriode.atDay(1), efSakPeriode.atEndOfMonth())
+        val perioder = service.hentPerioderForYtelser(EksternePerioderForStønadstyperRequest(ident, stønadstyper = listOf(StønadType.OVERGANGSSTØNAD))).perioder
+
+        assertThat(perioder).hasSize(1)
+        assertThat(perioder.first().fomDato).isEqualTo(efSakPeriode.atDay(1))
+        assertThat(perioder.first().tomDato).isEqualTo(efSakPeriode.atEndOfMonth())
+        assertThat(perioder.first().stønadstype).isEqualTo(StønadType.OVERGANGSSTØNAD)
+    }
+
+    @Test
+    internal fun `finn perioder gitt stønadstype uten ytelser gitt skal returnere alle`() {
+        val efSakPeriode = YearMonth.of(2021, 3)
+        mockPdl()
+        mockNyLøsning(efSakPeriode.atDay(1), efSakPeriode.atEndOfMonth())
+        val perioder = service.hentPerioderForYtelser(EksternePerioderForStønadstyperRequest(ident, stønadstyper = emptyList())).perioder
 
         assertThat(perioder).hasSize(2)
         assertThat(perioder.first().fomDato).isEqualTo(efSakPeriode.atDay(1))


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tilleggsstønader trenger noen ganger barnetilsyn, legger derfor til støtte for å filtrere på stønadstype.
Tilleggstønader er i prod og lar derfor det andre endepunktet leve inntil de har gått over til nytt endepunkt.