### PR TITLE
Unleash - empty map for UnleashContextField når bruker er systembruker

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/UnleashNextService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/UnleashNextService.kt
@@ -11,12 +11,12 @@ class UnleashNextService(
 ) {
     fun isEnabled(toggle: Toggle): Boolean {
         val unleashContextFieldsMap =
-            if (!SikkerhetContext.erSystembruker()) {
+            if (SikkerhetContext.erSystembruker()) {
+                emptyMap()
+            } else {
                 mapOf(
                     UnleashContextFields.NAV_IDENT to SikkerhetContext.hentSaksbehandler(),
                 )
-            } else {
-                emptyMap()
             }
 
         return unleashService.isEnabled(

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/UnleashNextService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/UnleashNextService.kt
@@ -10,14 +10,14 @@ class UnleashNextService(
     private val unleashService: UnleashService,
 ) {
     fun isEnabled(toggle: Toggle): Boolean {
-        if (SikkerhetContext.erSystembruker()) {
-            return false
-        }
-
         val unleashContextFieldsMap =
-            mapOf(
-                UnleashContextFields.NAV_IDENT to SikkerhetContext.hentSaksbehandler(),
-            )
+            if (!SikkerhetContext.erSystembruker()) {
+                mapOf(
+                    UnleashContextFields.NAV_IDENT to SikkerhetContext.hentSaksbehandler(),
+                )
+            } else {
+                emptyMap()
+            }
 
         return unleashService.isEnabled(
             toggleId = toggle.toggleId,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når systembruker prøver å gjøre et kall sender vi med en tom map av UnleashContextField verdier da disse ikke blir tatt i bruk. 