### PR TITLE
Lagt til validering for sjekk av avslags vedtak hvor utgåtte avslagsårsaker gir feilmelding

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
+import no.nav.familie.ef.sak.vedtak.dto.Avslå
 import no.nav.familie.ef.sak.vedtak.dto.BeslutteVedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.SendTilBeslutterDto
@@ -136,6 +137,7 @@ class VedtakController(
         val behandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         validerKanRedigereBehandling(behandling)
+        validerGyldigAvslagÅrsak(vedtak)
         validerAlleVilkårOppfyltDersomInvilgelse(vedtak, behandlingId)
         return Ressurs.success(stegService.håndterBeregnYtelseForStønad(behandling, vedtak).id)
     }
@@ -167,6 +169,12 @@ class VedtakController(
             "Behandlingen er låst og vedtaket kan derfor ikke lagres"
         }
         validerTilordnetRessurs(saksbehandling.id)
+    }
+
+    private fun validerGyldigAvslagÅrsak(vedtak: VedtakDto) {
+        if (vedtak is Avslå) {
+            brukerfeilHvis(!vedtak.erGydlig()) { "Ikke gyldig avslagsgrunn" }
+        }
     }
 
     private fun validerTilordnetRessurs(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/VedtakDto.kt
@@ -85,7 +85,9 @@ data class InnvilgelseOvergangsstønad(
 data class Avslå(
     val avslåÅrsak: AvslagÅrsak?,
     val avslåBegrunnelse: String?,
-) : VedtakDto(ResultatType.AVSLÅ, "Avslag")
+) : VedtakDto(ResultatType.AVSLÅ, "Avslag") {
+    fun erGydlig(): Boolean = avslåÅrsak != AvslagÅrsak.KORTVARIG_AVBRUDD_JOBB && avslåÅrsak != AvslagÅrsak.MANGLENDE_OPPLYSNINGER
+}
 
 data class Opphør(
     val opphørFom: YearMonth,


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23504)

Validering for å ikke bruke utgåtte avslagsårsaker til lagre vedtak endepunktet.