### PR TITLE
Ekstra info til beboer-knappen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.sak.fagsak
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.dto.Søkeresultat
-import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPersonEkstra
+import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatUtenFagsak
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
 import no.nav.familie.ef.sak.felles.util.FnrUtil.validerIdent
@@ -63,7 +63,7 @@ class SøkController(
     @GetMapping("{behandlingId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåBehandling(
         @PathVariable behandlingId: UUID,
-    ): Ressurs<SøkeresultatPersonEkstra> {
+    ): Ressurs<SøkeresultatPerson> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåBehandling(behandlingId))
     }
@@ -71,7 +71,7 @@ class SøkController(
     @GetMapping("fagsak/{fagsakId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåFagsak(
         @PathVariable fagsakId: UUID,
-    ): Ressurs<SøkeresultatPersonEkstra> {
+    ): Ressurs<SøkeresultatPerson> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåFagsak(fagsakId))
     }
@@ -79,7 +79,7 @@ class SøkController(
     @GetMapping("fagsak-person/{fagsakPersonId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåFagsakPerson(
         @PathVariable fagsakPersonId: UUID,
-    ): Ressurs<SøkeresultatPersonEkstra> {
+    ): Ressurs<SøkeresultatPerson> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåFagsakPerson(fagsakPersonId))
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
@@ -2,7 +2,7 @@ package no.nav.familie.ef.sak.fagsak
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.dto.Søkeresultat
-import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
+import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPersonEkstra
 import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatUtenFagsak
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
 import no.nav.familie.ef.sak.felles.util.FnrUtil.validerIdent
@@ -63,7 +63,7 @@ class SøkController(
     @GetMapping("{behandlingId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåBehandling(
         @PathVariable behandlingId: UUID,
-    ): Ressurs<SøkeresultatPerson> {
+    ): Ressurs<SøkeresultatPersonEkstra> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåBehandling(behandlingId))
     }
@@ -71,7 +71,7 @@ class SøkController(
     @GetMapping("fagsak/{fagsakId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåFagsak(
         @PathVariable fagsakId: UUID,
-    ): Ressurs<SøkeresultatPerson> {
+    ): Ressurs<SøkeresultatPersonEkstra> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåFagsak(fagsakId))
     }
