### PR TITLE
Ta i bruk tilbakekreving som er flyttet til nytt nais team i preprod

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -76,7 +76,8 @@ spec:
           namespace: tilleggsstonader
     outbound:
       rules:
-        - application: familie-tilbake
+        - application: tilbakekreving-backend
+          namespace: tilbake
         - application: familie-klage
         - application: familie-brev
         - application: familie-ef-iverksett

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,3 +24,5 @@ KAFKA_BROKERS: hostname:1234
 KAFKA_KEYSTORE_PATH: kafkaKeystorePath
 KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
+
+FAMILIE_TILBAKE_URL: http://tilbakekreving-backend.tilbake

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,3 +26,4 @@ KAFKA_CREDSTORE_PASSWORD: kafkaCredstorePassword
 KAFKA_TRUSTSTORE_PATH: kafkaTruststorePath
 
 FAMILIE_TILBAKE_URL: http://tilbakekreving-backend.tilbake
+FAMILIE_TILBAKE_SCOPE: api://dev-gcp.tilbake.tilbakekreving-backend/.default


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Team Tilbake skal ta over tilbakekrevingsløsningen. Den eksisterende løsningen kjører nå i teamfamilie nais teamet, og for å ta ordentlig eierskap til løsningen og gjøre det til en NAV fellestjeneste ønsker vi å flytte det til et NAIS team som er mer generelt.
