### PR TITLE
Forvaltning controller oppgave

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
@@ -30,7 +30,7 @@ class FerdigstillOppgavetypePåBehandlingTask(
 
         logger.info("Ferdigstiller oppgavetype $oppgavetype for behandling $behandlingId")
 
-        if (oppgavetype != Oppgavetype.BehandleSak || oppgavetype != Oppgavetype.GodkjenneVedtak) {
+        if (oppgavetype != Oppgavetype.BehandleSak && oppgavetype != Oppgavetype.GodkjenneVedtak) {
             throw IllegalArgumentException("Kan kun ferdigstille oppgavetype BehandleSak eller GodkjenneVedtak")
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
@@ -42,7 +42,7 @@ class FerdigstillOppgavetypePåBehandlingTask(
                 // Setter oppgave til ferdigstilt i EF
                 oppgaveRepository.update(it.copy(erFerdigstilt = true))
                 // Ferdigstiller oppgave i Gosys
-                oppgaveService.ferdigstillOppgave(it.id.mostSignificantBits)
+                oppgaveService.ferdigstillOppgave(it.gsakOppgaveId)
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
@@ -19,8 +19,8 @@ import java.util.Properties
     beskrivelse = "Skal ferdigstille oppgave i EF-sak og Gosys hvis det er flere oppgaver av samme type på behandling",
 )
 class FerdigstillOppgavetypePåBehandlingTask(
-    private val oppgaveRepository: OppgaveRepository,
     private val oppgaveService: OppgaveService,
+    private val oppgaveRepository: OppgaveRepository,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -30,7 +30,7 @@ class FerdigstillOppgavetypePåBehandlingTask(
 
         logger.info("Ferdigstiller oppgavetype $oppgavetype for behandling $behandlingId")
 
-        if (oppgavetype != Oppgavetype.BehandleSak && oppgavetype != Oppgavetype.GodkjenneVedtak) {
+        if (oppgavetype != Oppgavetype.BehandleSak || oppgavetype != Oppgavetype.GodkjenneVedtak) {
             throw IllegalArgumentException("Kan kun ferdigstille oppgavetype BehandleSak eller GodkjenneVedtak")
         }
 
@@ -40,8 +40,7 @@ class FerdigstillOppgavetypePåBehandlingTask(
             val sisteOppgave = efOppgaver.last()
             sisteOppgave.let {
                 // Setter oppgave til ferdigstilt i EF
-                oppgaveService.settEfOppgaveTilFerdig(it.behandlingId, it.type)
-
+                oppgaveRepository.update(it.copy(erFerdigstilt = true))
                 // Ferdigstiller oppgave i Gosys
                 oppgaveService.ferdigstillOppgave(it.id.mostSignificantBits)
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
@@ -1,0 +1,63 @@
+package no.nav.familie.ef.sak.forvaltning
+
+import no.nav.familie.ef.sak.oppgave.OppgaveRepository
+import no.nav.familie.ef.sak.oppgave.OppgaveService
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.Properties
+
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = FerdigstillOppgavetypePåBehandlingTask.TYPE,
+    maxAntallFeil = 1,
+    settTilManuellOppfølgning = true,
+    beskrivelse = "Skal ferdigstille oppgave i EF-sak og Gosys hvis det er flere oppgaver av samme type på behandling",
+)
+class FerdigstillOppgavetypePåBehandlingTask(
+    private val oppgaveRepository: OppgaveRepository,
+    private val oppgaveService: OppgaveService,
+) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        val payload = objectMapper.readValue(task.payload, ForvaltningFerdigstillRequest::class.java)
+        val (behandlingId, oppgavetype) = payload
+
+        logger.info("Ferdigstiller oppgavetype $oppgavetype for behandling $behandlingId")
+
+        if (oppgavetype != Oppgavetype.BehandleSak && oppgavetype != Oppgavetype.GodkjenneVedtak) {
+            throw IllegalArgumentException("Kan kun ferdigstille oppgavetype BehandleSak eller GodkjenneVedtak")
+        }
+
+        val efOppgaver = oppgaveService.finnAlleOppgaverPåBehandlingSomIkkeErFerdigstiltOgHarLikOppgavetype(behandlingId, oppgavetype)
+
+        if (efOppgaver != null && efOppgaver.size > 1) {
+            val sisteOppgave = efOppgaver.last()
+            sisteOppgave.let {
+                // Setter oppgave til ferdigstilt i EF
+                oppgaveService.settEfOppgaveTilFerdig(it.behandlingId, it.type)
+
+                // Ferdigstiller oppgave i Gosys
+                oppgaveService.ferdigstillOppgave(it.id.mostSignificantBits)
+            }
+        }
+    }
+
+    companion object {
+        const val TYPE = "FerdigstillOppgavetypePåBehandlingTask"
+
+        fun opprettTask(
+            request: ForvaltningFerdigstillRequest,
+        ): Task =
+            Task(
+                type = TYPE,
+                payload = objectMapper.writeValueAsString(request),
+                properties = Properties(),
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
@@ -2,13 +2,20 @@ package no.nav.familie.ef.sak.forvaltning
 
 import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
+
+data class ForvaltningFerdigstillRequest(
+    val behandlingId: UUID,
+    val oppgavetype: Oppgavetype,
+)
 
 @RestController
 @RequestMapping("/api/oppgave/forvaltning/")
@@ -41,6 +48,15 @@ class OppgaveforvaltningsController(
     ) {
         tilgangService.validerHarForvalterrolle()
         val task = GjennoprettOppgavePåBehandlingTask.opprettTask(behandlingId)
+        taskService.save(task)
+    }
+
+    @PostMapping("ferdigstill")
+    fun ferdigstillOppgavtypeForBehandling(
+        @RequestBody request: ForvaltningFerdigstillRequest,
+    ) {
+        tilgangService.validerHarForvalterrolle()
+        val task = FerdigstillOppgavetypePåBehandlingTask.opprettTask(request)
         taskService.save(task)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveRepository.kt
@@ -38,6 +38,11 @@ interface OppgaveRepository :
         oppgavetype: Set<Oppgavetype>,
     ): Oppgave?
 
+    fun findAllByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(
+        behandlingId: UUID,
+        oppgavetype: Set<Oppgavetype>,
+    ): List<Oppgave>?
+
     fun findByBehandlingIdAndBarnPersonIdentAndAlder(
         behandlingId: UUID,
         barnPersonIdent: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -269,6 +269,11 @@ class OppgaveService(
         oppgaveClient.ferdigstillOppgave(gsakOppgaveId)
     }
 
+    fun finnAlleOppgaverPåBehandlingSomIkkeErFerdigstiltOgHarLikOppgavetype(
+        behandlingId: UUID,
+        oppgavetype: Oppgavetype,
+    ): List<no.nav.familie.ef.sak.oppgave.Oppgave>? = oppgaveRepository.findAllByBehandlingIdAndErFerdigstiltIsFalseAndTypeIn(behandlingId, setOf(oppgavetype))
+
     fun settEfOppgaveTilFerdig(
         behandlingId: UUID,
         oppgavetype: Oppgavetype,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved en feil var det mulig å trykke "Send til beslutter" flere ganger, dette gjorde at 2 oppgaver ble opprettet.

Løser dette med et forvaltningsendepunkt som sender med id på behandling og oppgavetypen, for så å ferdigstille en av de ekstra oppgavene i ef-sak og gosys.