### PR TITLE
Filtrer ut kandidater til automatisk revurdering etter gitte kriterier. 

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
@@ -9,14 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping(path = ["/api/revurdering"])
+@RequestMapping(path = ["/api/automatisk-revurdering"])
 @ProtectedWithClaims(issuer = "azuread")
 class AutomatiskRevurderingController(
     private val automatiskRevurderingService: AutomatiskRevurderingService,
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-    @PostMapping("automatisk")
+    @PostMapping
     fun forsøkAutomatiskRevurdering(
         @RequestBody personIdenter: List<String>,
     ): Ressurs<List<AutomatiskRevurdering>> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
@@ -1,0 +1,41 @@
+package no.nav.familie.ef.sak.behandling.revurdering
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping(path = ["/api/revurdering"])
+@ProtectedWithClaims(issuer = "azuread")
+class AutomatiskRevurderingController(
+    private val automatiskRevurderingService: AutomatiskRevurderingService,
+) {
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    @PostMapping("automatisk")
+    fun forsøkAutomatiskRevurdering(
+        @RequestBody personIdenter: List<String>,
+    ): Ressurs<List<AutomatiskRevurdering>> {
+        val list = mutableListOf<AutomatiskRevurdering>()
+        personIdenter.forEach { personIdent ->
+            val kanAutomatiskRevurderes = automatiskRevurderingService.kanAutomatiskRevurderes(personIdent)
+            if (kanAutomatiskRevurderes) {
+                secureLogger.info("Kan automatisk revurdere person med ident: $personIdent")
+            }
+            list.add(AutomatiskRevurdering(personIdent, kanAutomatiskRevurderes))
+        }
+
+
+        return Ressurs.success(list)
+    }
+}
+
+data class AutomatiskRevurdering(
+    val personIdent: String,
+    val automatiskRevurdert: Boolean,
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingController.kt
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @RestController
 @RequestMapping(path = ["/api/revurdering"])
@@ -29,7 +28,6 @@ class AutomatiskRevurderingController(
             }
             list.add(AutomatiskRevurdering(personIdent, kanAutomatiskRevurderes))
         }
-
 
         return Ressurs.success(list)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -1,0 +1,62 @@
+package no.nav.familie.ef.sak.behandling.revurdering
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.ef.sak.sigrun.SigrunService
+import no.nav.familie.ef.sak.sigrun.harNæringsinntekt
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AutomatiskRevurderingService(
+    private val sigrunService: SigrunService,
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+    private val oppgaveService: OppgaveService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    fun kanAutomatiskRevurderes(personIdent: String): Boolean {
+        val fagsak = fagsakService.finnFagsak(setOf(personIdent), StønadType.OVERGANGSSTØNAD) ?: return false
+        logger.info("Sjekker om fagsak ${fagsak.id} automatisk revurderes")
+        val inntektForAlleÅr = sigrunService.hentInntektForAlleÅrMedInntekt(fagsak.fagsakPersonId)
+
+        if (inntektForAlleÅr.harNæringsinntekt()) {
+            logger.info("Har næringsinntekt for fagsak ${fagsak.id}")
+            secureLogger.info("Har næringsinntekt for fagsak ${fagsak.id} - InntektResponse: $inntektForAlleÅr")
+            return false
+        }
+
+        if (behandlingService.finnesÅpenBehandling(fagsak.id)) {
+            logger.info("Finnes åpen behandling for fagsak ${fagsak.id}")
+            return false
+        }
+
+        val oppgaverForPerson =
+            oppgaveService.hentOppgaver(
+                FinnOppgaveRequest(
+                    aktørId = personIdent,
+                    tema = Tema.ENF,
+                ),
+            )
+        val harBehandleSakEllerJournalføringsoppgave =
+            oppgaverForPerson.oppgaver.any {
+                (it.status == StatusEnum.AAPNET || it.status == StatusEnum.OPPRETTET || it.status == StatusEnum.UNDER_BEHANDLING) &&
+                    (it.oppgavetype == Oppgavetype.BehandleSak.toString() || it.oppgavetype == Oppgavetype.Journalføring.toString())
+            }
+
+        if (harBehandleSakEllerJournalføringsoppgave) {
+            logger.info("harBehandleSakEllerJournalføringsoppgave $oppgaverForPerson")
+            return false
+        }
+
+        return true
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingController.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.behandling
+package no.nav.familie.ef.sak.behandling.revurdering
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -1,7 +1,9 @@
-package no.nav.familie.ef.sak.behandling
+package no.nav.familie.ef.sak.behandling.revurdering
 
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.NyeBarnService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/ÅrsakRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/ÅrsakRevurderingService.kt
@@ -1,5 +1,7 @@
-package no.nav.familie.ef.sak.behandling
+package no.nav.familie.ef.sak.behandling.revurdering
 
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.RevurderingsinformasjonDto

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/ÅrsakRevurderingsRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/ÅrsakRevurderingsRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.familie.ef.sak.behandling
+package no.nav.familie.ef.sak.behandling.revurdering
 
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillOppgaveTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveTask

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingSteg.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.sak.behandlingsflyt.steg
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.dto.RevurderingsinformasjonDto
 import no.nav.familie.ef.sak.behandling.dto.ÅrsakRevurderingDto
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType.FØRSTEGANGSBEHANDLING
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType.REVURDERING
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.OppgaveService

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.sak.blankett
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.dto.tilDto
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.brev.BrevClient
 import no.nav.familie.ef.sak.felles.domain.Fil
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.ef.sak.ekstern
 
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.RevurderingService
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ef.sak.arbeidsfordeling.ArbeidsfordelingService
 import no.nav.familie.ef.sak.barn.BarnService
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.Saksbehandling
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingsRepository
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/SigrunService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/SigrunService.kt
@@ -49,6 +49,8 @@ fun PensjonsgivendeInntektForSkatteordning.næringsinntekt() = (this.pensjonsgiv
 
 fun PensjonsgivendeInntektVisning.totalInntektOverNull() = (this.næring + this.person + (this.svalbard?.næring ?: 0) + (this.svalbard?.person ?: 0)) > 0
 
+fun List<PensjonsgivendeInntektVisning>.harNæringsinntekt() = this.any { it.totalNæringsinntekt() > 0 }
+
 data class PensjonsgivendeInntektVisning(
     val inntektsår: Int,
     var næring: Int,

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentServiceIntegrationTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.behandling.dto.SettPåVentRequest
 import no.nav.familie.ef.sak.behandling.dto.TaAvVentStatus
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.clearBrukerContext
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil.mockBrukerContext
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/MigreringServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.behandling.migrering.MigreringService
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillBehandlingTask

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -1,0 +1,54 @@
+package no.nav.familie.ef.sak.behandling.revurdering
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.Tema
+import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
+import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
+import no.nav.familie.kontrakter.felles.oppgave.Oppgave
+import no.nav.familie.kontrakter.felles.oppgave.OppgaveIdentV2
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class AutomatiskRevurderingServiceTest {
+    val behandlingServiceMock = mockk<BehandlingService>(relaxed = true)
+    val oppgaveServiceMock = mockk<OppgaveService>(relaxed = true)
+    val automatiskRevurderingService = AutomatiskRevurderingService(mockk(relaxed = true), mockk(relaxed = true), behandlingServiceMock, oppgaveServiceMock)
+
+    @Test
+    fun `Kan automatisk revurderes`() {
+        assertThat(automatiskRevurderingService.kanAutomatiskRevurderes("1")).isTrue()
+    }
+
+    @Test
+    fun `Kan ikke automatisk revurderes som følge av åpen behandling`() {
+        every { behandlingServiceMock.finnesÅpenBehandling(any()) } returns true
+
+        assertThat(automatiskRevurderingService.kanAutomatiskRevurderes("1")).isFalse()
+    }
+
+    @Test
+    fun `Kan ikke automatisk revurderes som følge av at behandle sak oppgave finnes`() {
+        every { oppgaveServiceMock.hentOppgaver(any()) } returns
+            FinnOppgaveResponseDto(
+                1,
+                listOf(
+                    Oppgave(
+                        id = 1,
+                        aktoerId = "1",
+                        identer = listOf(OppgaveIdentV2("11111111111", IdentGruppe.FOLKEREGISTERIDENT)),
+                        tema = Tema.ENF,
+                        oppgavetype = Oppgavetype.BehandleSak.toString(),
+                        status = StatusEnum.AAPNET,
+                        versjon = 2,
+                    ),
+                ),
+            )
+
+        assertThat(automatiskRevurderingService.kanAutomatiskRevurderes("1")).isFalse()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingServiceTest.kt
@@ -8,6 +8,8 @@ import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.ÅrsakRevurderingDto
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.saksbehandling

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingsRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/ÅrsakRevurderingsRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.behandling
 
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.findByIdOrThrow

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
@@ -12,7 +12,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.INNVILGET
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTaskPayload
 import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillOppgaveTask

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/ÅrsakRevurderingStegTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.dto.RevurderingsinformasjonDto
 import no.nav.familie.ef.sak.behandling.dto.ÅrsakRevurderingDto
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.repository.revurderingsinformasjon
 import no.nav.familie.ef.sak.repository.saksbehandling

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTaskTest.kt
@@ -8,7 +8,7 @@ import io.mockk.slot
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType.FØRSTEGANGSBEHANDLING
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.OppgaveService

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingControllerTest.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.sak.ekstern
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.RevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService

--- a/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapperTest.kt
@@ -16,7 +16,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.HenlagtÅrsak
-import no.nav.familie.ef.sak.behandling.ÅrsakRevurderingsRepository
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -6,12 +6,12 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.barn.BarnRepository
 import no.nav.familie.ef.sak.barn.BehandlingBarn
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
-import no.nav.familie.ef.sak.behandling.RevurderingService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.behandlingsflyt.steg.BeregnYtelseSteg
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.felles.domain.SporbarUtils

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
@@ -3,8 +3,8 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.service
 import io.mockk.MockKException
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ef.sak.behandling.RevurderingService
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes


### PR DESCRIPTION
- Controller-metode blir trigget av personhendelse når inntektsendringkontroll er kjørt.
- Flyttet filer i behandling relatert til revurdering i egen pakke.

### Hvorfor er denne endringen nødvendig? ✨

Dette er første steg for å analysere hvor mange av brukere med 10% endring i inntekt over tre måneder som består gitte kriterier. Se metode `kanAutomatiskRevurderes()` og [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23903) for å se hvilke kriterier som er definert opp hittil.

Hører til PR: https://github.com/navikt/familie-ef-personhendelse/pull/576