### PR TITLE
Brukernotifikasjon topic peker nå mot den nye implementasjonen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektBrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/selvstendig/NæringsinntektBrukernotifikasjonService.kt
@@ -17,7 +17,7 @@ import java.util.UUID
 @Service
 class NæringsinntektBrukernotifikasjonService(
     private val kafkaTemplate: KafkaTemplate<String, String>,
-    @Value("\${BRUKERNOTIFIKASJON_BESKJED_TOPIC}")
+    @Value("\${BRUKERNOTIFIKASJON_VARSEL_TOPIC}")
     val topic: String,
     @Value("\${NAIS_APP_NAME}")
     val applicationName: String,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -297,7 +297,7 @@ FINN_BEHANDLINGER_MED_GAMMEL_G_CRON_EXPRESSION: 0 0 8 1 * * #kl 08:00 den 1. hve
 DEAKTIVER_MIKROFRONTEND_CRON_EXPRESSION: 0 0 6 * * TUE #kl 06:00 hver tirsdag
 
 MIN_SIDE_TOPIC: min-side.aapen-microfrontend-v1
-BRUKERNOTIFIKASJON_BESKJED_TOPIC: min-side.aapen-brukernotifikasjon-beskjed-v1
+BRUKERNOTIFIKASJON_VARSEL_TOPIC: min-side.aapen-brukervarsel-v1
 
 rolle:
   veileder: "31778fd8-3b71-4867-8db6-a81235fbe001"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Topic peker nå mot den nye implementasjonen, slik det er eksemplifisert i [migrerings-guide](https://navikt.github.io/tms-dokumentasjon/varsler/migrere/). 

Vi bruker nå `min-side.aapen-brukervarsel-v1`.