### PR TITLE
Bruk andel tilkjent ytelse til å beregne antall måneder med stønad for gitt år og forventet inntekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
@@ -17,7 +17,12 @@ data class Inntekt(
     val samordningsfradrag: BigDecimal?,
     val dagsats: BigDecimal? = null,
     val månedsinntekt: BigDecimal? = null,
-)
+) {
+    fun totalinntekt(): BigDecimal =
+        (this.forventetInntekt ?: BigDecimal.ZERO) +
+            (this.dagsats ?: BigDecimal.ZERO).multiply(BeregningUtils.DAGSATS_ANTALL_DAGER) +
+            (this.månedsinntekt ?: BigDecimal.ZERO).multiply(BeregningUtils.ANTALL_MÅNEDER_ÅR)
+}
 
 // TODO Dette er en domeneklasse og burde flyttes til Vedtak.kt.
 data class Inntektsperiode(

--- a/src/main/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektKontrollService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektKontrollService.kt
@@ -2,11 +2,13 @@ package no.nav.familie.ef.sak.selvstendig
 
 import no.nav.familie.ef.sak.amelding.InntektService
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
 import no.nav.familie.ef.sak.sigrun.SigrunService
+import no.nav.familie.ef.sak.tilkjentytelse.AndelsHistorikkService
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Månedsperiode
@@ -31,13 +33,15 @@ class NæringsinntektKontrollService(
     val vedtakService: VedtakService,
     val sigrunService: SigrunService,
     val inntektService: InntektService,
+    val andelsHistorikkService: AndelsHistorikkService,
+    val tilkjentYtelseService: TilkjentYtelseService,
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
     private val årstallIFjor = YearMonth.now().minusYears(1).year
     private val månedsperiodeIFjor = Månedsperiode(YearMonth.of(årstallIFjor, 1), YearMonth.of(årstallIFjor, 12))
 
     fun sjekkNæringsinntektMotForventetInntekt(): List<UUID> {
-        val behandlingIds = mutableListOf<UUID>()
+        val fagsakIds = mutableListOf<UUID>()
         if (LeaderClient.isLeader() == true) {
             val oppgaver = hentOppgaverForSelvstendigeTilInntektskontroll()
 
@@ -45,30 +49,30 @@ class NæringsinntektKontrollService(
                 val personIdent =
                     oppgave.identer?.firstOrNull { it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident
                         ?: oppgave.personident ?: throw Exception("Fant ikke registrert ident på oppgave ${oppgave.id}")
-
                 secureLogger.info("Kontrollerer person med ident: $personIdent")
 
-                val fagsakOS = fagsakService.finnFagsaker(setOf(personIdent)).filter { it.stønadstype == StønadType.OVERGANGSSTØNAD }.firstOrNull() ?: throw RuntimeException("Fant ikke fagsak for overgangsstønad for person: $personIdent")
-                val behandling = behandlingService.finnSisteIverksatteBehandling(fagsakOS.id) ?: throw RuntimeException("Fant ikke behandling for fagsakId: ${fagsakOS.id}")
-                val antallMånederMedVedtakForFjoråret = antallMånederMedVedtakForFjoråret(behandling)
+                val fagsakOS = fagsakService.finnFagsaker(setOf(personIdent)).firstOrNull { it.stønadstype == StønadType.OVERGANGSSTØNAD } ?: throw RuntimeException("Fant ikke fagsak for overgangsstønad for person: $personIdent")
+                val behandlingId = behandlingService.finnSisteIverksatteBehandling(fagsakOS.id)?.id ?: throw RuntimeException("Fant ingen gjeldende behandling for fagsakId: ${fagsakOS.id}")
+                val tilkjentYtelse = tilkjentYtelseService.hentForBehandling(behandlingId)
 
+                val antallMåneder = antallMånederMedVedtakForFjoråret(tilkjentYtelse)
                 val næringsinntekt = hentFjoråretsNæringsinntekt(fagsakOS.fagsakPersonId)
 
-                if (antallMånederMedVedtakForFjoråret > 3 && næringsinntekt > INNTEKTSGRENSE_FOR_KONTROLL_AV_AKTIVITET) {
+                if (antallMåneder > 3 && næringsinntekt > INNTEKTSGRENSE_FOR_KONTROLL_AV_AKTIVITET) {
                     val fjoråretsPersoninntekt = inntektService.hentÅrsinntekt(personIdent, årstallIFjor)
                     secureLogger.info("Forrige års inntekt for person uten ytelse fra offentlig: $fjoråretsPersoninntekt")
                     if (fjoråretsPersoninntekt == 0) {
-                        val forventetInntekt = forventetInntektSnitt(behandling.id)
-                        secureLogger.info("Beregnet inntekt i snitt for år $årstallIFjor og behandlingId ${behandling.id} er: $forventetInntekt")
+                        val forventetInntekt = forventetInntektSnitt(tilkjentYtelse)
+                        // secureLogger.info("Beregnet inntekt i snitt for år $årstallIFjor og behandlingId ${behandling.id} er: $forventetInntekt")
                         if (næringsinntekt > (forventetInntekt * 1.1)) {
                             secureLogger.info("Har 10% høyere næringsinntekt for person: $personIdent (Næringsinntekt: $næringsinntekt - ForventetInntekt: $forventetInntekt)")
-                            behandlingIds.add(behandling.id)
+                            fagsakIds.add(fagsakOS.id)
                         }
                     }
                 }
             }
         }
-        return behandlingIds
+        return fagsakIds
     }
 
     private fun hentFjoråretsNæringsinntekt(fagsakPersonId: UUID): Int {
@@ -79,16 +83,20 @@ class NæringsinntektKontrollService(
         return næringsinntekt
     }
 
-    private fun forventetInntektSnitt(behandlingId: UUID): Int {
-        val vedtak = vedtakService.hentVedtak(behandlingId)
+    private fun forventetInntektSnitt(tilkjentYtelse: TilkjentYtelse): Int {
+        val antallMånederInntektList =
+            tilkjentYtelse.andelerTilkjentYtelse.map {
+                (
+                    it.periode
+                        .snitt(månedsperiodeIFjor)
+                        ?.lengdeIHeleMåneder()
+                        ?.toInt() ?: 0
+                ) to it.inntekt
+            }
 
-        val inntektsperioderIFjor = vedtak.inntekter?.inntekter?.filter { it.periode.overlapper(Månedsperiode(YearMonth.of(årstallIFjor, 1), YearMonth.of(årstallIFjor, 12))) }
-        val totalInntekt = inntektsperioderIFjor?.sumOf { it.totalinntekt() }
-
-        val antallPerioder = inntektsperioderIFjor?.size ?: throw RuntimeException("Fant ikke inntektsperiode på vedtak for år $årstallIFjor for behandling $behandlingId")
-        val forventetInntektSnitt = (totalInntekt?.toInt() ?: 0) / antallPerioder
-
-        return forventetInntektSnitt
+        return antallMånederInntektList.sumOf { (inntekt, antallMåneder) ->
+            inntekt * (antallMåneder / 12)
+        }
     }
 
     private fun hentOppgaverForSelvstendigeTilInntektskontroll(): List<Oppgave> {
@@ -118,19 +126,11 @@ class NæringsinntektKontrollService(
     }
 
     private fun antallMånederMedVedtakForFjoråret(
-        behandling: Behandling,
-    ): Int {
-        val vedtak = vedtakService.hentVedtak(behandling.id)
-
-        val vedtaksperioder = vedtak.perioder?.perioder?.filter { !it.periodeType.midlertidigOpphørEllerSanksjon() }
-        val vedtaksperioderIÅr = vedtaksperioder?.filter { it.periode.overlapper(Månedsperiode(YearMonth.of(årstallIFjor, 1), YearMonth.of(årstallIFjor, 12))) }
-
-        val antallMåneder = vedtaksperioderIÅr?.mapNotNull { it.periode.snitt(månedsperiodeIFjor) }?.sumOf { it.lengdeIHeleMåneder() } ?: 0
-
-        // Beregn antall måneder
-        secureLogger.info("Antall måneder $antallMåneder med vedtak i ${YearMonth.now().year} for $behandling")
-
-        return antallMåneder.toInt()
+        tilkjentYtelse: TilkjentYtelse,
+    ): Long {
+        val perioder = tilkjentYtelse.andelerTilkjentYtelse.map { it.periode.snitt(månedsperiodeIFjor) }
+        val sum = perioder.sumOf { it?.lengdeIHeleMåneder() ?: 0 }
+        return sum
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektKontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektKontrollServiceTest.kt
@@ -1,17 +1,27 @@
 package no.nav.familie.ef.sak.selvstendig
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.mockk.every
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.beregning.Inntektsperiode
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
+import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.oppgave.OppgaveClient
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.vedtak
 import no.nav.familie.ef.sak.testutil.kjørSomLeader
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
+import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.VedtakRepository
+import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
+import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
+import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
+import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.ef.sak.økonomi.lagTilkjentYtelse
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
@@ -40,8 +50,11 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var oppgaveClient: OppgaveClient
 
-    private val fagsakTilknyttetPersonIdent = fagsak(setOf(PersonIdent("11111111111")))
-    private val behandlingId = UUID.randomUUID()
+    @Autowired
+    private lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
+
+    private val personIdent = "11111111111"
+    private val fagsakTilknyttetPersonIdent = fagsak(setOf(PersonIdent(personIdent)))
 
     @BeforeEach
     fun setup() {
@@ -55,21 +68,52 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
             )
         every { oppgaveClient.hentOppgaver(finnOppgaveRequest) } returns FinnOppgaveResponseDto(1, listOf(lagEksternTestOppgave()))
         testoppsettService.lagreFagsak(fagsakTilknyttetPersonIdent)
-        val behandling = behandling(id = behandlingId, fagsak = fagsakTilknyttetPersonIdent, status = BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET)
-        behandlingRepository.insert(behandling)
-        val vedtak = vedtak(behandlingId = behandlingId, år = YearMonth.now().minusYears(1).year)
-        vedtakRepository.insert(vedtak)
+
+        val behandlingIds = mutableListOf<UUID>()
+        for (i in 0..3) {
+            val behandling = behandling(id = UUID.randomUUID(), fagsak = fagsakTilknyttetPersonIdent, status = BehandlingStatus.FERDIGSTILT, resultat = BehandlingResultat.INNVILGET)
+            val behandlingId = behandlingRepository.insert(behandling).id
+            behandlingIds.add(behandlingId)
+            val vedtak = vedtak(behandlingId = behandlingId, perioder = PeriodeWrapper(objectMapper.readValue<List<Vedtaksperiode>>(vedtaksperiodeJsonList[i])), inntekter = InntektWrapper(objectMapper.readValue<List<Inntektsperiode>>(inntektsperiodeJsonList[i])))
+            vedtakRepository.insert(vedtak)
+        }
+
+        val andelerTilkjentYtelse = mutableListOf<AndelTilkjentYtelse>()
+
+        andelerTilkjentYtelse.add(lagAndelTilkjentYtelse(17517, LocalDate.of(2022, 9, 1), LocalDate.of(2023, 1, 31), personIdent, behandlingIds[0], 146000, 0, 3385))
+        andelerTilkjentYtelse.add(lagAndelTilkjentYtelse(19392, LocalDate.of(2023, 2, 1), LocalDate.of(2023, 4, 30), personIdent, behandlingIds[1], 96000, 0, 1510))
+        andelerTilkjentYtelse.add(lagAndelTilkjentYtelse(20865, LocalDate.of(2023, 5, 1), LocalDate.of(2023, 7, 31), personIdent, behandlingIds[1], 96000, 0, 1376))
+        andelerTilkjentYtelse.add(lagAndelTilkjentYtelse(21765, LocalDate.of(2023, 8, 1), LocalDate.of(2024, 4, 30), personIdent, behandlingIds[2], 72000, 0, 476))
+        andelerTilkjentYtelse.add(lagAndelTilkjentYtelse(22761, LocalDate.of(2024, 5, 1), LocalDate.of(2024, 7, 31), personIdent, behandlingIds[3], 75200, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = andelerTilkjentYtelse, behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        tilkjentYtelseRepository.insert(tilkjentYtelse)
     }
 
     private fun lagEksternTestOppgave(tilordnetRessurs: String? = null): no.nav.familie.kontrakter.felles.oppgave.Oppgave =
         no.nav.familie.kontrakter.felles.oppgave
-            .Oppgave(id = 1, tilordnetRessurs = tilordnetRessurs, oppgavetype = Oppgavetype.Fremlegg.toString(), fristFerdigstillelse = LocalDate.of(YearMonth.now().year, 12, 15).toString(), mappeId = 107, identer = listOf(OppgaveIdentV2("11111111111", IdentGruppe.FOLKEREGISTERIDENT)))
+            .Oppgave(id = 1, tilordnetRessurs = tilordnetRessurs, oppgavetype = Oppgavetype.Fremlegg.toString(), fristFerdigstillelse = LocalDate.of(YearMonth.now().year, 12, 15).toString(), mappeId = 107, identer = listOf(OppgaveIdentV2(personIdent, IdentGruppe.FOLKEREGISTERIDENT)))
 
     @Test
-    fun `sjekkNæringsinntektMotForventetInntekt`() {
+    fun `sjekkNæringsinntektMotForventetInntekt med flere behandlinger og vedtak`() {
         kjørSomLeader {
-            val behandlingIds = næringsinntektKontrollService.sjekkNæringsinntektMotForventetInntekt()
-            assertThat(behandlingIds).hasSize(1)
+            val fagsakIds = næringsinntektKontrollService.sjekkNæringsinntektMotForventetInntekt()
+            assertThat(fagsakIds.first()).isEqualTo(fagsakTilknyttetPersonIdent.id)
         }
     }
 }
+
+val vedtaksperiodeJsonList =
+    listOf(
+        """[{"datoFra":"2022-09-01","datoTil":"2023-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE"}]""",
+        """[{"datoFra":"2023-02-01","datoTil":"2023-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE","sanksjonsårsak":null}]""",
+        """[{"datoFra":"2023-08-01","datoTil":"2024-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
+        """[{"datoFra":"2024-05-01","datoTil":"2024-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
+    )
+
+val inntektsperiodeJsonList =
+    listOf(
+        """[{"startDato":"2022-09-01","sluttDato":"+999999999-12-31","inntekt":146000,"samordningsfradrag":0}]""",
+        """[{"startDato":null,"sluttDato":null,"periode":{"fom":"2023-02","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":96000,"samordningsfradrag":0}]""",
+        """[{"startDato":null,"sluttDato":null,"periode":{"fom":"2023-08","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":72000,"samordningsfradrag":0}]""",
+        """[{"startDato":null,"sluttDato":null,"periode":{"fom":"2024-05","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":75200,"samordningsfradrag":0}]""",
+    )


### PR DESCRIPTION
Hvorfor er denne endringen nødvendig? ✨
For at det skal gjennomføres en inntektskontroll på en bruker, må vedkommende ha hatt minimum 4 måneder med ytelse i løpet av fjoråret. I denne PR'n brukes andeler i tilkjent ytelse til å beregne forventet inntekt for kalenderåret, inkludert antall måneder med innvilget ytelse.

Lar loggingen stå for å se hvordan dette virker. Neste steg vil være å gjøre noen sjekk rundt aktivitet, men det gjenstår noen avklaringer der. Målet er å blant annet lukke oppgaver med et notat dersom inntekt ikke avviker med mer enn 10%.