### PR TITLE
Bugfix: Det lagres ned både personident og ukenummer i payload

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.behandling.revurdering
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.fagsak.FagsakService
@@ -16,11 +17,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 
-data class PayloadBehandleAutomatiskInntektsendringTask(
-    val personIdent: String,
-    val ukeÅr: String,
-)
-
 @Service
 @TaskStepBeskrivelse(
     taskStepType = BehandleAutomatiskInntektsendringTask.TYPE,
@@ -36,7 +32,7 @@ class BehandleAutomatiskInntektsendringTask(
     override fun doTask(task: Task) {
         val toggle = featureToggleService.isEnabled(Toggle.BEHANDLE_AUTOMATISK_INNTEKTSENDRING)
 
-        val personIdent = task.payload
+        val personIdent = objectMapper.readValue<PayloadBehandleAutomatiskInntektsendringTask>(task.payload).personIdent
         val fagsak =
             fagsakService.finnFagsak(
                 personIdenter = setOf(personIdent),
@@ -84,3 +80,8 @@ class BehandleAutomatiskInntektsendringTask(
         secureLogger.info("Kan opprette behandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak?.id}")
     }
 }
+
+data class PayloadBehandleAutomatiskInntektsendringTask(
+    val personIdent: String,
+    val ukeÅr: String,
+)


### PR DESCRIPTION
I BehandleAutomatiskInntektsendringTask lagres det ned både ident og ukenummer i payload. Dette må parses ut riktig ved videre bruk av personident.