### PR TITLE
Forbedre behandle-sak oppgaver som blir lagd som følge av automatisk inntektsendring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -112,16 +112,18 @@ class RevurderingService(
             metadata = metadata,
             stønadType = fagsak.stønadstype,
         )
+        val erAutomatiskRevurdering = revurderingDto.behandlingsårsak == BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING
         taskService.save(
             OpprettOppgaveForOpprettetBehandlingTask.opprettTask(
                 OpprettOppgaveForOpprettetBehandlingTask.OpprettOppgaveTaskData(
                     behandlingId = revurdering.id,
                     saksbehandler = saksbehandler,
-                    beskrivelse = "Revurdering i ny løsning",
+                    beskrivelse = if (erAutomatiskRevurdering) "Automatisk opprettet revurdering som følge av inntektskontroll" else "Revurdering i ny løsning",
+                    mappeId = if (erAutomatiskRevurdering) GOSYS_MAPPE_ID_INNTEKTSKONTROLL else null,
                 ),
             ),
         )
-        if (revurderingDto.behandlingsårsak != BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING) {
+        if (!erAutomatiskRevurdering) {
             taskService.save(BehandlingsstatistikkTask.opprettPåbegyntTask(behandlingId = revurdering.id))
         }
 
@@ -227,4 +229,8 @@ class RevurderingService(
     }
 
     private fun erSatsendring(revurderingDto: RevurderingDto) = revurderingDto.behandlingsårsak == BehandlingÅrsak.SATSENDRING
+
+    companion object {
+        const val GOSYS_MAPPE_ID_INNTEKTSKONTROLL = 63L
+    }
 }


### PR DESCRIPTION
Automatisk inntektsendring: Legger Behandle-sak oppgavene i egen mappe og markerer med egen tekst, da de blir opprette som følge av inntektskontroll den 6. og at det kan være lurt at de samme personene tar tak i disse oppgavene til å starte med.