### PR TITLE
Fjerne eøs borgere utrekk arbeidsøkere

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -57,7 +57,7 @@ class UttrekkArbeidssøkerService(
         visEøsBorgere: Boolean = false,
     ): UttrekkArbeidssøkereDto {
         tilgangService.validerHarSaksbehandlerrolle()
-        val arbeidssøkere = hentArbeidsøkereUtenEllerMedEøsFilter(årMåned, visEøsBorgere)
+        val arbeidssøkere = hentArbeidsøkereMedEllerUtenEøsFilter(årMåned, visEøsBorgere)
         val filtrerteArbeidsssøkere = mapTilDtoOgFiltrer(arbeidssøkere)
 
         val totaltAntallUkontrollerte = arbeidssøkere.count { !it.kontrollert }
@@ -101,7 +101,7 @@ class UttrekkArbeidssøkerService(
         return arbeidssøkere.filter { harPeriodeSomArbeidssøker(it, startdato, sluttdato) }
     }
 
-    fun hentArbeidsøkereUtenEllerMedEøsFilter(
+    fun hentArbeidsøkereMedEllerUtenEøsFilter(
         årMåned: YearMonth,
         visEøsBorgere: Boolean,
     ): List<UttrekkArbeidssøkere> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -29,7 +29,7 @@ class UttrekkArbeidssøkerService(
     private val fagsakService: FagsakService,
     private val personService: PersonService,
     private val arbeidssøkerClient: ArbeidssøkerClient,
-    private val vurderingService: VurderingService
+    private val vurderingService: VurderingService,
 ) {
     fun forrigeMåned(): () -> YearMonth = { YearMonth.now().minusMonths(1) }
 
@@ -101,9 +101,12 @@ class UttrekkArbeidssøkerService(
         return arbeidssøkere.filter { harPeriodeSomArbeidssøker(it, startdato, sluttdato) }
     }
 
-    fun hentArbeidsøkereUtenEllerMedEøsFilter(årMåned: YearMonth, visEøsBorgere: Boolean): List<UttrekkArbeidssøkere> {
+    fun hentArbeidsøkereUtenEllerMedEøsFilter(
+        årMåned: YearMonth,
+        visEøsBorgere: Boolean,
+    ): List<UttrekkArbeidssøkere> {
         val arbeidssøkere = uttrekkArbeidssøkerRepository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned)
-        return if(visEøsBorgere){
+        return if (visEøsBorgere) {
             arbeidssøkere
         } else {
             filtrerArbeidsssøkereUtenEøs(arbeidssøkere)
@@ -116,9 +119,10 @@ class UttrekkArbeidssøkerService(
         arbeidsssøkere.forEach { arbeidsøker ->
             val vurderinger = vurderingService.hentAlleVurderinger(arbeidsøker.vedtakId)
             val oppholdVurdering = vurderinger.first { it.vilkårType == VilkårType.LOVLIG_OPPHOLD }
-            val harDelvilkårMedEøsSvar = oppholdVurdering.delvilkårsvurderinger.any { delvilkår ->
-                delvilkår.vurderinger.any { it.svar == SvarId.OPPHOLDER_SEG_I_ANNET_EØS_LAND }
-            }
+            val harDelvilkårMedEøsSvar =
+                oppholdVurdering.delvilkårsvurderinger.any { delvilkår ->
+                    delvilkår.vurderinger.any { it.svar == SvarId.OPPHOLDER_SEG_I_ANNET_EØS_LAND }
+                }
 
             if (!harDelvilkårMedEøsSvar) {
                 filtrerteArbeidsssøkereUtenEøs.add(arbeidsøker)
@@ -192,19 +196,18 @@ class UttrekkArbeidssøkerService(
         sluttdato: LocalDate,
     ) = it.perioder.perioder.any {
         it.datoFra <= startdato &&
-                it.datoTil >= sluttdato &&
-                erArbeidssøker(it)
+            it.datoTil >= sluttdato &&
+            erArbeidssøker(it)
     }
 
     private fun erArbeidssøker(it: Vedtaksperiode) =
         (
-                it.aktivitet == AktivitetType.FORSØRGER_REELL_ARBEIDSSØKER ||
-                        it.aktivitet == AktivitetType.FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER
-                )
+            it.aktivitet == AktivitetType.FORSØRGER_REELL_ARBEIDSSØKER ||
+                it.aktivitet == AktivitetType.FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER
+        )
 
     private data class Persondata(
         val personIdent: String,
         val pdlPersonKort: PdlPersonKort,
     )
-
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -57,11 +57,10 @@ class UttrekkArbeidssøkerService(
         visEøsBorgere: Boolean = false,
     ): UttrekkArbeidssøkereDto {
         tilgangService.validerHarSaksbehandlerrolle()
-        val arbeidssøkere = uttrekkArbeidssøkerRepository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned)
-        val filtrerteArbeidsssøkereUtenEøs = filtrerArbeidsssøkereUtenEøs(arbeidssøkere)
-        val filtrerteArbeidsssøkere = mapTilDtoOgFiltrer(filtrerteArbeidsssøkereUtenEøs)
+        val arbeidssøkere = hentArbeidsøkereUtenEllerMedEøsFilter(årMåned, visEøsBorgere)
+        val filtrerteArbeidsssøkere = mapTilDtoOgFiltrer(arbeidssøkere)
 
-        val totaltAntallUkontrollerte = filtrerteArbeidsssøkereUtenEøs.count { !it.kontrollert }
+        val totaltAntallUkontrollerte = arbeidssøkere.count { !it.kontrollert }
         val antallKontrollert = filtrerteArbeidsssøkere.count { it.kontrollert }
         val antallManglerKontrollUtenTilgang = totaltAntallUkontrollerte - (filtrerteArbeidsssøkere.size - antallKontrollert)
 
@@ -100,6 +99,15 @@ class UttrekkArbeidssøkerService(
         val arbeidssøkere =
             uttrekkArbeidssøkerRepository.hentVedtaksperioderForSisteFerdigstilteBehandlinger(startdato, sluttdato)
         return arbeidssøkere.filter { harPeriodeSomArbeidssøker(it, startdato, sluttdato) }
+    }
+
+    fun hentArbeidsøkereUtenEllerMedEøsFilter(årMåned: YearMonth, visEøsBorgere: Boolean): List<UttrekkArbeidssøkere> {
+        val arbeidssøkere = uttrekkArbeidssøkerRepository.findAllByÅrMånedAndRegistrertArbeidssøkerIsFalse(årMåned)
+        return if(visEøsBorgere){
+            arbeidssøkere
+        } else {
+            filtrerArbeidsssøkereUtenEøs(arbeidssøkere)
+        }
     }
 
     fun filtrerArbeidsssøkereUtenEøs(arbeidsssøkere: List<UttrekkArbeidssøkere>): MutableList<UttrekkArbeidssøkere> {

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
@@ -427,6 +427,8 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
             identer.forEach {
                 val fagsak = testoppsettService.lagreFagsak(fagsak(fagsakpersoner(setOf(it.first))))
                 val behandling = behandlingRepository.insert(behandling(fagsak))
+                val vilkår = vilkårsvurdering(behandling.id)
+                vilkårsvurderingRepository.insert(vilkår)
                 val arbeidssøkere =
                     UttrekkArbeidssøkere(
                         fagsakId = fagsak.id,
@@ -592,6 +594,10 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
             listOf(Inntekt(februar2021, BigDecimal.ZERO, BigDecimal(10_000))),
         )
         ferdigstillBehandling(behandling2)
+        val vilkår = vilkårsvurdering(behandling.id)
+        vilkårsvurderingRepository.insert(vilkår)
+        val vilkår2 = vilkårsvurdering(behandling2.id)
+        vilkårsvurderingRepository.insert(vilkår2)
     }
 
     private fun opprettEkstraFagsak() {
@@ -612,6 +618,8 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
             listOf(Inntekt(februar2021, BigDecimal.ZERO, BigDecimal(15_000))),
         )
         ferdigstillBehandling(behandling)
+        val vilkår = vilkårsvurdering(behandling.id)
+        vilkårsvurderingRepository.insert(vilkår)
     }
 
     fun ferdigstillBehandling(behandling: Behandling) {


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22738)

Filtrert ut borgere som oppholder seg i utlandet fra P43 listen. Disse brukerne følges opp i egne fremleggsoppgaver av andre saksbehandlere enn de som sjekker uttrekkslisten for arbeidssøkere.