### PR TITLE
Info på beboer på personopplysninger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkController.kt
@@ -68,14 +68,6 @@ class SøkController(
         return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåBehandling(behandlingId))
     }
 
-    @GetMapping("fagsak/{fagsakId}/samme-adresse")
-    fun søkPersonerMedSammeAdressePåFagsak(
-        @PathVariable fagsakId: UUID,
-    ): Ressurs<SøkeresultatPerson> {
-        tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(søkService.søkEtterPersonerMedSammeAdressePåFagsak(fagsakId))
-    }
-
     @GetMapping("fagsak-person/{fagsakPersonId}/samme-adresse")
     fun søkPersonerMedSammeAdressePåFagsakPerson(
         @PathVariable fagsakPersonId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.fagsak.dto.FagsakForSøkeresultat
-import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøk
+import no.nav.familie.ef.sak.fagsak.dto.PersonPåAdresse
 import no.nav.familie.ef.sak.fagsak.dto.Søkeresultat
 import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatUtenFagsak
@@ -16,12 +16,11 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlPersonSøkHjelpe
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlSaksbehandlerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.BarnDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.KjønnMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdenter
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonFraSøk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
@@ -30,6 +29,7 @@ import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -96,20 +96,45 @@ class SøkService(
     fun søkEtterPersonerMedSammeAdressePåFagsakPerson(fagsakPersonId: UUID): SøkeresultatPerson {
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         val personopplysninger = personopplysningerService.hentPersonopplysningerFraRegister(aktivIdent)
-        return søkEtterPersonerMedSammeAdresseMedPersonopplysninger(aktivIdent, personopplysninger)
+        val barnAvBruker = personopplysninger.barn.tilBarnAvBruker()
+        return søkEtterPersonerMedSammeAdresse(aktivIdent, barnAvBruker)
     }
 
     fun søkEtterPersonerMedSammeAdressePåBehandling(behandlingId: UUID): SøkeresultatPerson {
         val (grunnlag) = vurderingService.hentGrunnlagOgMetadata(behandlingId)
 
         val aktivIdent = behandlingService.hentAktivIdent(behandlingId)
-        return søkEtterPersonerMedSammeAdresseMedGrunnlag(aktivIdent, grunnlag)
+        return søkEtterPersonerMedSammeAdresse(aktivIdent, grunnlag.barnAvBruker())
     }
 
-    private fun søkEtterPersonerMedSammeAdresseMedPersonopplysninger(
-        aktivIdent: String,
-        personopplysninger: PersonopplysningerDto,
+    private fun søkEtterPersonerMedSammeAdresse(
+        brukersPersonIdent: String,
+        barnAvBruker: List<BarnAvBrukerDto>,
     ): SøkeresultatPerson {
+        val allePersonerPåAdresse: List<PersonPåAdresse> = hentAllePersonerPåAdresse(brukersPersonIdent)
+
+        val personerMedMetadata =
+            allePersonerPåAdresse.map { personPåAdresse ->
+                val barnetAvBruker = barnAvBruker.find { it.personIdent == personPåAdresse.personIdent }
+                personPåAdresse.copy(
+                    erSøker = if (personPåAdresse.personIdent == brukersPersonIdent) true else null,
+                    erBarn = if (barnetAvBruker != null) true else null,
+                    fødselsdato = barnetAvBruker?.fødselsdato,
+                )
+            }
+
+        return SøkeresultatPerson(
+            personer =
+                personerMedMetadata
+                    .sortedWith(
+                        compareByDescending<PersonPåAdresse> { it.erSøker }
+                            .thenByDescending { it.erBarn }
+                            .thenByDescending { it.fødselsdato },
+                    ),
+        )
+    }
+
+    private fun hentAllePersonerPåAdresse(aktivIdent: String): List<PersonPåAdresse> {
         val søker = personService.hentSøker(aktivIdent)
         val aktuelleBostedsadresser = søker.bostedsadresse.filterNot { it.metadata.historisk }
         val bostedsadresse = aktuelleBostedsadresser.singleOrNull()
@@ -131,55 +156,19 @@ class SøkService(
         }
 
         val personSøkResultat = pdlSaksbehandlerClient.søkPersonerMedSammeAdresse(søkeKriterier).hits
-
-        return SøkeresultatPerson(
-            personer =
-                personSøkResultat
-                    .map { tilPersonFraSøkMedPersonsonopplysninger(it.person, personopplysninger) }
-                    .sortedWith(
-                        compareByDescending<PersonFraSøk> { it.erSøker }
-                            .thenByDescending { it.erBarn }
-                            .thenByDescending { it.fødselsdato },
-                    ),
-        )
-    }
-
-    private fun søkEtterPersonerMedSammeAdresseMedGrunnlag(
-        aktivIdent: String,
-        grunnlag: VilkårGrunnlagDto,
-    ): SøkeresultatPerson {
-        val søker = personService.hentSøker(aktivIdent)
-        val aktuelleBostedsadresser = søker.bostedsadresse.filterNot { it.metadata.historisk }
-        val bostedsadresse = aktuelleBostedsadresser.singleOrNull()
-        feilHvis(bostedsadresse == null) {
-            "Fant ${aktuelleBostedsadresser.size} bostedsadresser, forventet 1"
-        }
-
-        brukerfeilHvis(bostedsadresse.ukjentBosted != null) {
-            "Personen har ukjent bostedsadresse, kan ikke finne personer på samme adresse"
-        }
-
-        val søkeKriterier = PdlPersonSøkHjelper.lagPdlPersonSøkKriterier(bostedsadresse)
-        if (søkeKriterier.isEmpty()) {
-            secureLogger.error("Får ikke laget søkekriterer for $aktivIdent med bostedsadresse=$bostedsadresse")
-            throw Feil(
-                message = "Får ikke laget søkekriterer for bostedsadresse",
-                frontendFeilmelding = "Klarer ikke av å lage søkekriterer for bostedsadressen til person",
+        return personSøkResultat.map {
+            PersonPåAdresse(
+                personIdent =
+                    it.person.folkeregisteridentifikator
+                        .gjeldende()
+                        .identifikasjonsnummer,
+                visningsadresse =
+                    it.person.bostedsadresse
+                        .gjeldende()
+                        ?.let { adresseMapper.tilAdresse(it).visningsadresse },
+                visningsnavn = NavnDto.fraNavn(it.person.navn.gjeldende()).visningsnavn,
             )
         }
-
-        val personSøkResultat = pdlSaksbehandlerClient.søkPersonerMedSammeAdresse(søkeKriterier).hits
-
-        return SøkeresultatPerson(
-            personer =
-                personSøkResultat
-                    .map { tilPersonFraSøkMedGrunnlag(it.person, grunnlag) }
-                    .sortedWith(
-                        compareByDescending<PersonFraSøk> { it.erSøker }
-                            .thenByDescending { it.erBarn }
-                            .thenByDescending { it.fødselsdato },
-                    ),
-        )
     }
 
     fun søkPersonUtenFagsak(personIdent: String): SøkeresultatUtenFagsak =
@@ -190,53 +179,13 @@ class SøkService(
             )
         }
             ?: throw ApiFeil("Finner ingen personer for søket", HttpStatus.BAD_REQUEST)
-
-    private fun tilPersonFraSøkMedGrunnlag(
-        person: PdlPersonFraSøk,
-        grunnlag: VilkårGrunnlagDto,
-    ): PersonFraSøk {
-        val personIdent = person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer
-
-        val erSøker = if (grunnlag.personalia.personIdent == personIdent) true else null
-
-        val erBarn = if (grunnlag.barnMedSamvær.any { it.registergrunnlag.fødselsnummer == personIdent }) true else null
-
-        val barnFødselsdato =
-            grunnlag
-                .barnMedSamvær
-                .find { it.registergrunnlag.fødselsnummer == personIdent }
-                ?.registergrunnlag
-                ?.fødselsdato
-
-        return PersonFraSøk(
-            personIdent = personIdent,
-            visningsadresse = person.bostedsadresse.gjeldende()?.let { adresseMapper.tilAdresse(it).visningsadresse },
-            visningsnavn = NavnDto.fraNavn(person.navn.gjeldende()).visningsnavn,
-            fødselsdato = barnFødselsdato,
-            erSøker = erSøker,
-            erBarn = erBarn,
-        )
-    }
-
-    private fun tilPersonFraSøkMedPersonsonopplysninger(
-        person: PdlPersonFraSøk,
-        personopplysninger: PersonopplysningerDto,
-    ): PersonFraSøk {
-        val personIdent = person.folkeregisteridentifikator.gjeldende().identifikasjonsnummer
-
-        val erSøker = if (personopplysninger.personIdent == personIdent) true else null
-
-        val erBarn = if (personopplysninger.barn.any { it.personIdent == personIdent }) true else null
-
-        val barnFødselsdato = personopplysninger.barn.find { it.personIdent == personIdent }?.fødselsdato
-
-        return PersonFraSøk(
-            personIdent = personIdent,
-            visningsadresse = person.bostedsadresse.gjeldende()?.let { adresseMapper.tilAdresse(it).visningsadresse },
-            visningsnavn = NavnDto.fraNavn(person.navn.gjeldende()).visningsnavn,
-            fødselsdato = barnFødselsdato,
-            erSøker = erSøker,
-            erBarn = erBarn,
-        )
-    }
 }
+
+private fun List<BarnDto>.tilBarnAvBruker(): List<BarnAvBrukerDto> = this.map { BarnAvBrukerDto(it.personIdent, it.fødselsdato) }
+
+data class BarnAvBrukerDto(
+    val personIdent: String?,
+    val fødselsdato: LocalDate? = null,
+)
+
+private fun VilkårGrunnlagDto.barnAvBruker(): List<BarnAvBrukerDto> = this.barnMedSamvær.map { BarnAvBrukerDto(it.registergrunnlag.fødselsnummer, it.registergrunnlag.fødselsdato) }

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
@@ -182,13 +182,19 @@ class SøkService(
                 personopplysninger?.barn?.any { it.personIdent == personIdent },
             ).any { it == true }
 
-        val gjeldendeBarn = grunnlag?.barnMedSamvær?.find { it.registergrunnlag.fødselsnummer == personIdent }
+        val barnFødselsdato =
+            grunnlag
+                ?.barnMedSamvær
+                ?.find { it.registergrunnlag.fødselsnummer == personIdent }
+                ?.registergrunnlag
+                ?.fødselsdato
+                ?: personopplysninger?.barn?.find { it.personIdent == personIdent }?.fødselsdato
 
         return PersonFraSøk(
             personIdent = personIdent,
             visningsadresse = person.bostedsadresse.gjeldende()?.let { adresseMapper.tilAdresse(it).visningsadresse },
             visningsnavn = NavnDto.fraNavn(person.navn.gjeldende()).visningsnavn,
-            fødselsdato = gjeldendeBarn?.registergrunnlag?.fødselsdato,
+            fødselsdato = barnFødselsdato,
             erSøker = erSøker,
             erBarn = erBarn,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/dto/Søkeresultat.kt
@@ -20,17 +20,17 @@ data class FagsakForSøkeresultat(
     val erMigrert: Boolean,
 )
 
-data class PersonFraSøk(
+data class PersonPåAdresse(
     val personIdent: String,
     val visningsadresse: String?,
     val visningsnavn: String,
-    val fødselsdato: LocalDate?,
-    val erSøker: Boolean?,
-    val erBarn: Boolean?,
+    val fødselsdato: LocalDate? = null,
+    val erSøker: Boolean? = null,
+    val erBarn: Boolean? = null,
 )
 
 data class SøkeresultatPerson(
-    val personer: List<PersonFraSøk>,
+    val personer: List<PersonPåAdresse>,
 )
 
 data class SøkeresultatUtenFagsak(

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -11,9 +11,9 @@ import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil.mockVilkårGrunnlagDto
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlSaksbehandlerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Bostedsadresse
@@ -43,7 +43,7 @@ internal class SøkServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val fagsakPersonService = mockk<FagsakPersonService>()
     private val vurderingService = mockk<VurderingService>()
-    private val grunnlagsdataRegisterService = mockk<GrunnlagsdataRegisterService>()
+    private val personopplysningerService = mockk<PersonopplysningerService>()
     private val søkService =
         SøkService(
             fagsakPersonService,
@@ -53,7 +53,7 @@ internal class SøkServiceTest {
             adresseMapper,
             fagsakService,
             vurderingService,
-            grunnlagsdataRegisterService,
+            personopplysningerService,
         )
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -6,7 +6,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.SøkService
-import no.nav.familie.ef.sak.fagsak.dto.PersonFraSøk
+import no.nav.familie.ef.sak.fagsak.dto.PersonPåAdresse
 import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
@@ -133,7 +133,7 @@ internal class SøkServiceTest {
         } returns pdlSøker(bostedsadresse = bostedsadresseFraPdl)
 
         val forventetResultat =
-            PersonFraSøk(
+            PersonPåAdresse(
                 personIdent = "123456789",
                 visningsadresse = "Adressenavn 23 A, 0000 Oslo",
                 "Fornavn Mellomnavn Etternavn",

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -138,8 +138,8 @@ internal class SøkServiceTest {
                 visningsadresse = "Adressenavn 23 A, 0000 Oslo",
                 "Fornavn Mellomnavn Etternavn",
                 fødselsdato = null,
-                erSøker = false,
-                erBarn = false,
+                erSøker = null,
+                erBarn = null,
             )
 
         val person = SøkeresultatPerson(listOf(forventetResultat))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/SøkServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.fagsak.dto.SøkeresultatPerson
 import no.nav.familie.ef.sak.infrastruktur.config.KodeverkServiceMock
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil.mockVilkårGrunnlagDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataRegisterService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlSaksbehandlerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
@@ -42,6 +43,7 @@ internal class SøkServiceTest {
     private val behandlingService = mockk<BehandlingService>()
     private val fagsakPersonService = mockk<FagsakPersonService>()
     private val vurderingService = mockk<VurderingService>()
+    private val grunnlagsdataRegisterService = mockk<GrunnlagsdataRegisterService>()
     private val søkService =
         SøkService(
             fagsakPersonService,
@@ -51,6 +53,7 @@ internal class SøkServiceTest {
             adresseMapper,
             fagsakService,
             vurderingService,
+            grunnlagsdataRegisterService,
         )
 
     @BeforeEach


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Refaktorert og endret `søkEtterPersonerMedSammeAdresse` til å returnere liste med barn av søker.

[PR Frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/2948)