### PR TITLE
Vil legge inn datoer for konsistensavstemming 2025.

### DIFF
--- a/src/main/resources/db/migration/V148__konsistensavstemming_tidsplan_2025.sql
+++ b/src/main/resources/db/migration/V148__konsistensavstemming_tidsplan_2025.sql
@@ -1,0 +1,26 @@
+-- INSERT INTO konsistensavstemming_jobb (triggerdato)
+-- VALUES (TO_DATE('25.11.2024', 'DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('03.01.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('30.01.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('27.02.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('27.03.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('29.04.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('23.05.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('27.06.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('30.07.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('01.09.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('29.09.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('30.10.2025','DD.MM.YYYY'));
+INSERT INTO konsistensavstemming_jobb (triggerdato)
+VALUES (TO_DATE('21.11.2025','DD.MM.YYYY'));


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vi tremger å vite når vi skal kjøre konsistensavstemming. 

Datoer fra PO utbetaling, team Moby : 
https://nav-it.slack.com/archives/C01EH16LAD9/p1732692427434029
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23441