### PR TITLE
Bytt til representasjon-api i gcp

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -92,7 +92,6 @@ spec:
           namespace: nom
         - application: repr-api
           namespace: repr
-          cluster: dev-gcp
       external:
         - host: api-gw-q1.oera.no
         - host: familie-oppdrag.dev-fss-pub.nais.io

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -90,9 +90,9 @@ spec:
           namespace: paw
         - application: skjermede-personer-pip
           namespace: nom
-        - application: pdl-fullmakt
-          namespace: pdl
-          cluster: dev-fss
+        - application: repr-api
+          namespace: repr
+          cluster: dev-gcp
       external:
         - host: api-gw-q1.oera.no
         - host: familie-oppdrag.dev-fss-pub.nais.io

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -82,9 +82,8 @@ spec:
           namespace: paw
         - application: skjermede-personer-pip
           namespace: nom
-        - application: pdl-fullmakt
-          namespace: pdl
-          cluster: prod-fss
+        - application: repr-api
+          namespace: repr
       external:
         - host: api-gw.oera.no
         - host: familie-oppdrag.prod-fss-pub.nais.io

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 
 @Service
 class FullmaktClient(
-    @Value("\${PDL_FULLMAKT_URL}")
+    @Value("\${REPR_API_URL}")
     private val fullmaktUrl: String,
     @Qualifier("azure")
     private val restOperations: RestOperations,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt
 
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.logger
 import no.nav.familie.http.client.AbstractPingableRestClient
-import org.apache.hc.client5.http.utils.Base64
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -21,9 +21,8 @@ class FullmaktClient(
 
     fun hentFullmakt(ident: String): List<FullmaktResponse> {
         logger.info("Kaller PDL fullmakt")
-        val url = URI.create("$fullmaktUrl/api/internbruker/fullmaktsgiver")
-        val base64EncodedIdent = Base64.encodeBase64String(ident.toByteArray())
-        val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(base64EncodedIdent))
+        val url = URI.create("$fullmaktUrl/api/internbruker/fullmakt/fullmaktsgiver")
+        val fullmaktResponse = postForEntity<List<FullmaktResponse>>(url, FullmaktRequest(ident))
         secureLogger.info("Fullmakt response: $fullmaktResponse")
         return fullmaktResponse
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,3 +24,5 @@ KAFKA_BROKERS: hostname:1234
 KAFKA_KEYSTORE_PATH: kafkaKeystorePath
 KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
+
+PDL_FULLMAKT_URL: https://repr-api.intern.dev.nav.no

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,5 +24,3 @@ KAFKA_BROKERS: hostname:1234
 KAFKA_KEYSTORE_PATH: kafkaKeystorePath
 KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
-
-PDL_FULLMAKT_URL: https://repr-api.intern.dev.nav.no

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -281,7 +281,7 @@ FAMILIE_KLAGE_URL: http://familie-klage
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 INFOTRYGD_REPLIKA_API_URL: https://familie-ef-infotrygd.${ON_PREM_URL_ENV}-fss-pub.nais.io
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
-PDL_FULLMAKT_URL: https://pdl-fullmakt.${ON_PREM_URL_ENV}-fss-pub.nais.io
+PDL_FULLMAKT_URL: https://repr-api.intern.nav.no
 FAMILIE_EF_PROXY_URL: https://familie-ef-proxy.${ON_PREM_URL_ENV}-fss-pub.nais.io
 ARBEIDSSOKER_URL: http://veilarbregistrering.paw.svc.cluster.local
 HISTORISK_PENSJON_URL: http://historisk-pensjon.historisk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,20 +80,20 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      pdl-fullmakt:
-        resource-url: ${PDL_FULLMAKT_URL}
+      repr-api:
+        resource-url: ${REPR_API_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
-        scope: ${PDL_FULLMAKT_SCOPE}
+        scope: ${REPR_API_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
-      pdl-fullmakt-clientcredentials:
-        resource-url: ${PDL_FULLMAKT_URL}
+      repr-api-clientcredentials:
+        resource-url: ${REPR_API_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
         grant-type: client_credentials
-        scope: ${PDL_FULLMAKT_SCOPE}
+        scope: ${REPR_API_SCOPE}
         authentication:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
@@ -199,7 +199,7 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 
 PDL_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-api/.default
-PDL_FULLMAKT_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
+REPR_API_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
 EF_IVERKSETT_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-iverksett/.default
 FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-tilbake/.default
 FAMILIE_KLAGE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-klage/.default
@@ -281,7 +281,7 @@ FAMILIE_KLAGE_URL: http://familie-klage
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 INFOTRYGD_REPLIKA_API_URL: https://familie-ef-infotrygd.${ON_PREM_URL_ENV}-fss-pub.nais.io
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
-PDL_FULLMAKT_URL: http://repr-api.repr
+REPR_API_URL: http://repr-api.repr
 FAMILIE_EF_PROXY_URL: https://familie-ef-proxy.${ON_PREM_URL_ENV}-fss-pub.nais.io
 ARBEIDSSOKER_URL: http://veilarbregistrering.paw.svc.cluster.local
 HISTORISK_PENSJON_URL: http://historisk-pensjon.historisk

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -199,7 +199,7 @@ no.nav.security.jwt:
           client-auth-method: client_secret_basic
 
 PDL_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-api/.default
-PDL_FULLMAKT_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-fullmakt/.default
+PDL_FULLMAKT_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
 EF_IVERKSETT_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-iverksett/.default
 FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-tilbake/.default
 FAMILIE_KLAGE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-klage/.default

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -281,7 +281,7 @@ FAMILIE_KLAGE_URL: http://familie-klage
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 INFOTRYGD_REPLIKA_API_URL: https://familie-ef-infotrygd.${ON_PREM_URL_ENV}-fss-pub.nais.io
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
-PDL_FULLMAKT_URL: https://repr-api.intern.nav.no
+PDL_FULLMAKT_URL: http://repr-api.repr
 FAMILIE_EF_PROXY_URL: https://familie-ef-proxy.${ON_PREM_URL_ENV}-fss-pub.nais.io
 ARBEIDSSOKER_URL: http://veilarbregistrering.paw.svc.cluster.local
 HISTORISK_PENSJON_URL: http://historisk-pensjon.historisk

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
@@ -71,7 +71,7 @@ class FullmaktClientTest {
         ).isEqualTo("ENF")
     }
 
-    private val queryMappingForHentFullmakt: MappingBuilder = WireMock.post(WireMock.urlPathEqualTo("/api/internbruker/fullmaktsgiver"))
+    private val queryMappingForHentFullmakt: MappingBuilder = WireMock.post(WireMock.urlPathEqualTo("/api/internbruker/fullmakt/fullmaktsgiver"))
 
     private val hentFullmaktResponse =
         """


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Pdl-api har byttet til repr-api, og det er ikke lenge til pdl-api slutter å virke, ref: https://nav-it.slack.com/archives/C020Q1K6EAY/p1732611753116999
Repr-api finnes i gcp og url/scope må byttes til å gå mot gcp i stedet.
Dette må også gjøres for klage. 

Testet OK i preprod.

Vi er gitt tilganger her:
https://github.com/navikt/representasjon/blob/cc057eab93023fb4a3d7b5572b6373b3ec5bc8ea/.nais/prod-gcp/repr-api.yaml