@@ -79,7 +79,7 @@ class SøkController(
     @GetMapping("fagsak-person/{fagsakPersonId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåFagsakPerson(
         @PathVariable fagsakPersonId: UUID,
-    ): Ressurs<SøkeresultatPerson> {
+    ): Ressurs<SøkeresultatPersonEkstra> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåFagsakPerson(fagsakPersonId))
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
@@ -162,7 +162,7 @@ class SøkService(
         person: PdlPersonFraSøk,
         grunnlag: VilkårGrunnlagDto?,
     ): PersonFraSøk {
-        val gjeldeneBarn = grunnlag?.barnMedSamvær?.find { it.registergrunnlag.fødselsnummer == person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer }
+        val gjeldendeBarn = grunnlag?.barnMedSamvær?.find { it.registergrunnlag.fødselsnummer == person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer }
         val erSøker = grunnlag?.personalia?.personIdent == person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer
         val erBarn = grunnlag?.barnMedSamvær?.any { it.registergrunnlag.fødselsnummer == person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer }
         return PersonFraSøk(
@@ -172,7 +172,7 @@ class SøkService(
                     .gjeldende()
                     ?.let { adresseMapper.tilAdresse(it).visningsadresse },
             visningsnavn = NavnDto.fraNavn(person.navn.gjeldende()).visningsnavn,
-            fødselsdato = gjeldeneBarn?.registergrunnlag?.fødselsdato,
+            fødselsdato = gjeldendeBarn?.registergrunnlag?.fødselsdato,
             erSøker = erSøker,
             erBarn = erBarn,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
@@ -144,7 +144,7 @@ class SøkService(
                     .sortedWith(
                         compareByDescending<PersonFraSøkEkstraInfo> { it.erSøker }
                             .thenByDescending { it.erBarn }
-                            .thenBy { it.fødselsdato },
+                            .thenByDescending { it.fødselsdato },
                     ),
         )
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.fagsak.dto
 
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Kjønn
 import no.nav.familie.kontrakter.felles.ef.StønadType
+import java.time.LocalDate
 import java.util.UUID
 
 data class Søkeresultat(
@@ -23,6 +24,19 @@ data class PersonFraSøk(
     val personIdent: String,
     val visningsadresse: String?,
     val visningsnavn: String,
+)
+
+data class PersonFraSøkEkstraInfo( // TODO: rename
+    val personIdent: String,
+    val visningsadresse: String?,
+    val visningsnavn: String,
+    val fødselsdato: LocalDate?,
+    val erSøker: Boolean?,
+    val erBarn: Boolean?,
+)
+
+data class SøkeresultatPersonEkstra(
+    val personer: List<PersonFraSøkEkstraInfo>,
 )
 
 data class SøkeresultatPerson(

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
@@ -24,26 +24,13 @@ data class PersonFraSøk(
     val personIdent: String,
     val visningsadresse: String?,
     val visningsnavn: String,
-)
-
-data class PersonFraSøkEkstraInfo( // TODO: rename
-    val personIdent: String,
-    val visningsadresse: String?,
-    val visningsnavn: String,
     val fødselsdato: LocalDate?,
     val erSøker: Boolean?,
     val erBarn: Boolean?,
 )
 
-data class SøkeresultatPersonEkstra(
-    val personer: List<PersonFraSøkEkstraInfo>,
-)
-
 data class SøkeresultatPerson(
-    val hits: List<PersonFraSøk>,
-    val totalHits: Int,
-    val pageNumber: Int,
-    val totalPages: Int,
+    val personer: List<PersonFraSøk>,
 )
 
 data class SøkeresultatUtenFagsak(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -6,12 +6,14 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.SøkService
-import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøk
-import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
+import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøkEkstraInfo
+import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPersonEkstra
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil.mockVilkårGrunnlagDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlSaksbehandlerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Bostedsadresse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.FolkeregisteridentifikatorFraSøk
@@ -23,6 +25,8 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PersonSøkTreff
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Vegadresse
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.pdlSøker
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.ukjentBostedsadresse
+import no.nav.familie.ef.sak.vilkår.VurderingService
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -37,6 +41,7 @@ internal class SøkServiceTest {
     private val adresseMapper: AdresseMapper = AdresseMapper(KodeverkServiceMock().kodeverkService())
     private val behandlingService = mockk<BehandlingService>()
     private val fagsakPersonService = mockk<FagsakPersonService>()
+    private val vurderingService = mockk<VurderingService>()
     private val søkService =
         SøkService(
             fagsakPersonService,
@@ -45,13 +50,26 @@ internal class SøkServiceTest {
             pdlSaksbehandlerClient,
             adresseMapper,
             fagsakService,
+            vurderingService,
         )
 
     @BeforeEach
     internal fun setUp() {
-        every {
-            behandlingService.hentAktivIdent(any())
-        } returns "ident"
+        every { behandlingService.hentAktivIdent(any()) } returns "ident"
+        every { vurderingService.hentGrunnlagOgMetadata(any()) } returns
+            Pair(
+                mockVilkårGrunnlagDto(),
+                HovedregelMetadata(
+                    null,
+                    Sivilstandstype.UGIFT,
+                    false,
+                    emptyList(),
+                    emptyList(),
+                    emptyList(),
+                    mockk(),
+                    mockk(),
+                ),
+            )
     }
 
     @Test
@@ -112,13 +130,16 @@ internal class SøkServiceTest {
         } returns pdlSøker(bostedsadresse = bostedsadresseFraPdl)
 
         val forventetResultat =
-            PersonFraSøk(
+            PersonFraSøkEkstraInfo(
                 personIdent = "123456789",
                 visningsadresse = "Adressenavn 23 A, 0000 Oslo",
                 "Fornavn Mellomnavn Etternavn",
+                fødselsdato = null,
+                erSøker = false,
+                erBarn = false,
             )
 
-        val person = SøkeresultatPerson(listOf(forventetResultat), 1, 1, 1)
+        val person = SøkeresultatPersonEkstra(listOf(forventetResultat))
         assertThat(søkService.søkEtterPersonerMedSammeAdressePåBehandling(UUID.randomUUID())).isEqualTo(person)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -6,8 +6,8 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.SøkService
-import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøkEkstraInfo
-import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPersonEkstra
+import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøk
+import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil.mockVilkårGrunnlagDto
@@ -130,7 +130,7 @@ internal class SøkServiceTest {
         } returns pdlSøker(bostedsadresse = bostedsadresseFraPdl)
 
         val forventetResultat =
-            PersonFraSøkEkstraInfo(
+            PersonFraSøk(
                 personIdent = "123456789",
                 visningsadresse = "Adressenavn 23 A, 0000 Oslo",
                 "Fornavn Mellomnavn Etternavn",
@@ -139,7 +139,7 @@ internal class SøkServiceTest {
                 erBarn = false,
             )
 
-        val person = SøkeresultatPersonEkstra(listOf(forventetResultat))
+        val person = SøkeresultatPerson(listOf(forventetResultat))
         assertThat(søkService.søkEtterPersonerMedSammeAdressePåBehandling(UUID.randomUUID())).isEqualTo(person)
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker å sende med noen ekstra felter i responsen fra kall mot `samme-adresse`.
Feltene skal brukes for å gjøre det enklere å se hvilke personer som er relevante fra "beboer-knappen".

`erSøker` og `erBarn` kan samles til `erAktuelle`, da disse feltene uansett blir behandlet likt i frontend. Tanken var at disse skulle brukes for å enkelt skille søker fra søker sine barn...

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22526)