### PR TITLE
Feat/gjenbruk samvaersavtale

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/RevurderingService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.samværsavtale.SamværsavtaleService
 import no.nav.familie.ef.sak.vedtak.KopierVedtakService
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vilkår.VurderingService
@@ -45,6 +46,7 @@ class RevurderingService(
     private val vedtakService: VedtakService,
     private val nyeBarnService: NyeBarnService,
     private val tilordnetRessursService: TilordnetRessursService,
+    private val samværsavtaleService: SamværsavtaleService,
 ) {
     fun hentRevurderingsinformasjon(behandlingId: UUID): RevurderingsinformasjonDto = årsakRevurderingService.hentRevurderingsinformasjon(behandlingId)
 
@@ -104,6 +106,11 @@ class RevurderingService(
             nyBehandlingsId = revurdering.id,
             metadata = metadata,
             stønadType = fagsak.stønadstype,
+        )
+        samværsavtaleService.kopierSamværsavtalerTilNyBehandling(
+            eksisterendeBehandlingId = forrigeBehandlingId,
+            nyBehandlingId = revurdering.id,
+            metadata = metadata,
         )
         taskService.save(
             OpprettOppgaveForOpprettetBehandlingTask.opprettTask(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -27,6 +27,7 @@ import no.nav.familie.ef.sak.journalføring.dto.valider
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.samværsavtale.SamværsavtaleService
 import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
@@ -54,6 +55,7 @@ class JournalføringService(
     private val oppgaveService: OppgaveService,
     private val journalpostService: JournalpostService,
     private val infotrygdPeriodeValideringService: InfotrygdPeriodeValideringService,
+    private val samværsavtaleService: SamværsavtaleService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -269,6 +271,11 @@ class JournalføringService(
             nyBehandlingsId = behandling.id,
             metadata = metadata,
             stønadType = fagsak.stønadstype,
+        )
+        samværsavtaleService.kopierSamværsavtalerTilNyBehandling(
+            eksisterendeBehandlingId = forrigeBehandlingId,
+            nyBehandlingId = behandling.id,
+            metadata = metadata,
         )
         behandlingService.oppdaterStatusPåBehandling(behandling.id, BehandlingStatus.UTREDES)
         behandlingService.oppdaterStegPåBehandling(behandling.id, StegType.BEREGNE_YTELSE)

--- a/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleController.kt
@@ -37,7 +37,7 @@ class SamværsavtaleController(
     ): Ressurs<List<SamværsavtaleDto>> {
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
         tilgangService.validerHarSaksbehandlerrolle()
-        samværsavtaleService.opprettEllerErstatt(request)
+        samværsavtaleService.opprettEllerErstattSamværsavtale(request)
         return Ressurs.success(samværsavtaleService.hentSamværsavtalerForBehandling(request.behandlingId).tilDto())
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
@@ -64,11 +64,11 @@ class SamværsavtaleService(
         val barnIdMap = byggBarnMapFraTidligereTilNyId(barnPåForrigeBehandling, metadata.barn)
 
         val nyeSamværsavtaler =
-            barnIdMap.mapNotNull {
-                eksisterendeSamværsavtaler.get(it.key)?.copy(
+            barnIdMap.mapNotNull { (forrigeBehandlingBarnId, nåværendeBehandlingBarn) ->
+                eksisterendeSamværsavtaler.get(forrigeBehandlingBarnId)?.copy(
                     id = UUID.randomUUID(),
                     behandlingId = nyBehandlingId,
-                    behandlingBarnId = it.value.id,
+                    behandlingBarnId = nåværendeBehandlingBarn.id,
                 )
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataEndring
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.samværsavtale.SamværsavtaleService
 import no.nav.familie.ef.sak.vilkår.dto.VilkårDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
 import no.nav.familie.ef.sak.vilkår.dto.VilkårsvurderingDto
@@ -40,6 +41,7 @@ class VurderingService(
     private val fagsakService: FagsakService,
     private val gjenbrukVilkårService: GjenbrukVilkårService,
     private val tilordnetRessursService: TilordnetRessursService,
+    private val samværsavtaleService: SamværsavtaleService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -112,6 +114,11 @@ class VurderingService(
             metadata = metadata,
             stønadType = fagsak.stønadstype,
         )
+        kopierSamværsavtalerTilNyBehandling(
+            eksisterendeBehandlingId = behandling.forrigeBehandlingId,
+            nyBehandlingId = behandling.id,
+            metadata = metadata,
+        )
     }
 
     fun hentGrunnlagOgMetadata(behandlingId: UUID): Pair<VilkårGrunnlagDto, HovedregelMetadata> {
@@ -134,6 +141,18 @@ class VurderingService(
                 behandling = behandling,
             )
         return Pair(grunnlag, metadata)
+    }
+
+    private fun kopierSamværsavtalerTilNyBehandling(
+        eksisterendeBehandlingId: UUID,
+        nyBehandlingId: UUID,
+        metadata: HovedregelMetadata,
+    ) {
+        samværsavtaleService.kopierSamværsavtalerTilNyBehandling(
+            eksisterendeBehandlingId = eksisterendeBehandlingId,
+            nyBehandlingId = nyBehandlingId,
+            metadata = metadata,
+        )
     }
 
     private fun hentEllerOpprettVurderinger(

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -429,6 +429,7 @@ internal class JournalføringServiceTest {
                 journalpost = ustrukturertJournalpost,
             )
             verify(exactly = 0) { vurderingService.kopierVurderingerTilNyBehandling(any(), any(), any(), any()) }
+            verify(exactly = 0) { samværsavtaleService.kopierSamværsavtalerTilNyBehandling(any(), any(), any()) }
         }
 
         @Test
@@ -521,6 +522,7 @@ internal class JournalføringServiceTest {
                 journalpost = ustrukturertJournalpost,
             )
             verify(exactly = 0) { vurderingService.kopierVurderingerTilNyBehandling(any(), any(), any(), any()) }
+            verify(exactly = 0) { samværsavtaleService.kopierSamværsavtalerTilNyBehandling(any(), any(), any()) }
         }
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
@@ -36,6 +36,7 @@ internal class RevurderingServiceTest {
             vedtakService = mockk(),
             nyeBarnService = mockk(),
             tilordnetRessursService = mockk(),
+            samværsavtaleService = mockk(),
         )
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.samværsavtale.SamværsavtaleService
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat.OPPFYLT
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat.SKAL_IKKE_VURDERES

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingServiceTest.kt
@@ -61,6 +61,7 @@ internal class VurderingServiceTest {
     private val fagsakService = mockk<FagsakService>()
     private val gjenbrukVilkårService = mockk<GjenbrukVilkårService>()
     private val tilordnetRessursService = mockk<TilordnetRessursService>()
+    private val samværsavtaleService = mockk<SamværsavtaleService>()
     private val vurderingService =
         VurderingService(
             behandlingService = behandlingService,
@@ -72,6 +73,7 @@ internal class VurderingServiceTest {
             fagsakService = fagsakService,
             gjenbrukVilkårService = gjenbrukVilkårService,
             tilordnetRessursService = tilordnetRessursService,
+            samværsavtaleService = samværsavtaleService,
         )
     private val søknad =
         SøknadsskjemaMapper

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegServiceTest.kt
@@ -31,6 +31,7 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.saksbehandling
 import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.samværsavtale.SamværsavtaleService
 import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vilkår.dto.DelvilkårsvurderingDto
 import no.nav.familie.ef.sak.vilkår.dto.OppdaterVilkårsvurderingDto
@@ -72,6 +73,7 @@ internal class VurderingStegServiceTest {
     private val gjenbrukVilkårService = mockk<GjenbrukVilkårService>()
     private val behandlingshistorikkService = mockk<BehandlingshistorikkService>()
     private val tilordnetRessursService = mockk<TilordnetRessursService>()
+    private val samværsavtaleService = mockk<SamværsavtaleService>()
     private val vurderingService =
         VurderingService(
             behandlingService,
@@ -83,6 +85,7 @@ internal class VurderingStegServiceTest {
             fagsakService,
             gjenbrukVilkårService,
             tilordnetRessursService,
+            samværsavtaleService,
         )
     private val vurderingStegService =
         VurderingStegService(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved opprettelse av revurderinger ønsker vi å kopiere over samværsavtaler fra tidligere behandling på samme vis som vi gjør med vilkårsvurderinger. Dette gjør vi i tre tilfeller:
- Ved manuell opprettelse av revurdering
- Ved opprettelse av revurdering i journalføringsløypa
- Ved opprettelse av G-omregningsbehandlinger

[Overordnet Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24023)

Ønsker å dytte ut denne så fort som mulig slik at saksbehandlere får testet og kommet med feedback. Skriver tester parallellt i annen PR