### PR TITLE
Skal sjekke for metadata historisk-feltet ved uthenting av navn etter…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonUtil.kt
@@ -16,7 +16,7 @@ fun Personnavn.visningsnavn(): String =
         "$fornavn $mellomnavn $etternavn"
     }
 
-fun List<Navn>.gjeldende(): Navn = this.single()
+fun List<Navn>.gjeldende(): Navn = this.find { !it.metadata.historisk } ?: this.first()
 
 fun List<Bostedsadresse>.gjeldende(): Bostedsadresse? = this.find { !it.metadata.historisk }
 


### PR DESCRIPTION
…som det, for første gang siden oppstart, finnes personer med en liste av navn fra PDL. Litt merkelig at vi ikke har fått denne feilen tidligere, det burde være vanlig med navnebytte?

### Hvorfor er denne endringen nødvendig? ✨
[Ref teams-forespørsel](https://teams.microsoft.com/l/message/19:55fb7a15fdad4fb29e568d7dc617b52e@thread.tacv2/1729171094584?tenantId=62366534-1ec3-4962-8869-9b5535279d0b&groupId=11014155-e8a7-46ad-8be0-b5c10a863a36&parentMessageId=1729171094584&teamName=Team%20enslig%20fors%C3%B8rger%20kontinuerlig%20forbedring&channelName=EF%20sak%20(ny)&createdTime=1729171094584)