### PR TITLE
Automatisering inntektsendring tilpasse inntektsresponse til data

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -12,7 +12,7 @@ data class InntektResponse(
 ) {
     fun totalInntektFraÅrMåned(årMåned: YearMonth): Int =
         inntektsmåneder
-            .filter { it.måned.isEqualOrAfter(årMåned) }
+            .filter { it.måned.isEqualOrAfter(årMåned) && it.måned.isBefore(YearMonth.now())}
             .flatMap { it.inntektListe }
             .sumOf { it.beløp }
             .toInt()
@@ -26,9 +26,17 @@ data class InntektResponse(
             ?.second
             ?.toPair()
 
+    fun inntektsmånderUtenEfOvergangstonad(): List<Inntektsmåned> =
+        inntektsmåneder.filter { inntektsmåned ->
+            inntektsmåned.inntektListe.all {
+                it.type != InntektType.YTELSE_FRA_OFFENTLIGE &&
+                        it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
+            }
+        }
+
     fun forventetMånedsinntekt() =
         if (harTreForrigeInntektsmåneder) {
-            totalInntektFraÅrMåned(inntektsmåneder.last().måned.minusMonths(2)) / 3
+            totalInntektFraÅrMåned(YearMonth.now().minusMonths(3))/3
         } else {
             throw IllegalStateException("Mangler inntektsinformasjon for de tre siste måneder")
         }
@@ -37,7 +45,10 @@ data class InntektResponse(
 
     fun revurderesFraDato() = førsteMånedOgInntektMed10ProsentØkning()?.first
 
-    val harTreForrigeInntektsmåneder = inntektsmåneder.filter { it.måned.isEqualOrAfter(YearMonth.now().minusMonths(3)) }.size == 3
+    val harTreForrigeInntektsmåneder = inntektsmåneder
+        .filter { it.måned.isEqualOrAfter(YearMonth.now().minusMonths(3)) && it.måned.isBefore(YearMonth.now()) }
+        .map { it.måned }
+        .distinct().size == 3
 }
 
 data class Inntektsmåned(

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -12,7 +12,7 @@ data class InntektResponse(
 ) {
     fun totalInntektFraÅrMåned(årMåned: YearMonth): Int =
         inntektsmåneder
-            .filter { it.måned.isEqualOrAfter(årMåned) && it.måned.isBefore(YearMonth.now())}
+            .filter { it.måned.isEqualOrAfter(årMåned) && it.måned.isBefore(YearMonth.now()) }
             .flatMap { it.inntektListe }
             .sumOf { it.beløp }
             .toInt()
@@ -30,13 +30,13 @@ data class InntektResponse(
         inntektsmåneder.filter { inntektsmåned ->
             inntektsmåned.inntektListe.all {
                 it.type != InntektType.YTELSE_FRA_OFFENTLIGE &&
-                        it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
+                    it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
             }
         }
 
     fun forventetMånedsinntekt() =
         if (harTreForrigeInntektsmåneder) {
-            totalInntektFraÅrMåned(YearMonth.now().minusMonths(3))/3
+            totalInntektFraÅrMåned(YearMonth.now().minusMonths(3)) / 3
         } else {
             throw IllegalStateException("Mangler inntektsinformasjon for de tre siste måneder")
         }
@@ -45,10 +45,12 @@ data class InntektResponse(
 
     fun revurderesFraDato() = førsteMånedOgInntektMed10ProsentØkning()?.first
 
-    val harTreForrigeInntektsmåneder = inntektsmåneder
-        .filter { it.måned.isEqualOrAfter(YearMonth.now().minusMonths(3)) && it.måned.isBefore(YearMonth.now()) }
-        .map { it.måned }
-        .distinct().size == 3
+    val harTreForrigeInntektsmåneder =
+        inntektsmåneder
+            .filter { it.måned.isEqualOrAfter(YearMonth.now().minusMonths(3)) && it.måned.isBefore(YearMonth.now()) }
+            .map { it.måned }
+            .distinct()
+            .size == 3
 }
 
 data class Inntektsmåned(

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -11,7 +11,7 @@ data class InntektResponse(
     val inntektsmåneder: List<Inntektsmåned> = emptyList(),
 ) {
     fun totalInntektFraÅrMåned(årMåned: YearMonth): Int =
-        inntektsmåneder
+        inntektsmånederUtenEfYtelser()
             .filter { it.måned.isEqualOrAfter(årMåned) && it.måned.isBefore(YearMonth.now()) }
             .flatMap { it.inntektListe }
             .sumOf { it.beløp }
@@ -26,7 +26,7 @@ data class InntektResponse(
             ?.second
             ?.toPair()
 
-    fun inntektsmånderUtenEfOvergangstonad(): List<Inntektsmåned> =
+    fun inntektsmånederUtenEfYtelser(): List<Inntektsmåned> =
         inntektsmåneder.filter { inntektsmåned ->
             inntektsmåned.inntektListe.all {
                 it.type != InntektType.YTELSE_FRA_OFFENTLIGE &&
@@ -48,8 +48,7 @@ data class InntektResponse(
     val harTreForrigeInntektsmåneder =
         inntektsmåneder
             .filter { it.måned.isEqualOrAfter(YearMonth.now().minusMonths(3)) && it.måned.isBefore(YearMonth.now()) }
-            .map { it.måned }
-            .distinct()
+            .distinctBy { it.måned }
             .size == 3
 }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -92,17 +92,18 @@ class AutomatiskRevurderingServiceTest {
 
     @Test
     fun `skal fjerne ef overgangstønad og beregne forventet inntekt hvor den filtrerer bort ugyldige måneder`() {
-        val inntekterSisteTreMånederOvergangsstønad = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0, InntektType.YTELSE_FRA_OFFENTLIGE, "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere")))
+        val inntekterSisteTreMånederOvergangsstønad = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(16000.0, InntektType.YTELSE_FRA_OFFENTLIGE, "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere")))
         val inntekterSisteTreMånederFastlønn = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0)))
         val inntekterSisteTreMånederFastlønn2 = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(1000.0)))
+        val inntekterFraSeksMånederTilTreMånederSidenFastlønn = inntektsmåneder(YearMonth.now().minusMonths(6), inntektListe = listOf(inntekt(1400.0))).take(3)
 
-        val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2
+        val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2 + inntekterFraSeksMånederTilTreMånederSidenFastlønn
         val inntektResponse = InntektResponse(inntekter)
 
-        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånderUtenEfOvergangstonad()
-        val forventetInntekt = InntektResponse(inntekterUtenOvergangsstønad).forventetMånedsinntekt()
+        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederUtenEfYtelser()
+        val forventetInntekt = inntektResponse.forventetMånedsinntekt()
 
-        assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(8)
+        assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(11)
         assertThat(forventetInntekt).isEqualTo(6000)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.behandling.revurdering
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.amelding.InntektResponse
+import no.nav.familie.ef.sak.amelding.InntektType
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.repository.inntekt
@@ -87,5 +88,22 @@ class AutomatiskRevurderingServiceTest {
         assertThat(månedOgInntektMed10ProsentØkning).isNotNull
         assertThat(månedOgInntektMed10ProsentØkning?.first).isEqualTo(YearMonth.now().minusMonths(6))
         assertThat(månedOgInntektMed10ProsentØkning?.second).isEqualTo(1400.0)
+    }
+
+    @Test
+    fun `skal fjerne ef overgangstønad og beregne forventet inntekt hvor den filtrerer bort ugyldige måneder`() {
+        val inntekterSisteTreMånederOvergangsstønad = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0, InntektType.YTELSE_FRA_OFFENTLIGE, "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere")))
+        val inntekterSisteTreMånederFastlønn = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0)))
+        val inntekterSisteTreMånederFastlønn2 = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(1000.0)))
+
+        val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2
+        val inntektResponse = InntektResponse(inntekter)
+
+        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånderUtenEfOvergangstonad()
+        val forventetInntekt = InntektResponse(inntekterUtenOvergangsstønad).forventetMånedsinntekt()
+
+        assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(8)
+        assertThat(forventetInntekt).isEqualTo(6000)
+
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -104,6 +104,5 @@ class AutomatiskRevurderingServiceTest {
 
         assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(8)
         assertThat(forventetInntekt).isEqualTo(6000)
-
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -632,23 +632,26 @@ fun inntektsmåned(
     avvikListe = emptyList(),
 )
 
-fun inntekt(beløp: Double, inntektType: InntektType = InntektType.LØNNSINNTEKT, beskrivelse: String = "fastloenn") =
-    Inntekt(
-        type = inntektType,
-        beløp = beløp,
-        fordel = "",
-        beskrivelse = beskrivelse,
-        inngårIGrunnlagForTrekk = true,
-        utløserArbeidsgiveravgift = true,
-        skatteOgAvgiftsregel = null,
-        opptjeningsperiodeFom = null,
-        opptjeningsperiodeTom = null,
-        tilleggsinformasjon = null,
-        manuellVurdering = true,
-        antall = null,
-        skattemessigBosattLand = null,
-        opptjeningsland = null,
-    )
+fun inntekt(
+    beløp: Double,
+    inntektType: InntektType = InntektType.LØNNSINNTEKT,
+    beskrivelse: String = "fastloenn",
+) = Inntekt(
+    type = inntektType,
+    beløp = beløp,
+    fordel = "",
+    beskrivelse = beskrivelse,
+    inngårIGrunnlagForTrekk = true,
+    utløserArbeidsgiveravgift = true,
+    skatteOgAvgiftsregel = null,
+    opptjeningsperiodeFom = null,
+    opptjeningsperiodeTom = null,
+    tilleggsinformasjon = null,
+    manuellVurdering = true,
+    antall = null,
+    skattemessigBosattLand = null,
+    opptjeningsland = null,
+)
 
 private fun lagNyVilkårsvurdering(
     vilkårsregel: Vilkårsregel,

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -632,12 +632,12 @@ fun inntektsmåned(
     avvikListe = emptyList(),
 )
 
-fun inntekt(beløp: Double) =
+fun inntekt(beløp: Double, inntektType: InntektType = InntektType.LØNNSINNTEKT, beskrivelse: String = "fastloenn") =
     Inntekt(
-        type = InntektType.LØNNSINNTEKT,
+        type = inntektType,
         beløp = beløp,
         fordel = "",
-        beskrivelse = "",
+        beskrivelse = beskrivelse,
         inngårIGrunnlagForTrekk = true,
         utløserArbeidsgiveravgift = true,
         skatteOgAvgiftsregel = null,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Tilpasse seg funskjonene for utregning av forventet inntekt til den faktiske inntektresponsen vi jobber på. Tar nå hensyn til at det kan være lagt til inntekt for gjeldende måned allerede, som skal filtreres bort. Tar også nå hensyn til lønn tilknyttet en inntektsmåned kan være delt opp og må legges sammen. Filtrerer også nå bort lønn i sammenheng med ytelser tilknyttet ef.