### PR TITLE
dersom bruker har mange journalposter i nav øyemed får vi ikke hentet…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
@@ -62,7 +62,7 @@ class JournalpostService(
                 tema = vedleggRequest.tema,
                 dokumenttype = vedleggRequest.dokumenttype,
                 journalpostStatus = vedleggRequest.journalpostStatus,
-                antall = 200,
+                antall = 10000,
             ),
         )
 


### PR DESCRIPTION
… ut alle relevante dokumenter på bruker. Øker derfor antallet dokumenter som hentes ut til det samme som gosys

### Hvorfor er denne endringen nødvendig? ✨
Skrur opp grensen på uthentede journalposter fra dokumentoversikten til 10000 - det samme antallet som gosys bruker dersom man først har hentet ut 300 og deretter ser at bruker har flere journalposter liggende.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22932)