### PR TITLE
En periode må ha sluttdato større enn siste dato for forrige måned, for at den skal være relevant å ta med i uttrekk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -190,7 +190,7 @@ class UttrekkArbeidssøkerService(
         sluttdato: LocalDate,
     ) = it.perioder.perioder.any {
         it.datoFra <= startdato &&
-            it.datoTil >= sluttdato &&
+            it.datoTil > sluttdato &&
             erArbeidssøker(it)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerServiceTest.kt
@@ -114,8 +114,9 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
     private val januar2021 = YearMonth.of(2021, 1)
     private val februar2021 = YearMonth.of(2021, 2)
     private val mars2021 = YearMonth.of(2021, 3)
+    private val april2021 = YearMonth.of(2021, 4)
 
-    private val vedtaksperiode = opprettVedtaksperiode(januar2021, mars2021)
+    private val vedtaksperiode = opprettVedtaksperiode(januar2021, april2021)
     private val vedtaksperiode2 =
         opprettVedtaksperiode(
             februar2021,
@@ -125,7 +126,7 @@ internal class UttrekkArbeidssøkerServiceTest : OppslagSpringRunnerTest() {
     private val vedtaksperiode3 =
         opprettVedtaksperiode(
             mars2021,
-            mars2021,
+            april2021,
             aktivitetType = FORLENGELSE_STØNAD_PÅVENTE_ARBEID_REELL_ARBEIDSSØKER,
         )
     private val navn = Navn("fornavn", "", "", Metadata(false))


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dette fikser en bug som ble meldt av saksbehandler, hvor noen med opphørt stønad vises. Dersom kjøringen skjer i desember, hvor november skal sjekkes, vil personer med opphørt stønad fra og med desember vises. Denne endringen gjør det slik at de ikke tas med, fordi til og med dato må være større enn siste dato i måneden det sjekkes for (forrige måned).
