### PR TITLE
Opprett og initier revurdering for inntektsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -6,7 +6,6 @@ import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.beregning.tilInntekt
 import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
@@ -56,7 +55,6 @@ class BehandleAutomatiskInntektsendringTask(
 
         if (toggle) {
             if (fagsak != null) {
-
                 val behandling =
                     revurderingService.opprettRevurderingManuelt(
                         RevurderingDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -2,10 +2,8 @@ package no.nav.familie.ef.sak.behandling.revurdering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
-import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandling.domain.ÅrsakRevurdering
 import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
-import no.nav.familie.ef.sak.behandling.dto.tilDomene
 import no.nav.familie.ef.sak.beregning.tilInntekt
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
@@ -14,7 +12,6 @@ import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.vedtak.VedtakService
-import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
 import no.nav.familie.ef.sak.vedtak.dto.fraDomene
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -60,26 +57,28 @@ class BehandleAutomatiskInntektsendringTask(
             if (fagsak != null) {
                 loggInfoOpprett(personIdent, fagsak)
 
-                val behandling = revurderingService.opprettRevurderingManuelt(
-                    RevurderingDto(
-                        fagsakId = fagsak.id,
-                        behandlingsårsak = BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING,
-                        kravMottatt = LocalDate.now(),
-                        vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
+                val behandling =
+                    revurderingService.opprettRevurderingManuelt(
+                        RevurderingDto(
+                            fagsakId = fagsak.id,
+                            behandlingsårsak = BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING,
+                            kravMottatt = LocalDate.now(),
+                            vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
+                        ),
                     )
-                )
 
                 val forrigeBehandling = behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it) } ?: throw IllegalStateException("Burde vært en forrigeBehandlingId etter automatisk revurdering for behandlingId: ${behandling.id}")
                 val forrigeVedtak = vedtakService.hentVedtak(forrigeBehandling.id)
-                val innvilgelseOvergangsstønad = InnvilgelseOvergangsstønad(
-                    periodeBegrunnelse = forrigeVedtak.periodeBegrunnelse,
-                    inntektBegrunnelse = forrigeVedtak.inntektBegrunnelse,
-                    perioder = forrigeVedtak.perioder?.perioder?.fraDomene() ?: emptyList(),
-                    inntekter = forrigeVedtak.inntekter?.inntekter?.tilInntekt() ?: emptyList(),
-                    samordningsfradragType = forrigeVedtak.samordningsfradragType,
-                )
+                val innvilgelseOvergangsstønad =
+                    InnvilgelseOvergangsstønad(
+                        periodeBegrunnelse = forrigeVedtak.periodeBegrunnelse,
+                        inntektBegrunnelse = forrigeVedtak.inntektBegrunnelse,
+                        perioder = forrigeVedtak.perioder?.perioder?.fraDomene() ?: emptyList(),
+                        inntekter = forrigeVedtak.inntekter?.inntekter?.tilInntekt() ?: emptyList(),
+                        samordningsfradragType = forrigeVedtak.samordningsfradragType,
+                    )
 
-                årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER, Revurderingsårsak.ENDRING_INNTEKT, "Delautomatisk inntektsendring"))
+                årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
                 vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
 
                 logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -52,11 +52,10 @@ class BehandleAutomatiskInntektsendringTask(
                 personIdenter = setOf(personIdent),
                 stønadstype = StønadType.OVERGANGSSTØNAD,
             )
-        loggInfoOpprett(personIdent, fagsak)
+        secureLogger.info("Kan opprette behandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak?.id}")
 
         if (toggle) {
             if (fagsak != null) {
-                loggInfoOpprett(personIdent, fagsak)
 
                 val behandling =
                     revurderingService.opprettRevurderingManuelt(
@@ -106,13 +105,6 @@ class BehandleAutomatiskInntektsendringTask(
                     },
             )
         }
-    }
-
-    fun loggInfoOpprett(
-        personIdent: String,
-        fagsak: Fagsak?,
-    ) {
-        secureLogger.info("Kan opprette behandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak?.id}")
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.behandling.revurdering
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.fagsak.FagsakService
@@ -16,11 +17,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 
-data class PayloadBehandleAutomatiskInntektsendringTask(
-    val personIdent: String,
-    val ukeÅr: String,
-)
-
 @Service
 @TaskStepBeskrivelse(
     taskStepType = BehandleAutomatiskInntektsendringTask.TYPE,
@@ -36,7 +32,7 @@ class BehandleAutomatiskInntektsendringTask(
     override fun doTask(task: Task) {
         val toggle = featureToggleService.isEnabled(Toggle.BEHANDLE_AUTOMATISK_INNTEKTSENDRING)
 
-        val personIdent = task.payload
+        val personIdent = objectMapper.readValue<PayloadBehandleAutomatiskInntektsendringTask>(task.payload).personIdent
         val fagsak =
             fagsakService.finnFagsak(
                 personIdenter = setOf(personIdent),
@@ -84,3 +80,8 @@ class BehandleAutomatiskInntektsendringTask(
         secureLogger.info("Kan opprette behandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak?.id}")
     }
 }
+
+data class PayloadBehandleAutomatiskInntektsendringTask(
+    val personIdent: String,
+    val ukeÅr: String,
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -86,6 +86,8 @@ class BehandleAutomatiskInntektsendringTask(
             } else {
                 secureLogger.error("Finner ikke fagsak for personIdent=$personIdent på stønadstype=${StønadType.OVERGANGSSTØNAD} under automatisk inntektsendring")
             }
+        } else {
+            logger.info("Toggle for automatisering av inntekt er AV. Ville opprettet revurdering for fagsak=${fagsak?.id} med en forventetInntekt på X og revurdert fra dato: Y")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -37,6 +37,7 @@ class BehandleAutomatiskInntektsendringTask(
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
     private val årsakRevurderingsRepository: ÅrsakRevurderingsRepository,
+    private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -80,7 +81,7 @@ class BehandleAutomatiskInntektsendringTask(
 
                 årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
                 vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
-
+                automatiskRevurderingService.lagreInntektResponse(personIdent, behandling.id)
                 logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")
             } else {
                 secureLogger.error("Finner ikke fagsak for personIdent=$personIdent på stønadstype=${StønadType.OVERGANGSSTØNAD} under automatisk inntektsendring")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -128,7 +128,9 @@ class RevurderingService(
                 ),
             ),
         )
-        taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId = revurdering.id))
+        if (revurderingDto.behandlingsårsak != BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING) {
+            taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId = revurdering.id))
+        }
 
         if (erSatsendring(revurderingDto)) {
             val vedtakDto =

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -92,7 +92,8 @@ class RevurderingService(
         val forrigeBehandlingId =
             behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)?.id
                 ?: error("Revurdering må ha eksisterende iverksatt behandling")
-        val saksbehandler = SikkerhetContext.hentSaksbehandler()
+
+        val saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker()
 
         søknadService.kopierSøknad(forrigeBehandlingId, revurdering.id)
         val grunnlagsdata = grunnlagsdataService.opprettGrunnlagsdata(revurdering.id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/BehandlingsstatistikkTask.kt
@@ -200,7 +200,7 @@ class BehandlingsstatistikkTask(
                 behandlingId = behandlingId,
                 hendelse = Hendelse.PÅBEGYNT,
                 hendelseTidspunkt = LocalDateTime.now(),
-                gjeldendeSaksbehandler = SikkerhetContext.hentSaksbehandler(),
+                gjeldendeSaksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker(),
             )
 
         fun opprettVenterTask(behandlingId: UUID): Task =

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.behandling.revurdering
 
-import io.mockk.mockk
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -1,10 +1,12 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.behandling.revurdering
 
+import io.mockk.mockk
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.revurdering.AutomatiskRevurderingService
 import no.nav.familie.ef.sak.behandling.revurdering.BehandleAutomatiskInntektsendringTask
 import no.nav.familie.ef.sak.behandling.revurdering.PayloadBehandleAutomatiskInntektsendringTask
 import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
@@ -52,6 +54,9 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
     private lateinit var årsakRevurderingsRepository: ÅrsakRevurderingsRepository
 
     @Autowired
+    private lateinit var automatiskRevurderingService: AutomatiskRevurderingService
+
+    @Autowired
     private lateinit var vilkårHelperService: VilkårHelperService
 
     @Autowired
@@ -72,6 +77,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
                 behandlingService = behandlingService,
                 vedtakService = vedtakService,
                 årsakRevurderingsRepository = årsakRevurderingsRepository,
+                automatiskRevurderingService = automatiskRevurderingService,
                 featureToggleService = featureToggleService,
             )
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -1,0 +1,115 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.behandling.revurdering
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandling.revurdering.BehandleAutomatiskInntektsendringTask
+import no.nav.familie.ef.sak.behandling.revurdering.PayloadBehandleAutomatiskInntektsendringTask
+import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
+import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakpersoner
+import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.repository.vedtak
+import no.nav.familie.ef.sak.testutil.VedtakHelperService
+import no.nav.familie.ef.sak.testutil.VilkårHelperService
+import no.nav.familie.ef.sak.vedtak.VedtakService
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import no.nav.familie.kontrakter.ef.felles.Opplysningskilde
+import no.nav.familie.kontrakter.ef.felles.Revurderingsårsak
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.YearMonth
+
+class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var featureToggleService: FeatureToggleService
+
+    @Autowired
+    private lateinit var fagsakService: FagsakService
+
+    @Autowired
+    private lateinit var revurderingService: RevurderingService
+
+    @Autowired
+    private lateinit var behandlingService: BehandlingService
+
+    @Autowired
+    private lateinit var vedtakService: VedtakService
+
+    @Autowired
+    private lateinit var årsakRevurderingsRepository: ÅrsakRevurderingsRepository
+
+    @Autowired
+    private lateinit var vilkårHelperService: VilkårHelperService
+
+    @Autowired
+    private lateinit var vedtakHelperService: VedtakHelperService
+
+    private val personIdent = "123456789012"
+    private val fagsak = fagsak(identer = fagsakpersoner(setOf(personIdent)))
+
+    private lateinit var behandleAutomatiskInntektsendringTask: BehandleAutomatiskInntektsendringTask
+
+    @BeforeEach
+    fun setup() {
+        testoppsettService.lagreFagsak(fagsak)
+        behandleAutomatiskInntektsendringTask =
+            BehandleAutomatiskInntektsendringTask(
+                revurderingService = revurderingService,
+                fagsakService = fagsakService,
+                behandlingService = behandlingService,
+                vedtakService = vedtakService,
+                årsakRevurderingsRepository = årsakRevurderingsRepository,
+                featureToggleService = featureToggleService,
+            )
+    }
+
+    @Test
+    fun `behandling automatisk inntektsendring`() {
+        val behandling = behandling(fagsak, resultat = BehandlingResultat.INNVILGET, status = BehandlingStatus.UTREDES)
+        behandlingRepository.insert(behandling)
+        vilkårHelperService.opprettVilkår(behandling)
+        vedtakHelperService.ferdigstillVedtak(vedtak(behandlingId = behandling.id), behandling, fagsak)
+
+        val payload = PayloadBehandleAutomatiskInntektsendringTask("123456789012", "2025-15")
+        val test = BehandleAutomatiskInntektsendringTask.opprettTask(objectMapper.writeValueAsString(payload))
+
+        behandleAutomatiskInntektsendringTask.doTask(test)
+
+        val behandlingerForFagsak = behandlingRepository.findByFagsakId(fagsakId = fagsak.id)
+        assertThat(behandlingerForFagsak).hasSize(2)
+        val automatiskInntektsendringBehandling = behandlingerForFagsak.first { it.årsak == BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING }
+        val årsakTilRevurdering = årsakRevurderingsRepository.findByIdOrThrow(automatiskInntektsendringBehandling.id)
+        assertThat(årsakTilRevurdering.opplysningskilde).isEqualTo(Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER) // Endres til Automatisk opprettet behandling
+        assertThat(årsakTilRevurdering.årsak).isEqualTo(Revurderingsårsak.ENDRING_INNTEKT)
+        assertThat(årsakTilRevurdering.beskrivelse).isNullOrEmpty()
+
+        val vedtak = vedtakService.hentVedtak(automatiskInntektsendringBehandling.id)
+        assertThat(
+            vedtak.perioder
+                ?.perioder
+                ?.first()
+                ?.periode
+                ?.fom,
+        ).isEqualTo(YearMonth.of(2021, 1)) // Revurderes fra
+        assertThat(
+            vedtak.inntekter
+                ?.inntekter
+                ?.first()
+                ?.inntekt
+                ?.toInt(),
+        ).isEqualTo(100000)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -97,19 +97,12 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         assertThat(årsakTilRevurdering.beskrivelse).isNullOrEmpty()
 
         val vedtak = vedtakService.hentVedtak(automatiskInntektsendringBehandling.id)
-        assertThat(
-            vedtak.perioder
-                ?.perioder
-                ?.first()
-                ?.periode
-                ?.fom,
-        ).isEqualTo(YearMonth.of(2021, 1)) // Revurderes fra
-        assertThat(
-            vedtak.inntekter
-                ?.inntekter
-                ?.first()
-                ?.inntekt
-                ?.toInt(),
-        ).isEqualTo(100000)
+
+        val vedtaksperioder = vedtak.perioder?.perioder
+        val førsteFom = vedtaksperioder?.first()?.periode?.fom
+        assertThat(førsteFom).isEqualTo(YearMonth.of(2021, 1)) // Revurderes fra
+
+        val inntektsperioder = vedtak.inntekter?.inntekter
+        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(100000)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -21,7 +21,6 @@ import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadRepository
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
-import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
@@ -30,7 +29,6 @@ import no.nav.familie.ef.sak.repository.saksbehandling
 import no.nav.familie.ef.sak.repository.vedtakBarnetilsyn
 import no.nav.familie.ef.sak.testutil.VedtakHelperService
 import no.nav.familie.ef.sak.testutil.VilkårHelperService
-import no.nav.familie.ef.sak.testutil.søknadBarnTilBehandlingBarn
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.KontantstøtteWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeMedBeløp
@@ -42,7 +40,6 @@ import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import no.nav.familie.kontrakter.ef.søknad.Barn
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.ef.StønadType

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceIntegrationTest.kt
@@ -421,7 +421,7 @@ internal class RevurderingServiceIntegrationTest : OppslagSpringRunnerTest() {
         behandling: Behandling,
         fagsakBarnetilsyn: Fagsak,
     ) {
-        vedtakService.lagreVedtak(vedtak.tilVedtakDto(), behandling.id, StønadType.BARNETILSYN)
+        vedtakService.lagreVedtak(vedtak.tilVedtakDto(), behandling.id, fagsak.stønadstype)
 
         beregnYtelseSteg.utførSteg(saksbehandling(fagsakBarnetilsyn, behandling), vedtak.tilVedtakDto())
         behandlingRepository.update(

--- a/src/test/kotlin/testutil/SøknadHelperService.kt
+++ b/src/test/kotlin/testutil/SøknadHelperService.kt
@@ -2,8 +2,8 @@ package no.nav.familie.ef.sak.testutil
 
 import no.nav.familie.ef.sak.barn.BarnRepository
 import no.nav.familie.ef.sak.behandling.domain.Behandling
-import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaBarnetilsyn
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.Barn
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
@@ -22,11 +22,7 @@ class SøknadHelperService {
 
     fun lagreSøknad(
         behandling: Behandling,
-        barn: List<Barn> =
-            listOf(
-                TestsøknadBuilder.Builder().defaultBarn("Barn Barnesen", PdlClientConfig.BARN_FNR),
-                TestsøknadBuilder.Builder().defaultBarn("Barn2 Barnesen", PdlClientConfig.BARN2_FNR),
-            ),
+        barn: List<Barn>,
     ): SøknadsskjemaOvergangsstønad {
         val søknad =
             TestsøknadBuilder
@@ -40,5 +36,21 @@ class SøknadHelperService {
                 ?: error("Fant ikke overgangsstønad for testen")
         barnRepository.insertAll(søknadBarnTilBehandlingBarn(overgangsstønad.barn, behandling.id))
         return overgangsstønad
+    }
+
+    fun lagreSøknadForBarnetilsyn(
+        behandling: Behandling,
+        barn: List<Barn>,
+    ): SøknadsskjemaBarnetilsyn {
+        val søknad =
+            TestsøknadBuilder
+                .Builder()
+                .setBarn(barn)
+                .build()
+                .søknadBarnetilsyn
+        søknadService.lagreSøknadForBarnetilsyn(søknad, behandling.id, behandling.fagsakId, "1L")
+        val barnetilsyn = søknadService.hentBarnetilsyn(behandling.id) ?: error("Fant ikke overgangsstønad for testen")
+        barnRepository.insertAll(søknadBarnTilBehandlingBarn(barnetilsyn.barn, behandling.id))
+        return barnetilsyn
     }
 }

--- a/src/test/kotlin/testutil/SøknadHelperService.kt
+++ b/src/test/kotlin/testutil/SøknadHelperService.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.ef.sak.testutil
+
+import no.nav.familie.ef.sak.barn.BarnRepository
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
+import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
+import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaOvergangsstønad
+import no.nav.familie.kontrakter.ef.søknad.Barn
+import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("integrasjonstest")
+@Service
+class SøknadHelperService {
+    @Autowired
+    private lateinit var barnRepository: BarnRepository
+
+    @Autowired
+    private lateinit var søknadService: SøknadService
+
+    fun lagreSøknad(
+        behandling: Behandling,
+        barn: List<Barn> =
+            listOf(
+                TestsøknadBuilder.Builder().defaultBarn("Barn Barnesen", PdlClientConfig.BARN_FNR),
+                TestsøknadBuilder.Builder().defaultBarn("Barn2 Barnesen", PdlClientConfig.BARN2_FNR),
+            ),
+    ): SøknadsskjemaOvergangsstønad {
+        val søknad =
+            TestsøknadBuilder
+                .Builder()
+                .setBarn(barn)
+                .build()
+                .søknadOvergangsstønad
+        søknadService.lagreSøknadForOvergangsstønad(søknad, behandling.id, behandling.fagsakId, "1L")
+        val overgangsstønad =
+            søknadService.hentOvergangsstønad(behandling.id)
+                ?: error("Fant ikke overgangsstønad for testen")
+        barnRepository.insertAll(søknadBarnTilBehandlingBarn(overgangsstønad.barn, behandling.id))
+        return overgangsstønad
+    }
+}

--- a/src/test/kotlin/testutil/VedtakHelperService.kt
+++ b/src/test/kotlin/testutil/VedtakHelperService.kt
@@ -1,0 +1,46 @@
+package no.nav.familie.ef.sak.testutil
+
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.behandlingsflyt.steg.BeregnYtelseSteg
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.felles.domain.SporbarUtils
+import no.nav.familie.ef.sak.repository.saksbehandling
+import no.nav.familie.ef.sak.vedtak.VedtakService
+import no.nav.familie.ef.sak.vedtak.domain.Vedtak
+import no.nav.familie.ef.sak.vedtak.dto.tilVedtakDto
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("integrasjonstest")
+@Service
+class VedtakHelperService {
+    @Autowired
+    private lateinit var vedtakService: VedtakService
+
+    @Autowired
+    private lateinit var beregnYtelseSteg: BeregnYtelseSteg
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    fun ferdigstillVedtak(
+        vedtak: Vedtak,
+        behandling: Behandling,
+        fagsak: Fagsak,
+    ) {
+        vedtakService.lagreVedtak(vedtak.tilVedtakDto(), behandling.id, fagsak.stønadstype)
+
+        beregnYtelseSteg.utførSteg(saksbehandling(fagsak, behandling), vedtak.tilVedtakDto())
+        behandlingRepository.update(
+            behandling.copy(
+                status = BehandlingStatus.FERDIGSTILT,
+                resultat = BehandlingResultat.INNVILGET,
+                vedtakstidspunkt = SporbarUtils.now(),
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/testutil/VilkårHelperService.kt
+++ b/src/test/kotlin/testutil/VilkårHelperService.kt
@@ -1,0 +1,110 @@
+package no.nav.familie.ef.sak.testutil
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.barn.BarnRepository
+import no.nav.familie.ef.sak.barn.BehandlingBarn
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.vilkår.VilkårTestUtil
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Sivilstandstype
+import no.nav.familie.ef.sak.opplysninger.søknad.domain.Sivilstand
+import no.nav.familie.ef.sak.repository.vilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
+import no.nav.familie.ef.sak.vilkår.VilkårType
+import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
+import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
+import no.nav.familie.ef.sak.vilkår.regler.HovedregelMetadata
+import no.nav.familie.ef.sak.vilkår.regler.vilkår.AleneomsorgRegel
+import no.nav.familie.ef.sak.vilkår.regler.vilkår.SivilstandRegel
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("integrasjonstest")
+@Service
+class VilkårHelperService {
+    @Autowired
+    private lateinit var barnRepository: BarnRepository
+
+    @Autowired
+    private lateinit var vilkårsvurderingRepository: VilkårsvurderingRepository
+
+    @Autowired
+    private lateinit var søknadHelperService: SøknadHelperService
+
+    fun opprettVilkår(
+        behandling: Behandling,
+    ) {
+        val barn = barnRepository.findByBehandlingId(behandling.id)
+        val sivilstand = søknadHelperService.lagreSøknad(behandling).sivilstand
+        val delvilkårsvurdering =
+            lagSivilstandDelvilkår(sivilstand)
+
+        val delvilkårsvurderingAleneomsorg =
+            lagDelvilkårsvurderingAleneomsorg(barn, sivilstand, behandling)
+        lagreVilkår(behandling, delvilkårsvurdering, barn, delvilkårsvurderingAleneomsorg)
+    }
+
+    fun lagSivilstandDelvilkår(sivilstand: Sivilstand?): List<Delvilkårsvurdering> {
+        val behandlingMock = mockk<Behandling>()
+        every { behandlingMock.erDigitalSøknad() } returns true
+        val delvilkårsvurdering =
+            SivilstandRegel().initiereDelvilkårsvurdering(
+                HovedregelMetadata(
+                    sivilstand,
+                    Sivilstandstype.ENKE_ELLER_ENKEMANN,
+                    barn = emptyList(),
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = mockk(),
+                    behandling = behandlingMock,
+                ),
+            )
+        return delvilkårsvurdering
+    }
+
+    fun lagDelvilkårsvurderingAleneomsorg(
+        barn: List<BehandlingBarn>,
+        sivilstand: Sivilstand?,
+        behandling: Behandling,
+    ): List<Delvilkårsvurdering> {
+        val delvilkårsvurderingAleneomsorg =
+            AleneomsorgRegel().initiereDelvilkårsvurdering(
+                HovedregelMetadata(
+                    sivilstand,
+                    Sivilstandstype.ENKE_ELLER_ENKEMANN,
+                    barn = barn,
+                    søktOmBarnetilsyn = emptyList(),
+                    vilkårgrunnlagDto = VilkårTestUtil.mockVilkårGrunnlagDto(),
+                    behandling = behandling,
+                ),
+            )
+        return delvilkårsvurderingAleneomsorg
+    }
+
+    fun lagreVilkår(
+        behandling: Behandling,
+        delvilkårsvurdering: List<Delvilkårsvurdering>,
+        barn: List<BehandlingBarn>,
+        delvilkårsvurderingAleneomsorg: List<Delvilkårsvurdering>,
+    ) {
+        val vilkårForBarn =
+            barn.map {
+                vilkårsvurdering(
+                    resultat = Vilkårsresultat.OPPFYLT,
+                    type = VilkårType.ALENEOMSORG,
+                    behandlingId = behandling.id,
+                    barnId = it.id,
+                    delvilkårsvurdering = delvilkårsvurderingAleneomsorg,
+                )
+            }
+        vilkårsvurderingRepository.insertAll(
+            vilkårForBarn +
+                vilkårsvurdering(
+                    resultat = Vilkårsresultat.OPPFYLT,
+                    type = VilkårType.SIVILSTAND,
+                    behandlingId = behandling.id,
+                    delvilkårsvurdering = delvilkårsvurdering,
+                ),
+        )
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Kopierer vilkår og vedtak fra forrige behandling.
Det som må settes er verdier som er på førstesiden av en revurdering, årsak til revurdering. Se screenshot for preutfylte verdier som settes med denne koden.
![Screenshot 2025-04-02 at 12 50 56](https://github.com/user-attachments/assets/a5a16b8d-9916-452e-9fdf-a17251ad79a6)

I stedet for "Opplysninger fra intern kontroll" skal det settes noe ala "automatisk inntektskontroll", men det må avklares først.

![Screenshot 2025-04-02 at 12 34 26](https://github.com/user-attachments/assets/88b649b4-514c-4e0b-96d1-48a53c4a6b55)

I tillegg skal forventet inntekt og revurderes fra-dato fylles ut automatisk på vedtak og beregning, men dette krever analyse og avklaringer. Derfor kopieres alt over uten endring, inntil videre. 

Dette er fortsatt gjemt bak en featuretoggle. Planen er at det bare skal logges i prod ved neste kjøring. 
