### PR TITLE
Fjerner bruk av utledning av fødselsdato fra fødselsnummer i AlderPåBa…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
@@ -44,7 +44,6 @@ import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
-import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -292,7 +291,10 @@ class TestSaksbehandlingController(
                         harSkalHaSammeAdresse = true,
                         ikkeRegistrertPåSøkersAdresseBeskrivelse = "Fordi",
                         erBarnetFødt = true,
-                        fødselTermindato = Fødselsnummer(it.key).fødselsdato,
+                        fødselTermindato =
+                            it.value.fødselsdato
+                                .first()
+                                .fødselsdato ?: LocalDate.now(),
                         annenForelder =
                             TestsøknadBuilder.Builder().defaultAnnenForelder(
                                 ikkeOppgittAnnenForelderBegrunnelse = null,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingController.kt
@@ -294,7 +294,7 @@ class TestSaksbehandlingController(
                         fødselTermindato =
                             it.value.fødselsdato
                                 .first()
-                                .fødselsdato ?: LocalDate.now(),
+                                .fødselsdato ?: error("Fødselsdato kan ikke være null"),
                         annenForelder =
                             TestsøknadBuilder.Builder().defaultAnnenForelder(
                                 ikkeOppgittAnnenForelderBegrunnelse = null,

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -103,6 +103,9 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
     private fun hentFødselsdatoFraGrunnlagsdata(barn: BarnTilUtplukkForOppgave): LocalDate? {
         val grunnlagsdata = grunnlagsdataService.hentGrunnlagsdata(barn.behandlingId)
         val barnAvGrunnlagsdata = grunnlagsdata.grunnlagsdata.barn.filter { it.personIdent == barn.fødselsnummerBarn }
+        if (barnAvGrunnlagsdata.isEmpty()) {
+            secureLogger.warn("Fant ikke barn i grunnlagsdata for behandling ${barn.behandlingId} og fødselsnummer ${barn.fødselsnummerBarn}")
+        }
         return barnAvGrunnlagsdata
             .first()
             .fødsel

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -105,6 +105,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
         val barnAvGrunnlagsdata = grunnlagsdata.grunnlagsdata.barn.filter { it.personIdent == barn.fødselsnummerBarn }
         if (barnAvGrunnlagsdata.isEmpty()) {
             secureLogger.warn("Fant ikke barn i grunnlagsdata for behandling ${barn.behandlingId} og fødselsnummer ${barn.fødselsnummerBarn}")
+            return null
         }
         return barnAvGrunnlagsdata
             .first()

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
@@ -21,7 +21,6 @@ import no.nav.familie.ef.sak.vilkår.dto.BarnepassDto
 import no.nav.familie.ef.sak.vilkår.dto.PersonaliaDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
-import no.nav.familie.kontrakter.felles.Fødselsnummer
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -129,8 +128,7 @@ class VilkårGrunnlagService(
         return barnMedsamværMapper
             .slåSammenBarnMedSamvær(søknadsgrunnlag, barnMedSamværRegistergrunnlag, barnepass)
             .sortedByDescending {
-                it.registergrunnlag.fødselsnummer?.let { fødsesnummer -> Fødselsnummer(fødsesnummer).fødselsdato }
-                    ?: it.søknadsgrunnlag.fødselTermindato
+                it.registergrunnlag.fødselsdato ?: it.søknadsgrunnlag.fødselTermindato
             }
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
@@ -70,7 +70,7 @@ class AlderPåBarnRegel :
     private fun HovedregelMetadata.finnFødselsdatoEllerTermindatoForBarn(barnId: UUID?): LocalDate =
         vilkårgrunnlagDto.finnFødselsdatoForBarn(barnId)
             ?: barn.firstOrNull { it.id == barnId }?.fødselTermindato
-            ?: error("Kunne ikke finne hverken fødselsdato fra registerdata eller termindato")
+            ?: error("Kunne ikke finne hverken fødselsdato fra registerdata eller termindato for barnID=$barnId")
 
     private fun VilkårGrunnlagDto.finnFødselsdatoForBarn(barnId: UUID?): LocalDate? = barnMedSamvær.firstOrNull { it.barnId == barnId }?.registergrunnlag?.fødselsdato
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
@@ -15,7 +15,6 @@ import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.AlderPåBarnRegelUtil.harFullførtFjerdetrinn
-import no.nav.familie.kontrakter.felles.Fødselsnummer
 import java.time.LocalDate
 import java.util.UUID
 
@@ -66,9 +65,7 @@ class AlderPåBarnRegel :
         val fødselsdato =
             metadata.barn
                 .firstOrNull { it.id == barnId }
-                ?.personIdent
-                ?.let { Fødselsnummer(it).fødselsdato }
-                ?: error("Finner ikke ident til barn=$barnId")
+                ?.fødselTermindato ?: error("Finnes ingen fødsel-termindato for barn=$barnId")
         return harFullførtFjerdetrinn(fødselsdato)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vurdering
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.NesteRegel
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
@@ -62,12 +63,16 @@ class AlderPåBarnRegel :
         metadata: HovedregelMetadata,
         barnId: UUID?,
     ): Boolean {
-        val fødselsdato =
-            metadata.barn
-                .firstOrNull { it.id == barnId }
-                ?.fødselTermindato ?: error("Finnes ingen fødsel-termindato for barn=$barnId")
+        val fødselsdato = metadata.finnFødselsdatoEllerTermindatoForBarn(barnId)
         return harFullførtFjerdetrinn(fødselsdato)
     }
+
+    private fun HovedregelMetadata.finnFødselsdatoEllerTermindatoForBarn(barnId: UUID?): LocalDate =
+        vilkårgrunnlagDto.finnFødselsdatoForBarn(barnId)
+            ?: barn.firstOrNull { it.id == barnId }?.fødselTermindato
+            ?: error("Kunne ikke finne hverken fødselsdato fra registerdata eller termindato")
+
+    private fun VilkårGrunnlagDto.finnFødselsdatoForBarn(barnId: UUID?): LocalDate? = barnMedSamvær.firstOrNull { it.barnId == barnId }?.registergrunnlag?.fødselsdato
 
     companion object {
         private val unntakAlderMapping =

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -52,7 +52,7 @@ internal class OppdaterVilkårTest {
                 søknadBarnId = null,
                 personIdent = "01472152579",
                 navn = null,
-                fødselTermindato = null,
+                fødselTermindato = LocalDate.now().minusYears(3),
             )
         val barnUtenSøknad = barn.copy(id = UUID.randomUUID())
         val metadata =
@@ -89,7 +89,7 @@ internal class OppdaterVilkårTest {
                 søknadBarnId = null,
                 personIdent = FnrGenerator.generer(LocalDate.now().minusYears(5)),
                 navn = null,
-                fødselTermindato = null,
+                fødselTermindato = LocalDate.now().minusYears(5),
             )
         val barnUtenSøknad =
             barn.copy(
@@ -133,7 +133,7 @@ internal class OppdaterVilkårTest {
                 søknadBarnId = null,
                 personIdent = "03441983106",
                 navn = null,
-                fødselTermindato = null,
+                fødselTermindato = LocalDate.now().minusYears(5),
             )
         val barnUtenSøknad = barn.copy(id = UUID.randomUUID())
         val metadata =

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AktivitetspliktigAlderPåBarnRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AktivitetspliktigAlderPåBarnRegelTest.kt
@@ -10,11 +10,12 @@ import no.nav.familie.ef.sak.vilkår.regler.vilkår.AlderPåBarnRegel
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 import java.util.UUID
 
 class AktivitetspliktigAlderPåBarnRegelTest {
     val hovedregelMetadataMock = mockk<HovedregelMetadata>()
-    val behandlingBarnMedDnr = behandlingBarn(behandlingId = UUID.randomUUID(), personIdent = "06431960727", søknadBarnId = UUID.randomUUID())
+    val behandlingBarnMedDnr = behandlingBarn(behandlingId = UUID.randomUUID(), personIdent = "06431960727", søknadBarnId = UUID.randomUUID(), fødselTermindato = LocalDate.now().minusYears(5))
     val behandlingBarn2 = behandlingBarn(behandlingId = UUID.randomUUID(), personIdent = "03041983106", søknadBarnId = UUID.randomUUID())
 
     @BeforeEach
@@ -24,7 +25,7 @@ class AktivitetspliktigAlderPåBarnRegelTest {
     }
 
     @Test
-    fun `Vilkår ikke tatt stilling til og har fullført fjerdetrinn - skal automatisk oppfylle vilkår`() {
+    fun `Vilkår ikke tatt stilling til og har ikke fullført fjerdetrinn - skal automatisk oppfylle vilkår`() {
         val listDelvilkårsvurdering =
             AlderPåBarnRegel().initiereDelvilkårsvurdering(
                 hovedregelMetadataMock,

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AktivitetspliktigAlderPåBarnRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AktivitetspliktigAlderPåBarnRegelTest.kt
@@ -5,6 +5,10 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.behandlingBarn
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværSøknadsgrunnlagDto
+import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.AlderPåBarnRegel
 import org.assertj.core.api.Assertions
@@ -14,14 +18,48 @@ import java.time.LocalDate
 import java.util.UUID
 
 class AktivitetspliktigAlderPåBarnRegelTest {
+    val barnId = UUID.randomUUID()
     val hovedregelMetadataMock = mockk<HovedregelMetadata>()
     val behandlingBarnMedDnr = behandlingBarn(behandlingId = UUID.randomUUID(), personIdent = "06431960727", søknadBarnId = UUID.randomUUID(), fødselTermindato = LocalDate.now().minusYears(5))
     val behandlingBarn2 = behandlingBarn(behandlingId = UUID.randomUUID(), personIdent = "03041983106", søknadBarnId = UUID.randomUUID())
+    val vilkårGrunnlagDto = mockk<VilkårGrunnlagDto>()
+    val barnMedSamværSøknadsgrunnlagDto = mockk<BarnMedSamværSøknadsgrunnlagDto>()
+    val barnMedSamværRegistergrunnlagDto = mockk<BarnMedSamværRegistergrunnlagDto>()
+    val barnMedSamvær = BarnMedSamværDto(barnId, barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto)
 
     @BeforeEach
     fun setup() {
         every { hovedregelMetadataMock.barn } returns listOf(behandlingBarnMedDnr, behandlingBarn2)
         every { hovedregelMetadataMock.behandling } returns behandling()
+        every { hovedregelMetadataMock.vilkårgrunnlagDto } returns vilkårGrunnlagDto
+        every { vilkårGrunnlagDto.barnMedSamvær } returns listOf(barnMedSamvær)
+    }
+
+    @Test
+    fun `skal bruke fødselTermindato hvis fødselsdato ikke finnes i registerdata`() {
+        val listDelvilkårsvurdering =
+            AlderPåBarnRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                behandlingBarnMedDnr.id,
+            )
+
+        Assertions.assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.AUTOMATISK_OPPFYLT)
+    }
+
+    @Test
+    fun `skal bruke fødselsdato av registerdata hvis datoen finnes der`() {
+        every { barnMedSamværRegistergrunnlagDto.fødselsdato } returns LocalDate.now().minusYears(50)
+        every { vilkårGrunnlagDto.barnMedSamvær } returns listOf(BarnMedSamværDto(barnId, barnMedSamværSøknadsgrunnlagDto, barnMedSamværRegistergrunnlagDto))
+        val listDelvilkårsvurdering =
+            AlderPåBarnRegel().initiereDelvilkårsvurdering(
+                hovedregelMetadataMock,
+                Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+                barnId,
+            )
+        Assertions.assertThat(listDelvilkårsvurdering.size).isEqualTo(1)
+        Assertions.assertThat(listDelvilkårsvurdering.first().resultat).isEqualTo(Vilkårsresultat.IKKE_TATT_STILLING_TIL)
     }
 
     @Test


### PR DESCRIPTION
…rnRegel

### Hvorfor er denne endringen nødvendig? ✨

Fjerner utledning av fødselsdato fra fødselsnummer. Usikker på om bruk av fødselTermindato holder ? 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22634