### PR TITLE
Fjern spørsmål delt bostedsavtale

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/Vilkårsvurdering.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.vilkår
 
 import no.nav.familie.ef.sak.felles.domain.Sporbar
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.ef.StønadType.BARNETILSYN
@@ -45,6 +46,11 @@ data class Vilkårsvurdering(
      * Brukes når man skal gjenbruke denne vilkårsvurderingen i en annan vilkårsvurdering
      */
     fun opprettOpphavsvilkår(): Opphavsvilkår = opphavsvilkår ?: Opphavsvilkår(behandlingId, sporbar.endret.endretTid)
+
+    fun gjeldendeDelvilkårsvurderinger(): List<Delvilkårsvurdering> =
+        this.delvilkårsvurdering.delvilkårsvurderinger.filter {
+            it.hovedregel.regelVersjon == RegelVersjon.GJELDENDE
+        }
 }
 
 fun List<Vilkårsvurdering>.utledVurderinger(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -20,7 +20,6 @@ import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.ef.sak.vilkår.gjenbruk.GjenbrukVilkårService
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
-import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkårsvurderinger
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -274,7 +273,7 @@ class VurderingService(
                         sporbar = Sporbar(),
                         barnId = finnBarnId(vurdering.barnId, barnIdMap),
                         opphavsvilkår = vurdering.opprettOpphavsvilkår(),
-                        delvilkårsvurdering = vurdering.delvilkårsvurdering.copy(delvilkårsvurderinger = vurdering.delvilkårsvurdering.delvilkårsvurderinger.filter { it.hovedregel.regelVersjon == RegelVersjon.GJELDENDE }),
+                        delvilkårsvurdering = vurdering.delvilkårsvurdering.copy(delvilkårsvurderinger = vurdering.gjeldendeDelvilkårsvurderinger()),
                     )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.ef.sak.vilkår.gjenbruk.GjenbrukVilkårService
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkårsvurderinger
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -273,6 +274,7 @@ class VurderingService(
                         sporbar = Sporbar(),
                         barnId = finnBarnId(vurdering.barnId, barnIdMap),
                         opphavsvilkår = vurdering.opprettOpphavsvilkår(),
+                        delvilkårsvurdering = vurdering.delvilkårsvurdering.copy(delvilkårsvurderinger = vurdering.delvilkårsvurdering.delvilkårsvurderinger.filter { it.hovedregel.regelVersjon == RegelVersjon.GJELDENDE }),
                     )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -101,17 +101,17 @@ class GjenbrukVilkårService(
         val barnForVurdering = forrigeBarnIdTilNåværendeBarnMap[tidligereVurdering.barnId]
         nåværendeVurderinger
             .firstOrNull { it.type == tidligereVurdering.type && it.barnId == barnForVurdering?.id }
-            ?.let { vurdering ->
+            ?.let { nåværendeVurdering ->
                 tidligereVurdering.copy(
-                    id = vurdering.id,
+                    id = nåværendeVurdering.id,
                     behandlingId = behandlingId,
-                    sporbar = vurdering.sporbar,
-                    barnId = vurdering.barnId,
+                    sporbar = nåværendeVurdering.sporbar,
+                    barnId = nåværendeVurdering.barnId,
                     opphavsvilkår = tidligereVurdering.opprettOpphavsvilkår(),
                     delvilkårsvurdering =
-                        vurdering.delvilkårsvurdering.copy(
+                        tidligereVurdering.delvilkårsvurdering.copy(
                             delvilkårsvurderinger =
-                                vurdering.gjeldendeDelvilkårsvurderinger(),
+                                tidligereVurdering.gjeldendeDelvilkårsvurderinger(),
                         ),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -101,13 +102,20 @@ class GjenbrukVilkårService(
         val barnForVurdering = forrigeBarnIdTilNåværendeBarnMap[tidligereVurdering.barnId]
         nåværendeVurderinger
             .firstOrNull { it.type == tidligereVurdering.type && it.barnId == barnForVurdering?.id }
-            ?.let {
+            ?.let { vurdering ->
                 tidligereVurdering.copy(
-                    id = it.id,
+                    id = vurdering.id,
                     behandlingId = behandlingId,
-                    sporbar = it.sporbar,
-                    barnId = it.barnId,
+                    sporbar = vurdering.sporbar,
+                    barnId = vurdering.barnId,
                     opphavsvilkår = tidligereVurdering.opprettOpphavsvilkår(),
+                    delvilkårsvurdering =
+                        vurdering.delvilkårsvurdering.copy(
+                            delvilkårsvurderinger =
+                                vurdering.delvilkårsvurdering.delvilkårsvurderinger.filter { delvurdering ->
+                                    delvurdering.hovedregel.regelVersjon == RegelVersjon.GJELDENDE
+                                },
+                        ),
                 )
             }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -18,7 +18,6 @@ import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
-import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -112,9 +111,7 @@ class GjenbrukVilkårService(
                     delvilkårsvurdering =
                         vurdering.delvilkårsvurdering.copy(
                             delvilkårsvurderinger =
-                                vurdering.delvilkårsvurdering.delvilkårsvurderinger.filter { delvurdering ->
-                                    delvurdering.hovedregel.regelVersjon == RegelVersjon.GJELDENDE
-                                },
+                                vurdering.gjeldendeDelvilkårsvurderinger(),
                         ),
                 )
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelId.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelId.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.vilkår.regler
 
 enum class RegelId(
     val beskrivelse: String,
+    val regelVersjon: RegelVersjon = RegelVersjon.GJELDENDE,
 ) {
     SLUTT_NODE("SLUTT_NODE"),
 
@@ -21,7 +22,7 @@ enum class RegelId(
     ),
 
     // Aleneomsorg
-    SKRIFTLIG_AVTALE_OM_DELT_BOSTED(""),
+    SKRIFTLIG_AVTALE_OM_DELT_BOSTED("", RegelVersjon.HISTORISK),
     NÆRE_BOFORHOLD(""),
     MER_AV_DAGLIG_OMSORG(""),
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelSteg.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.Feil
  * Ett [RegelSteg] er en regel med ett spørsmål med flere svar som mapper til en [SvarRegel]
  * @param regelId er id for spørsmålet
  * @param svarMapping er en mapping mellom svarId og regel for det svaret
+ * @param versjon forteller om spørsmålet tilhører nåværende regelverk eller er foreldet
  *
  * Eks
  * SPØRSMÅL_1 har 2 ulike svar,
@@ -19,12 +20,14 @@ import no.nav.familie.ef.sak.infrastruktur.exception.Feil
  *          "regelId": "SPØRSMÅL_2",
  *          "begrunnelseType": "UTEN"
  *      }
- *  }
+ *  },
+ *  [versjon]: "GJELDENDE",
  * }
  */
 data class RegelSteg(
     val regelId: RegelId,
     val svarMapping: Map<SvarId, SvarRegel>,
+    val versjon: RegelVersjon = RegelVersjon.GJELDENDE,
 ) {
     fun svarMapping(svarId: SvarId): SvarRegel = svarMapping[svarId] ?: throw Feil("Finner ikke svarId=$svarId for regelId=$regelId")
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelVersjon.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/RegelVersjon.kt
@@ -1,0 +1,12 @@
+package no.nav.familie.ef.sak.vilkår.regler
+
+/**
+ * [GJELDENDE] Spørsmålet skal fortsatt stilles og besvares siden dette kreves av gjeldende regelverk.
+ * [HISTORISK] Spørsmålet tilhører et foreldet regelverk og skal ikke stilles lenger. Allerede
+ *             besvarte spørsmål som tidligere har vært gjeldende men som nå er historiske skal
+ *             fortsatt vises i lesemodus i saksbehandlingen.
+ */
+enum class RegelVersjon {
+    GJELDENDE,
+    HISTORISK,
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -47,12 +47,14 @@ abstract class Vilkårsregel(
         resultat: Vilkårsresultat = Vilkårsresultat.IKKE_TATT_STILLING_TIL,
         barnId: UUID? = null,
     ): List<Delvilkårsvurdering> =
-        hovedregler.map {
+        gjeldendeHovedregler().map {
             Delvilkårsvurdering(
                 resultat,
                 vurderinger = listOf(Vurdering(it)),
             )
         }
+
+    fun gjeldendeHovedregler() = hovedregler.filter { regelId -> regler[regelId]?.let { it.versjon != RegelVersjon.HISTORISK } ?: error("Kan ikke initiere delvilkårsvurdering for regel som ikke finnes. RegelId=$regelId") }
 
     constructor(vilkårType: VilkårType, regler: Set<RegelSteg>, hovedregler: Set<RegelId>) :
         this(vilkårType, regler.associateBy { it.regelId }, hovedregler)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregel.kt
@@ -54,7 +54,7 @@ abstract class Vilkårsregel(
             )
         }
 
-    fun gjeldendeHovedregler() = hovedregler.filter { regelId -> regler[regelId]?.let { it.versjon != RegelVersjon.HISTORISK } ?: error("Kan ikke initiere delvilkårsvurdering for regel som ikke finnes. RegelId=$regelId") }
+    fun gjeldendeHovedregler() = hovedregler.filter { it.regelVersjon == RegelVersjon.GJELDENDE }
 
     constructor(vilkårType: VilkårType, regler: Set<RegelSteg>, hovedregler: Set<RegelId>) :
         this(vilkårType, regler.associateBy { it.regelId }, hovedregler)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregler.kt
@@ -50,7 +50,7 @@ fun vilkårsreglerForStønad(stønadstype: StønadType): List<Vilkårsregel> =
                 AktivitetRegel(),
                 SagtOppEllerRedusertRegel(),
                 TidligareVedtaksperioderRegel(),
-            )
+            ).map { vilkårsregel -> vilkårsregel }
         BARNETILSYN ->
             listOf(
                 ForutgåendeMedlemskapRegel(),

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/Vilkårsregler.kt
@@ -50,7 +50,7 @@ fun vilkårsreglerForStønad(stønadstype: StønadType): List<Vilkårsregel> =
                 AktivitetRegel(),
                 SagtOppEllerRedusertRegel(),
                 TidligareVedtaksperioderRegel(),
-            ).map { vilkårsregel -> vilkårsregel }
+            )
         BARNETILSYN ->
             listOf(
                 ForutgåendeMedlemskapRegel(),

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -12,7 +12,6 @@ import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.ef.sak.vilkår.harSvar
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
-import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregler.Companion.ALLE_VILKÅRSREGLER
@@ -77,10 +76,9 @@ object OppdaterVilkår {
     ): DelvilkårsvurderingWrapper {
         val vurderingerPåType = oppdatering.associateBy { it.vurderinger.first().regelId }
         val delvilkårsvurderinger =
-            vilkårsvurdering.delvilkårsvurdering.delvilkårsvurderinger
-                .filter {
-                    it.hovedregel.regelVersjon == RegelVersjon.GJELDENDE
-                }.map {
+            vilkårsvurdering
+                .gjeldendeDelvilkårsvurderinger()
+                .map {
                     if (it.resultat == Vilkårsresultat.IKKE_AKTUELL) {
                         it
                     } else {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkår.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import no.nav.familie.ef.sak.vilkår.harSvar
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregler.Companion.ALLE_VILKÅRSREGLER
@@ -77,7 +78,9 @@ object OppdaterVilkår {
         val vurderingerPåType = oppdatering.associateBy { it.vurderinger.first().regelId }
         val delvilkårsvurderinger =
             vilkårsvurdering.delvilkårsvurdering.delvilkårsvurderinger
-                .map {
+                .filter {
+                    it.hovedregel.regelVersjon == RegelVersjon.GJELDENDE
+                }.map {
                     if (it.resultat == Vilkårsresultat.IKKE_AKTUELL) {
                         it
                     } else {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValidering.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValidering.kt
@@ -93,14 +93,14 @@ object RegelValidering {
         tidligereDelvilkårsvurderinger: List<Delvilkårsvurdering>,
     ) {
         val aktuelleDelvilkår = aktuelleDelvilkår(tidligereDelvilkårsvurderinger)
-        val delvilkårRegelIdn = delvilkår.map { it.hovedregel() }
-        val aktuelleHvovedregler = vilkårsregel.hovedregler.filter { aktuelleDelvilkår.contains(it) }
-        feilHvis(!aktuelleHvovedregler.containsAll(delvilkårRegelIdn)) {
-            "Delvilkårsvurderinger savner svar på hovedregler - hovedregler=$aktuelleHvovedregler delvilkår=$delvilkårRegelIdn"
+        val delvilkårRegelIds = delvilkår.map { it.hovedregel() }
+        val aktuelleHovedregler = vilkårsregel.gjeldendeHovedregler().filter { aktuelleDelvilkår.contains(it) }
+        feilHvis(!aktuelleHovedregler.containsAll(delvilkårRegelIds)) {
+            "Delvilkårsvurderinger savner svar på hovedregler - hovedregler=$aktuelleHovedregler delvilkår=$delvilkårRegelIds"
         }
-        feilHvis(delvilkårRegelIdn.size != aktuelleHvovedregler.size) {
-            "Feil i antall regler dto har ${delvilkårRegelIdn.size} " +
-                "mens vilkår har ${aktuelleHvovedregler.size} aktuelle delvilkår"
+        feilHvis(delvilkårRegelIds.size != aktuelleHovedregler.size) {
+            "Feil i antall regler dto har ${delvilkårRegelIds.size} " +
+                "mens vilkår har ${aktuelleHovedregler.size} aktuelle delvilkår"
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AlderPåBarnRegel.kt
@@ -34,7 +34,7 @@ class AlderPåBarnRegel :
             return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
         }
 
-        return hovedregler.map {
+        return gjeldendeHovedregler().map {
             if (it == RegelId.HAR_ALDER_LAVERE_ENN_GRENSEVERDI && !harFullførtFjerdetrinn(metadata, barnId)) {
                 automatisktOppfyltHarAlderLavereEnnGrenseverdi()
             } else {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegel.kt
@@ -88,11 +88,9 @@ class AleneomsorgRegel :
 
     private fun harSammeAdresse(registergrunnlagBarn: BarnMedSamværRegistergrunnlagDto) = registergrunnlagBarn.harSammeAdresse ?: false
 
-    private fun erDonorbarn(søknadsgrunnlagBarn: BarnMedSamværSøknadsgrunnlagDto) =
-        søknadsgrunnlagBarn.ikkeOppgittAnnenForelderBegrunnelse?.lowercase() == "donor"
+    private fun erDonorbarn(søknadsgrunnlagBarn: BarnMedSamværSøknadsgrunnlagDto) = søknadsgrunnlagBarn.ikkeOppgittAnnenForelderBegrunnelse?.lowercase() == "donor"
 
-    private fun erTerminbarnOgOgHarSammeAdresse(søknadsgrunnlagBarn: BarnMedSamværSøknadsgrunnlagDto) =
-        søknadsgrunnlagBarn.erTerminbarn() && søknadsgrunnlagBarn.harSammeAdresse == true
+    private fun erTerminbarnOgOgHarSammeAdresse(søknadsgrunnlagBarn: BarnMedSamværSøknadsgrunnlagDto) = søknadsgrunnlagBarn.erTerminbarn() && søknadsgrunnlagBarn.harSammeAdresse == true
 
     private fun opprettAutomatiskVurdertAleneomsorgVilkår(): List<Delvilkårsvurdering> {
         val begrunnelseTekst = "Automatisk vurdert (${

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegel.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.vilkår.dto.LangAvstandTilSøker
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.RegelSteg
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.SluttSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
@@ -49,7 +50,7 @@ class AleneomsorgRegel :
             return opprettAutomatiskVurdertAleneomsorgVilkår()
         }
 
-        return hovedregler.map { hovedregel ->
+        return gjeldendeHovedregler().map { hovedregel ->
             if (
                 skalAutomatiskOppfylleNæreBoforhold(hovedregel, metadata, barnId)
             ) {
@@ -188,6 +189,7 @@ class AleneomsorgRegel :
             ).associateWith {
                 SluttSvarRegel.IKKE_OPPFYLT_MED_PÅKREVD_BEGRUNNELSE
             } + mapOf(SvarId.NEI to SluttSvarRegel.OPPFYLT_MED_PÅKREVD_BEGRUNNELSE)
+
         private val NÆRE_BOFORHOLD =
             RegelSteg(
                 regelId = RegelId.NÆRE_BOFORHOLD,
@@ -201,6 +203,7 @@ class AleneomsorgRegel :
                     hvisJa = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                     hvisNei = SluttSvarRegel.OPPFYLT_MED_VALGFRI_BEGRUNNELSE,
                 ),
+                versjon = RegelVersjon.HISTORISK,
             )
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/MorEllerFarRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/MorEllerFarRegel.kt
@@ -30,7 +30,7 @@ class MorEllerFarRegel :
             return super.initiereDelvilkårsvurdering(metadata, resultat, barnId)
         }
 
-        return hovedregler.map {
+        return gjeldendeHovedregler().map {
             if (it == RegelId.OMSORG_FOR_EGNE_ELLER_ADOPTERTE_BARN && erMorEllerFarForAlleBarn(metadata)) {
                 automatiskVurdertDelvilkår(RegelId.OMSORG_FOR_EGNE_ELLER_ADOPTERTE_BARN, SvarId.JA, "Bruker søker stønad for egne/adopterte barn.")
             } else {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/SivilstandRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/SivilstandRegel.kt
@@ -56,7 +56,7 @@ class SivilstandRegel :
             return listOf(automatiskVurdertDelvilkår(RegelId.KRAV_SIVILSTAND_UTEN_PÅKREVD_BEGRUNNELSE, SvarId.JA, "Bruker er ${metadata.sivilstandstype.visningsnavn.lowercase()}."))
         }
 
-        return hovedregler.map {
+        return gjeldendeHovedregler().map {
             val resultatForDelvilkår = if (it == hovedregel) resultat else Vilkårsresultat.IKKE_AKTUELL
             Delvilkårsvurdering(resultat = resultatForDelvilkår, listOf(Vurdering(it)))
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/api/gui/VurderingControllerTest.kt
@@ -320,12 +320,15 @@ internal class VurderingControllerTest : OppslagSpringRunnerTest() {
                     ?.vurderinger
                     ?.first { it.vilkårType == VilkårType.ALENEOMSORG }
 
-            val vurderingDeltBosted = utledVurdering(aleneOmsorgVilkår, RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
             val vurderingNæreBoforhold = utledVurdering(aleneOmsorgVilkår, RegelId.NÆRE_BOFORHOLD)
             val vurderingDagligOmsorg = utledVurdering(aleneOmsorgVilkår, RegelId.MER_AV_DAGLIG_OMSORG)
 
-            assertThat(vurderingDeltBosted?.svar).isNull()
-            assertThat(vurderingDeltBosted?.begrunnelse).isNull()
+            assertThat(aleneOmsorgVilkår?.delvilkårsvurderinger?.size).isEqualTo(2)
+            assertThat(
+                aleneOmsorgVilkår?.delvilkårsvurderinger?.flatMap { delvurdering ->
+                    delvurdering.vurderinger.map { it.regelId }
+                },
+            ).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
 
             assertThat(vurderingNæreBoforhold?.svar).isNull()
             assertThat(vurderingNæreBoforhold?.begrunnelse).isNull()

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
@@ -6,13 +6,26 @@ import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.opprettAlleVilkårsvurderinger
+import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.vilkår.VurderingService
+import no.nav.familie.ef.sak.vilkår.VurderingStegService
+import no.nav.familie.ef.sak.vilkår.dto.DelvilkårsvurderingDto
+import no.nav.familie.ef.sak.vilkår.dto.SvarPåVurderingerDto
+import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
+import no.nav.familie.ef.sak.vilkår.dto.VurderingDto
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
+import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
 
 internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -20,6 +33,12 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var vurderingService: VurderingService
+
+    @Autowired
+    private lateinit var vurderingStegService: VurderingStegService
+
+    @Autowired
+    private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
 
     @Autowired
     private lateinit var testSaksbehandlingController: TestSaksbehandlingController
@@ -32,7 +51,7 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @ParameterizedTest
     @EnumSource(StønadType::class)
-    internal fun `automatiskt utfyller vilkår`(stønadType: StønadType) {
+    internal fun `skal fylle ut vilkår automatisk`(stønadType: StønadType) {
         val fagsak = testoppsettService.lagreFagsak(fagsak(stønadstype = stønadType))
         val behandling = behandlingRepository.insert(behandling(fagsak))
 
@@ -44,6 +63,76 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
         }
 
         val oppdaterteVurderinger = vurderingService.hentAlleVurderinger(behandling.id)
+        val regelIdsForOppdaterteVurderinger = tilRegelIds(oppdaterteVurderinger)
+
+        // Skal hverken ha opprettet eller vurdert delvilkår som er historiske
+        assertThat(regelIdsForOppdaterteVurderinger).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
         assertThat(oppdaterteVurderinger.map { it.resultat }.distinct()).containsExactly(Vilkårsresultat.OPPFYLT)
     }
+
+    @ParameterizedTest
+    @EnumSource(StønadType::class)
+    internal fun `skal kunne endre delvilkårsvurderinger på vilkår som inneholder historiske delvilkår`(stønadType: StønadType) {
+        val fagsak = testoppsettService.lagreFagsak(fagsak(stønadstype = stønadType))
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        grunnlagsdataService.opprettGrunnlagsdata(behandling.id)
+        val opprettedeVurderinger = vilkårsvurderingRepository.insertAll(opprettAlleVurderinger(behandling.id, stønadType))
+
+        // Skal ha opprettet delvilkår som er historiske
+        assertThat(tilRegelIds(opprettedeVurderinger.map { it.tilDto() })).contains(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
+
+        val aleneomsorgVilkår = opprettedeVurderinger.first { it.type == VilkårType.ALENEOMSORG }
+        val nyeDelvilkårsvurderinger =
+            listOf(
+                DelvilkårsvurderingDto(
+                    resultat = Vilkårsresultat.OPPFYLT,
+                    vurderinger =
+                        listOf(
+                            VurderingDto(
+                                RegelId.NÆRE_BOFORHOLD,
+                                SvarId.NEI,
+                                "Begrunnelse",
+                            ),
+                        ),
+                ),
+                DelvilkårsvurderingDto(
+                    resultat = Vilkårsresultat.OPPFYLT,
+                    vurderinger =
+                        listOf(
+                            VurderingDto(
+                                RegelId.MER_AV_DAGLIG_OMSORG,
+                                SvarId.JA,
+                                "Begrunnelse",
+                            ),
+                        ),
+                ),
+            )
+
+        val vilkårsVurderingDto = SvarPåVurderingerDto(aleneomsorgVilkår.id, behandling.id, nyeDelvilkårsvurderinger)
+
+        testWithBrukerContext(preferredUsername = "Z999999", groups = listOf(rolleConfig.saksbehandlerRolle)) {
+            vurderingStegService.oppdaterVilkår(vilkårsVurderingDto)
+        }
+
+        val endredeVurderinger = vurderingService.hentAlleVurderinger(behandling.id)
+
+        // Skal ha fjernet delvilkår som er historiske
+        assertThat(tilRegelIds(endredeVurderinger)).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
+        assertThat(endredeVurderinger.first { it.id == aleneomsorgVilkår.id }.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
+    }
+
+    private fun opprettAlleVurderinger(
+        behandlingId: UUID,
+        stønadType: StønadType,
+    ): List<Vilkårsvurdering> {
+        val (_, metadata) = vurderingService.hentGrunnlagOgMetadata(behandlingId)
+        return opprettAlleVilkårsvurderinger(behandlingId, metadata, stønadType)
+    }
+
+    private fun tilRegelIds(vilkårsvurderinger: List<VilkårsvurderingDto>): List<RegelId> =
+        vilkårsvurderinger.flatMap { vilkårsvurdering ->
+            vilkårsvurdering.delvilkårsvurderinger.flatMap { delvilkårsvurdering ->
+                delvilkårsvurdering.vurderinger.map { it.regelId }.distinct()
+            }
+        }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
@@ -31,6 +31,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 import java.util.UUID
 
 internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
@@ -159,8 +160,21 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
             )
 
         // Opprett behandlingsbarn
-        barnRepository.insert(BehandlingBarn(behandlingId = førstegangsbehandling.id, personIdent = "13481975357"))
-        barnRepository.insert(BehandlingBarn(behandlingId = revurdering.id, personIdent = "13481975357"))
+        val fødselTerminDato = LocalDate.now().minusYears(2)
+        barnRepository.insert(
+            BehandlingBarn(
+                behandlingId = førstegangsbehandling.id,
+                personIdent = "18411577259",
+                fødselTermindato = fødselTerminDato,
+            ),
+        )
+        barnRepository.insert(
+            BehandlingBarn(
+                behandlingId = revurdering.id,
+                personIdent = "18411577259",
+                fødselTermindato = fødselTerminDato,
+            ),
+        )
 
         // Opprett grunnlagsdata
         grunnlagsdataService.opprettGrunnlagsdata(førstegangsbehandling.id)
@@ -169,7 +183,7 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
         // Opprett alle vurderinger (med historiske vilkår) for førstegangsbehandling
         val vurderingerForFørstegangsbehandling = vilkårsvurderingRepository.insertAll(opprettAlleVurderinger(førstegangsbehandling.id, stønadType))
 
-        // Opprett vurderiner (uten historiske vilkår) for revurdering
+        // Opprett vurderinger (uten historiske vilkår) for revurdering
         testWithBrukerContext(preferredUsername = "Z999999", groups = listOf(rolleConfig.saksbehandlerRolle)) {
             // Initier vilkår for revurdering
             vurderingService.hentEllerOpprettVurderinger(revurdering.id)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/TestSaksbehandlingControllerTest.kt
@@ -1,6 +1,10 @@
 package no.nav.familie.ef.sak.behandling
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.barn.BarnRepository
+import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.testWithBrukerContext
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
@@ -18,8 +22,10 @@ import no.nav.familie.ef.sak.vilkår.dto.SvarPåVurderingerDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.VurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
+import no.nav.familie.ef.sak.vilkår.gjenbruk.GjenbrukVilkårService
 import no.nav.familie.ef.sak.vilkår.regler.RegelId
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.params.ParameterizedTest
@@ -36,6 +42,12 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
 
     @Autowired
     private lateinit var vurderingStegService: VurderingStegService
+
+    @Autowired
+    private lateinit var gjenbrukVilkårService: GjenbrukVilkårService
+
+    @Autowired
+    private lateinit var barnRepository: BarnRepository
 
     @Autowired
     private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
@@ -119,6 +131,67 @@ internal class TestSaksbehandlingControllerTest : OppslagSpringRunnerTest() {
         // Skal ha fjernet delvilkår som er historiske
         assertThat(tilRegelIds(endredeVurderinger)).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
         assertThat(endredeVurderinger.first { it.id == aleneomsorgVilkår.id }.resultat).isEqualTo(Vilkårsresultat.OPPFYLT)
+    }
+
+    @ParameterizedTest
+    @EnumSource(StønadType::class)
+    internal fun `skal gjenbruke vilkårsvurderinger fra tidligere behandling uten å ta med historiske delvilkår`(stønadType: StønadType) {
+        val fagsak = testoppsettService.lagreFagsak(fagsak(stønadstype = stønadType))
+
+        // Opprett behandlinger
+        val førstegangsbehandling =
+            behandlingRepository.insert(
+                behandling(
+                    fagsak = fagsak,
+                    resultat = BehandlingResultat.INNVILGET,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    årsak = BehandlingÅrsak.SØKNAD,
+                ),
+            )
+        val revurdering =
+            behandlingRepository.insert(
+                behandling(
+                    fagsak = fagsak,
+                    resultat = BehandlingResultat.IKKE_SATT,
+                    status = BehandlingStatus.UTREDES,
+                    årsak = BehandlingÅrsak.SØKNAD,
+                ),
+            )
+
+        // Opprett behandlingsbarn
+        barnRepository.insert(BehandlingBarn(behandlingId = førstegangsbehandling.id, personIdent = "13481975357"))
+        barnRepository.insert(BehandlingBarn(behandlingId = revurdering.id, personIdent = "13481975357"))
+
+        // Opprett grunnlagsdata
+        grunnlagsdataService.opprettGrunnlagsdata(førstegangsbehandling.id)
+        grunnlagsdataService.opprettGrunnlagsdata(revurdering.id)
+
+        // Opprett alle vurderinger (med historiske vilkår) for førstegangsbehandling
+        val vurderingerForFørstegangsbehandling = vilkårsvurderingRepository.insertAll(opprettAlleVurderinger(førstegangsbehandling.id, stønadType))
+
+        // Opprett vurderiner (uten historiske vilkår) for revurdering
+        testWithBrukerContext(preferredUsername = "Z999999", groups = listOf(rolleConfig.saksbehandlerRolle)) {
+            // Initier vilkår for revurdering
+            vurderingService.hentEllerOpprettVurderinger(revurdering.id)
+        }
+
+        val initielleVurderingerForRevurdering = vurderingService.hentAlleVurderinger(revurdering.id)
+
+        // Skal ha opprettet delvilkår som er historiske for førstegangsbehandling
+        assertThat(tilRegelIds(vurderingerForFørstegangsbehandling.map { it.tilDto() })).contains(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
+        // Skal ikke ha opprettet delvilkår som er historiske for revurdering
+        assertThat(initielleVurderingerForRevurdering.flatMap { vilkårsvurdering -> vilkårsvurdering.delvilkårsvurderinger.flatMap { deilvilkårsvurdering -> deilvilkårsvurdering.vurderinger.map { it.regelId } } }).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
+
+        testWithBrukerContext(preferredUsername = "Z999999", groups = listOf(rolleConfig.saksbehandlerRolle)) {
+            // Kopier over vilkår fra førstegangsbehandling til revurdering
+            gjenbrukVilkårService.gjenbrukInngangsvilkårVurderinger(revurdering.id, førstegangsbehandling.id)
+        }
+
+        // Hent vurderinger for revurdering etter gjenbruk
+        val endredeVurderingerForRevurdering = vurderingService.hentAlleVurderinger(revurdering.id)
+
+        // Skal ikke ha gjenbrukt delvilkår som er historiske
+        assertThat(tilRegelIds(endredeVurderingerForRevurdering)).doesNotContain(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
     }
 
     private fun opprettAlleVurderinger(

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -57,6 +57,12 @@ import no.nav.familie.ef.sak.vilkår.Opphavsvilkår
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.Vurdering
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
+import no.nav.familie.ef.sak.vilkår.regler.evalutation.RegelEvaluering.utledResultat
+import no.nav.familie.ef.sak.vilkår.regler.vilkårsreglerForStønad
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.felles.Opplysningskilde
 import no.nav.familie.kontrakter.ef.felles.Revurderingsårsak
@@ -516,3 +522,56 @@ fun søker(sivilstand: List<SivilstandMedNavn> = emptyList()): Søker =
         listOf(),
         listOf(),
     )
+
+/**
+ * Oppretter alle vilkårsvurderiger med alle delvilkår - både gjeldende og historiske
+ * */
+fun opprettAlleVilkårsvurderinger(
+    behandlingId: UUID,
+    metadata: HovedregelMetadata,
+    stønadstype: StønadType,
+): List<Vilkårsvurdering> =
+    vilkårsreglerForStønad(stønadstype).flatMap { vilkårsregel ->
+        if (vilkårsregel.vilkårType.gjelderFlereBarn() && metadata.barn.isNotEmpty()) {
+            metadata.barn.map { lagNyVilkårsvurdering(vilkårsregel, metadata, behandlingId, it.id) }
+        } else {
+            listOf(lagNyVilkårsvurdering(vilkårsregel, metadata, behandlingId))
+        }
+    }
+
+private fun lagNyVilkårsvurdering(
+    vilkårsregel: Vilkårsregel,
+    metadata: HovedregelMetadata,
+    behandlingId: UUID,
+    barnId: UUID? = null,
+): Vilkårsvurdering {
+    val delvilkårsvurdering = initierDelvilkårsvurderinger(vilkårsregel, metadata, barnId)
+    return Vilkårsvurdering(
+        behandlingId = behandlingId,
+        type = vilkårsregel.vilkårType,
+        barnId = barnId,
+        delvilkårsvurdering = DelvilkårsvurderingWrapper(delvilkårsvurdering),
+        resultat = utledResultat(vilkårsregel, delvilkårsvurdering.map { it.tilDto() }).vilkår,
+        opphavsvilkår = null,
+    )
+}
+
+private fun initierDelvilkårsvurderinger(
+    vilkårsregel: Vilkårsregel,
+    metadata: HovedregelMetadata,
+    barnId: UUID? = null,
+): List<Delvilkårsvurdering> =
+    when (vilkårsregel.vilkårType) {
+        VilkårType.ALENEOMSORG -> initierDelvilkårsvurderingForHovedregler(vilkårsregel)
+        else -> vilkårsregel.initiereDelvilkårsvurdering(metadata, barnId = barnId)
+    }
+
+private fun initierDelvilkårsvurderingForHovedregler(
+    vilkårsregel: Vilkårsregel,
+): List<Delvilkårsvurdering> =
+    vilkårsregel.hovedregler.map {
+        Delvilkårsvurdering(
+            Vilkårsresultat.IKKE_TATT_STILLING_TIL,
+            vurderinger = listOf(Vurdering(it)),
+        )
+    }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/OppdaterVilkårTest.kt
@@ -431,7 +431,7 @@ internal class OppdaterVilkårTest {
             )
         assertThat(catchThrowable { OppdaterVilkår.lagNyOppdatertVilkårsvurdering(vilkårsvurdering, oppdatering) })
             .hasMessage(
-                "Delvilkårsvurderinger savner svar på hovedregler - " +
+                "Delvilkårsvurderinger mangler svar på hovedregler - " +
                     "hovedregler=[KRAV_SIVILSTAND_UTEN_PÅKREVD_BEGRUNNELSE] delvilkår=[SIVILSTAND_UNNTAK]",
             )
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValideringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValideringTest.kt
@@ -13,15 +13,15 @@ import org.junit.jupiter.api.Test
 
 internal class RegelValideringTest {
     @Test
-    fun `sender in en tom liste med svar - skal kaste exception`() {
+    fun `sender inn en tom liste med svar - skal kaste exception`() {
         val regel = VilkårsregelEnHovedregel()
 
         assertThat(
             Assertions.catchThrowable {
                 valider(regel, *emptyArray<VurderingDto>())
             },
-        ).hasMessage("Savner svar for en av delvilkåren for vilkår=ALENEOMSORG")
-            .isInstanceOf(Feil::class.java)
+        ).hasMessage("List is empty.")
+            .isInstanceOf(NoSuchElementException::class.java)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValideringTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/evalutation/RegelValideringTest.kt
@@ -35,7 +35,7 @@ internal class RegelValideringTest {
                     VurderingDto(RegelId.KRAV_SIVILSTAND_PÅKREVD_BEGRUNNELSE),
                 )
             },
-        ).hasMessageStartingWith("Delvilkårsvurderinger savner svar på hovedregler")
+        ).hasMessageStartingWith("Delvilkårsvurderinger mangler svar på hovedregler")
             .isInstanceOf(Feil::class.java)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegelTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/AleneomsorgRegelTest.kt
@@ -9,6 +9,8 @@ import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværRegistergrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.BarnMedSamværSøknadsgrunnlagDto
 import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.RegelId
+import no.nav.familie.ef.sak.vilkår.regler.RegelVersjon
 import no.nav.familie.ef.sak.vilkår.regler.vilkår.AleneomsorgRegel
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import org.assertj.core.api.Assertions
@@ -32,7 +34,13 @@ class AleneomsorgRegelTest {
     val barnId = UUID.randomUUID()
 
     @Test
-    fun `Skal automatisk vurdere vilkår om aleneomsorg når det er digital søknad,donorbarn og har samme adresse`() {
+    fun `Vilkårsregel SKRIFTLIG_AVTALE_OM_DELT_BOSTED sin versjon skal være HISTORISK`() {
+        val skriftligAvtaleRegel = AleneomsorgRegel().regel(RegelId.SKRIFTLIG_AVTALE_OM_DELT_BOSTED)
+        Assertions.assertThat(skriftligAvtaleRegel.versjon).isEqualTo(RegelVersjon.HISTORISK)
+    }
+
+    @Test
+    fun `Skal automatisk vurdere vilkår om aleneomsorg når det er digital søknad, donorbarn og har samme adresse`() {
         every { hovedregelMetadataMock.behandling } returns behandling(årsak = BehandlingÅrsak.SØKNAD)
         every { barnMedSamværSøknadsgrunnlagDto.ikkeOppgittAnnenForelderBegrunnelse } returns "donor"
         every { barnMedSamværRegistergrunnlagDto.harSammeAdresse } returns true

--- a/src/test/resources/omregning/expectedIverksettDto.json
+++ b/src/test/resources/omregning/expectedIverksettDto.json
@@ -102,16 +102,6 @@
             "resultat": "OPPFYLT",
             "vurderinger": [
               {
-                "regelId": "SKRIFTLIG_AVTALE_OM_DELT_BOSTED",
-                "svar": null,
-                "begrunnelse": "Godkjent"
-              }
-            ]
-          },
-          {
-            "resultat": "OPPFYLT",
-            "vurderinger": [
-              {
                 "regelId": "NÆRE_BOFORHOLD",
                 "svar": null,
                 "begrunnelse": "Godkjent"

--- a/src/test/resources/regler/AKTIVITET.json
+++ b/src/test/resources/regler/AKTIVITET.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/AKTIVITET_ARBEID.json
+++ b/src/test/resources/regler/AKTIVITET_ARBEID.json
@@ -20,7 +20,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/ALDER_PÅ_BARN.json
+++ b/src/test/resources/regler/ALDER_PÅ_BARN.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "UNNTAK_ALDER" : {
       "regelId" : "UNNTAK_ALDER",
@@ -29,7 +30,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/ALENEOMSORG.json
+++ b/src/test/resources/regler/ALENEOMSORG.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "HISTORISK"
     },
     "NÆRE_BOFORHOLD" : {
       "regelId" : "NÆRE_BOFORHOLD",
@@ -45,7 +46,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "MER_AV_DAGLIG_OMSORG" : {
       "regelId" : "MER_AV_DAGLIG_OMSORG",
@@ -58,7 +60,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/DOKUMENTASJON_AV_UTDANNING.json
+++ b/src/test/resources/regler/DOKUMENTASJON_AV_UTDANNING.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "DOKUMENTASJON_AV_UTGIFTER_UTDANNING" : {
       "regelId" : "DOKUMENTASJON_AV_UTGIFTER_UTDANNING",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/DOKUMENTASJON_TILSYNSUTGIFTER.json
+++ b/src/test/resources/regler/DOKUMENTASJON_TILSYNSUTGIFTER.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/ER_UTDANNING_HENSIKTSMESSIG.json
+++ b/src/test/resources/regler/ER_UTDANNING_HENSIKTSMESSIG.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "SAKSBEHANDLER_VURDERING" : {
       "regelId" : "SAKSBEHANDLER_VURDERING",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/FORUTGÅENDE_MEDLEMSKAP.json
+++ b/src/test/resources/regler/FORUTGÅENDE_MEDLEMSKAP.json
@@ -12,7 +12,8 @@
           "regelId" : "MEDLEMSKAP_UNNTAK",
           "begrunnelseType" : "UTEN"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "MEDLEMSKAP_UNNTAK" : {
       "regelId" : "MEDLEMSKAP_UNNTAK",
@@ -57,7 +58,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/INNTEKT.json
+++ b/src/test/resources/regler/INNTEKT.json
@@ -16,7 +16,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "INNTEKT_SAMSVARER_MED_OS" : {
       "regelId" : "INNTEKT_SAMSVARER_MED_OS",
@@ -33,7 +34,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/LOVLIG_OPPHOLD.json
+++ b/src/test/resources/regler/LOVLIG_OPPHOLD.json
@@ -12,7 +12,8 @@
           "regelId" : "OPPHOLD_UNNTAK",
           "begrunnelseType" : "UTEN"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "OPPHOLD_UNNTAK" : {
       "regelId" : "OPPHOLD_UNNTAK",
@@ -33,7 +34,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/MOR_ELLER_FAR.json
+++ b/src/test/resources/regler/MOR_ELLER_FAR.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/NYTT_BARN_SAMME_PARTNER.json
+++ b/src/test/resources/regler/NYTT_BARN_SAMME_PARTNER.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/RETT_TIL_OVERGANGSSTØNAD.json
+++ b/src/test/resources/regler/RETT_TIL_OVERGANGSSTØNAD.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/SAGT_OPP_ELLER_REDUSERT.json
+++ b/src/test/resources/regler/SAGT_OPP_ELLER_REDUSERT.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "RIMELIG_GRUNN_SAGT_OPP" : {
       "regelId" : "RIMELIG_GRUNN_SAGT_OPP",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/SAMLIV.json
+++ b/src/test/resources/regler/SAMLIV.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "LEVER_IKKE_I_EKTESKAPLIGNENDE_FORHOLD" : {
       "regelId" : "LEVER_IKKE_I_EKTESKAPLIGNENDE_FORHOLD",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/SIVILSTAND.json
+++ b/src/test/resources/regler/SIVILSTAND.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "KRAV_SIVILSTAND_UTEN_PÅKREVD_BEGRUNNELSE" : {
       "regelId" : "KRAV_SIVILSTAND_UTEN_PÅKREVD_BEGRUNNELSE",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "SAMLIVSBRUDD_LIKESTILT_MED_SEPARASJON" : {
       "regelId" : "SAMLIVSBRUDD_LIKESTILT_MED_SEPARASJON",
@@ -38,7 +40,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "SAMSVAR_DATO_SEPARASJON_OG_FRAFLYTTING" : {
       "regelId" : "SAMSVAR_DATO_SEPARASJON_OG_FRAFLYTTING",
@@ -51,7 +54,8 @@
           "regelId" : "KRAV_SIVILSTAND_PÅKREVD_BEGRUNNELSE",
           "begrunnelseType" : "UTEN"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "SIVILSTAND_UNNTAK" : {
       "regelId" : "SIVILSTAND_UNNTAK",
@@ -68,7 +72,8 @@
           "begrunnelseType" : "PÅKREVD",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }

--- a/src/test/resources/regler/TIDLIGERE_VEDTAKSPERIODER.json
+++ b/src/test/resources/regler/TIDLIGERE_VEDTAKSPERIODER.json
@@ -12,7 +12,8 @@
           "begrunnelseType" : "UTEN",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     },
     "HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING" : {
       "regelId" : "HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING",
@@ -25,7 +26,8 @@
           "begrunnelseType" : "VALGFRI",
           "regelId" : "SLUTT_NODE"
         }
-      }
+      },
+      "versjon" : "GJELDENDE"
     }
   }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22919)

Vi skal fjerne et delvilkår `skriftlig avtale om delt bosted` under vilkåret `aleneomsorg`. Måten vi har valgt å løse dette på er å innføre konseptet om [historiske vs. gjeldende regler som står forklart her.](https://github.com/navikt/familie-ef-sak/compare/fjern-sp%C3%B8rsm%C3%A5l-delt-bostedsavtale?expand=1#diff-a1dd663e78d16b91afec06e92f8cc3da1a270188ae44b0bfcc1c464506d645efR1)

- Skal støtte historisk visning av vilkår som ikke lenger er gjeldende
- Skal kunne gjenbruke delvilkår fra tidligere behandlinger uten å kopiere med historiske delvilkår
- Må kunne behandle vilkåret `aleneomsorg` med kun to delvilkår fra nå av