### PR TITLE
Byttet opplysningskilde til AUTOMATISK_OPPRETTET_BEHANDLING

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-validation-spring.version>5.0.20</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>3.0_20250328102435_154d3a4</kontrakter.version>
+        <kontrakter.version>3.0_20250401151544_aae9e33</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20230214104704_706e9c0</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.21.1</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -76,7 +76,7 @@ class BehandleAutomatiskInntektsendringTask(
                         samordningsfradragType = forrigeVedtak.samordningsfradragType,
                     )
 
-                årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
+                årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.AUTOMATISK_OPPRETTET_BEHANDLING, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
                 vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
                 automatiskRevurderingService.lagreInntektResponse(personIdent, behandling.id)
                 logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -97,7 +97,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         assertThat(behandlingerForFagsak).hasSize(2)
         val automatiskInntektsendringBehandling = behandlingerForFagsak.first { it.årsak == BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING }
         val årsakTilRevurdering = årsakRevurderingsRepository.findByIdOrThrow(automatiskInntektsendringBehandling.id)
-        assertThat(årsakTilRevurdering.opplysningskilde).isEqualTo(Opplysningskilde.OPPLYSNINGER_INTERNE_KONTROLLER) // Endres til Automatisk opprettet behandling
+        assertThat(årsakTilRevurdering.opplysningskilde).isEqualTo(Opplysningskilde.AUTOMATISK_OPPRETTET_BEHANDLING)
         assertThat(årsakTilRevurdering.årsak).isEqualTo(Revurderingsårsak.ENDRING_INNTEKT)
         assertThat(årsakTilRevurdering.beskrivelse).isNullOrEmpty()
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Mer passende opplysningskilde for behandlinger opprettet ved automatisk sjekk av inntektsendring