### PR TITLE
Legger inn en validering på at behandling har kun en vedtak- og inntektsperiode for at den kan revurderes automatisk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -69,7 +69,7 @@ class AutomatiskRevurderingService(
 
         val sisteIverksatteBehandlingId = behandlingService.finnSisteIverksatteBehandling(fagsak.id)?.id
         if (sisteIverksatteBehandlingId == null) {
-            logger.info("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
+            logger.error("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
             return false
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.Grunnlagsda
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.GrunnlagsdataInntektRepository
 import no.nav.familie.ef.sak.sigrun.SigrunService
 import no.nav.familie.ef.sak.sigrun.harNæringsinntekt
+import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
@@ -27,6 +28,7 @@ class AutomatiskRevurderingService(
     private val oppgaveService: OppgaveService,
     private val aMeldingInntektClient: AMeldingInntektClient,
     private val grunnlagsdataInntektRepository: GrunnlagsdataInntektRepository,
+    private val vedtakService: VedtakService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -62,6 +64,18 @@ class AutomatiskRevurderingService(
 
         if (harBehandleSakEllerJournalføringsoppgave) {
             logger.info("harBehandleSakEllerJournalføringsoppgave $oppgaverForPerson")
+            return false
+        }
+
+        val sisteIverksatteBehandlingId = behandlingService.finnSisteIverksatteBehandling(fagsak.id)?.id
+        if (sisteIverksatteBehandlingId == null) {
+            logger.info("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
+            return false
+        }
+
+        val vedtak = vedtakService.hentVedtak(sisteIverksatteBehandlingId)
+        if (vedtak.perioder?.perioder?.size != 1 && vedtak.inntekter?.inntekter?.size != 1) { // Denne valideringen kan fjernes når logikken for å sette revurderes fra-dato er forbedret
+            logger.info("behandlingId: $sisteIverksatteBehandlingId har flere vedtaksperioder og kan derfor ikke automatisk revurderes")
             return false
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -410,6 +410,25 @@ fun vedtak(
         samordningsfradragType = null,
     )
 
+fun vedtak(
+    behandlingId: UUID,
+    månedsperioder: List<Månedsperiode>,
+): Vedtak =
+    Vedtak(
+        behandlingId = behandlingId,
+        resultatType = ResultatType.INNVILGE,
+        periodeBegrunnelse = "OK",
+        inntektBegrunnelse = "OK",
+        avslåBegrunnelse = null,
+        perioder = PeriodeWrapper(månedsperioder.map { vedtaksperiode(startDato = it.fomDato, sluttDato = it.tomDato) }),
+        inntekter = InntektWrapper(månedsperioder.map { inntektsperiode(startDato = it.fomDato, sluttDato = it.tomDato) }),
+        skolepenger = null,
+        saksbehandlerIdent = "VL",
+        opprettetAv = "VL",
+        opprettetTid = LocalDateTime.now(),
+        samordningsfradragType = null,
+    )
+
 fun vedtakBarnetilsyn(
     behandlingId: UUID,
     barn: List<UUID>,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Dette gjøres for å redusere kompleksitet i første mvp.

Etter en rask gjennomgang av forrige kjøring for potensielle kandidater til automatisk revurdering, vil ikke denne begrensningen redusere antallet noe særlig. Det ser ut til at de fleste med stabil inntekt har gjerne kun en vedtak- og inntektsperiode. Neste steg vil være å forbedre det slik at dette ikke er en begrensning, men det ville vært fint å teste at resten av flyten virker slik det er nå.