### PR TITLE
Skal tillate at Mirja migrerer saker tilbake til 2009

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -287,7 +287,7 @@ class InfotrygdPeriodeValideringService(
 
     private fun hentDatogrenseForMigrering(): LocalDate {
         if (featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE)) {
-            return LocalDate.of(2016, 1, 1)
+            return LocalDate.of(2009, 1, 1)
         }
         return LocalDate.of(2019, 1, 1)
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringServiceTest.kt
@@ -167,9 +167,9 @@ internal class InfotrygdPeriodeValideringServiceTest {
         }
 
         @Test
-        internal fun `Skal kaste feil hvis perioder er før 2016-01-01`() {
-            val dato = YearMonth.of(2015, 12)
-            val grense = LocalDate.of(2016, 1, 1)
+        internal fun `Skal kaste feil hvis perioder er før 2009-01-01`() {
+            val dato = YearMonth.of(2008, 12)
+            val grense = LocalDate.of(2009, 1, 1)
 
             every { featureToggleService.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE) } returns true
             every { infotrygdService.hentDtoPerioder(personIdent) } returns


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å opphøre overgangsstønad og barnetilsyn tilbake til 2009 for en person