### PR TITLE
Vil at "0.00" skal være lik "0" når vi sjekker om det er etterbetalin…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringController.kt
@@ -74,8 +74,7 @@ data class SimuleringsperiodeDto(
 fun Simuleringsoppsummering.tilSimuleringsoppsummeringDto(): SimuleringsoppsummeringDto {
     val sistefeilutbetalingsperiode = this.perioder.sortedBy { it.tom }.lastOrNull { it.feilutbetaling > BigDecimal.ZERO }
     val år = sistefeilutbetalingsperiode?.tom?.year
-    val rettsgebyr = rettsgebyrForÅr[år]
-    val erUnder4rettsgebyr = rettsgebyr != null && feilutbetaling < BigDecimal(rettsgebyr * 4) && etterbetaling == BigDecimal.ZERO
+    val fireRettsgebyr = rettsgebyrForÅr[år]?.let { it * 4 }
 
     return SimuleringsoppsummeringDto(
         perioder =
@@ -94,8 +93,8 @@ fun Simuleringsoppsummering.tilSimuleringsoppsummeringDto(): Simuleringsoppsumme
         etterbetaling = this.etterbetaling,
         feilutbetaling = this.feilutbetaling,
         feilutbetalingsår = år,
-        fireRettsgebyr = rettsgebyr?.let { it * 4 },
-        visUnder4rettsgebyr = erUnder4rettsgebyr,
+        fireRettsgebyr = fireRettsgebyr,
+        visUnder4rettsgebyr = erUnder4Rettsgebyr(fireRettsgebyr),
         fom = this.fom,
         tomDatoNestePeriode = this.tomDatoNestePeriode,
         forfallsdatoNestePeriode = this.forfallsdatoNestePeriode,
@@ -105,3 +104,5 @@ fun Simuleringsoppsummering.tilSimuleringsoppsummeringDto(): Simuleringsoppsumme
         sumKreditorPosteringer = this.sumKreditorPosteringer,
     )
 }
+
+fun Simuleringsoppsummering.erUnder4Rettsgebyr(fireRettsgebyr: Int?) = fireRettsgebyr != null && feilutbetaling < BigDecimal(fireRettsgebyr) && etterbetaling.toInt() == 0

--- a/src/test/kotlin/no/nav/familie/ef/sak/simulering/SimuleringoppsummeringTilDtoTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/simulering/SimuleringoppsummeringTilDtoTest.kt
@@ -1,0 +1,31 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.simulering
+
+import no.nav.familie.ef.sak.simulering.erUnder4Rettsgebyr
+import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class SimuleringoppsummeringTilDtoTest {
+    @Test
+    fun `Skal sjekke erUnder4Rettsgebyr uten å bruke scale på etterbetaling`() {
+        val erUnder4Rettsgebyr = lagSimuleringsoppsummering(etterbetaling = BigDecimal("0.00"), feilutbetaling = BigDecimal("234")).erUnder4Rettsgebyr(345)
+        Assertions.assertThat(erUnder4Rettsgebyr).isTrue
+    }
+
+    fun lagSimuleringsoppsummering(
+        etterbetaling: BigDecimal = BigDecimal("0.00"),
+        feilutbetaling: BigDecimal = BigDecimal("234"),
+    ) = Simuleringsoppsummering(
+        perioder = emptyList(),
+        fomDatoNestePeriode = null,
+        etterbetaling = etterbetaling,
+        feilutbetaling = feilutbetaling,
+        fom = null,
+        tomDatoNestePeriode = null,
+        forfallsdatoNestePeriode = null,
+        tidSimuleringHentet = null,
+        tomSisteUtbetaling = null,
+        sumManuellePosteringer = null,
+    )
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vil at "0.00" skal være lik "0" når vi sjekker om det er etterbetaling i simulering.

Vi viser ikke fram valg "under fire rettsgebyr" på simuleringssiden hvis det finnes en etterbetaling. 
Vi sjekket dette med: 
BigDecimal("0") != BigDecimal.ZERO = true
Men: 
BigDecimal("0.00") != BigDecimal.ZERO = false