### PR TITLE
henter ut grunnlagsdata for alle barn i BarnFyllerÅrOppfølgingsOppgav…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdat
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Personopplysninger
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
@@ -58,6 +59,11 @@ class GrunnlagsdataService(
         )
     }
 
+    fun hentGrunnlagsdataForBehandlinger(behandlingIder: Set<UUID>): Map<UUID, GrunnlagsdataMedMetadata> {
+        val grunnlagsdataForBehandlinger = hentLagretGrunnlagsdataForBehandlinger(behandlingIder)
+        return grunnlagsdataForBehandlinger.associate { it.behandlingId to GrunnlagsdataMedMetadata(it.data, it.sporbar.opprettetTid) }
+    }
+
     @Transactional
     fun oppdaterOgHentNyGrunnlagsdata(behandlingId: UUID): GrunnlagsdataMedMetadata {
         val behandling = behandlingService.hentBehandling(behandlingId)
@@ -77,6 +83,8 @@ class GrunnlagsdataService(
     }
 
     fun hentLagretGrunnlagsdata(behandlingId: UUID): Grunnlagsdata = grunnlagsdataRepository.findByIdOrThrow(behandlingId)
+
+    fun hentLagretGrunnlagsdataForBehandlinger(behandlingIder: Set<UUID>): List<Grunnlagsdata> = grunnlagsdataRepository.findAllByIdOrThrow(behandlingIder) { it.behandlingId }
 
     fun hentFraRegisterMedSøknadsdata(behandlingId: UUID): GrunnlagsdataDomene {
         val stønadstype = fagsakService.hentFagsakForBehandling(behandlingId).stønadstype

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveServiceTest.kt
@@ -89,10 +89,9 @@ internal class BarnFyllerÅrOppfølgingsoppgaveServiceTest {
         every { oppgaveRepository.findByTypeAndAlderIsNotNullAndBarnPersonIdenter(any(), any()) } returns emptyList()
         every { taskService.save(capture(taskSlot)) } returns mockk()
         every { personService.hentPersonForelderBarnRelasjon(any()) } returns emptyMap()
-        every { grunnlagsdataService.hentGrunnlagsdata(any()) } returns grunnlagsDataMedMetadata
         every { grunnlagsDataMedMetadata.grunnlagsdata } returns grunnlagsdataDomene
         every { grunnlagsdataDomene.barn } returns listOf(barnMedIdent("04042495250", "fornavn etternavn"))
-        every { grunnlagsdataService.hentGrunnlagsdata(any()) } returns grunnlagsDataMedMetadata
+        every { grunnlagsdataService.hentGrunnlagsdataForBehandlinger(any()) } answers { firstArg<Set<UUID>>().associateWith { grunnlagsDataMedMetadata } }
     }
 
     @AfterEach


### PR DESCRIPTION
…eTask i et kall mot databasen. Slik unngår vi timeout pga for mange kall på kort tid

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22930)

Tidligere har vi hentet ut grunnlagsdata for en og en behandling i denne tasken. Dette har ført til at tasken har brukt lang tid på å kjøre mot databasen. Skal nå hente ut all relevant grunnlagsdata i et kall.