### PR TITLE
Lagt til toggle for å vise kopier knapp i alert error

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -17,6 +17,7 @@ class FeatureToggleController(
         setOf(
             Toggle.BEHANDLING_KORRIGERING,
             Toggle.FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER,
+            Toggle.FRONTEND_KOPIER_KNAPP_ERROR_ALERT,
             Toggle.OPPRETT_BEHANDLING_FERDIGSTILT_JOURNALPOST,
             Toggle.FRONTEND_AUTOMATISK_UTFYLLE_VILKÅR,
             Toggle.FRONTEND_SATSENDRING,

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -20,6 +20,7 @@ enum class Toggle(
     ),
     KONTROLLER_NÆRINGSINNTEKT("familie.ef.sak.kontroller-naeringsinntekt"),
     BEHANDLE_AUTOMATISK_INNTEKTSENDRING("familie.ef.sak-behandle-automatisk-inntektsendring-task", "Release"),
+    FRONTEND_KOPIER_KNAPP_ERROR_ALERT("familie.ef.sak.frontend-alert-error-med-copy-button", "Release"),
 
     // Operational
     G_BEREGNING("familie.ef.sak.g-beregning", "Operational"),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjøre det letter for saksbehandlerer å kopiere feilmelding så vi forhåpentligvis får mindre bilder av feilmeldinger.