### PR TITLE
Disable kall mot sigrun i inntektskontroll i preprod

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -4,8 +4,6 @@ import no.nav.familie.ef.sak.amelding.InntektResponse
 import no.nav.familie.ef.sak.amelding.ekstern.AMeldingInntektClient
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.GrunnlagsdataInntekt
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.GrunnlagsdataInntektRepository
@@ -18,9 +16,11 @@ import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.UUID
+import kotlin.collections.contains
 
 @Service
 class AutomatiskRevurderingService(
@@ -31,7 +31,7 @@ class AutomatiskRevurderingService(
     private val aMeldingInntektClient: AMeldingInntektClient,
     private val grunnlagsdataInntektRepository: GrunnlagsdataInntektRepository,
     private val vedtakService: VedtakService,
-    private val featureToggleService: FeatureToggleService,
+    private val environment: Environment,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -41,7 +41,7 @@ class AutomatiskRevurderingService(
         logger.info("Sjekker om fagsak ${fagsak.id} automatisk revurderes")
 
         val inntektForAlleÅr =
-            if (featureToggleService.isEnabled(Toggle.BEHANDLE_AUTOMATISK_INNTEKTSENDRING)) {
+            if (environment.activeProfiles.contains("prod")) {
                 sigrunService.hentInntektForAlleÅrMedInntekt(fagsak.fagsakPersonId)
             } else {
                 emptyList()

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -44,7 +44,7 @@ class AutomatiskRevurderingService(
             if (featureToggleService.isEnabled(Toggle.BEHANDLE_AUTOMATISK_INNTEKTSENDRING)) {
                 sigrunService.hentInntektForAlleÅrMedInntekt(fagsak.fagsakPersonId)
             } else {
-                listOf()
+                emptyList()
             }
 
         if (inntektForAlleÅr.harNæringsinntekt()) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -30,7 +30,7 @@ class AutomatiskRevurderingServiceTest {
     val behandlingServiceMock = mockk<BehandlingService>(relaxed = true)
     val oppgaveServiceMock = mockk<OppgaveService>(relaxed = true)
     val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
-    val automatiskRevurderingService = AutomatiskRevurderingService(mockk(relaxed = true), mockk(relaxed = true), behandlingServiceMock, oppgaveServiceMock, mockk(relaxed = true), mockk(relaxed = true), vedtakServiceMock)
+    val automatiskRevurderingService = AutomatiskRevurderingService(mockk(relaxed = true), mockk(relaxed = true), behandlingServiceMock, oppgaveServiceMock, mockk(relaxed = true), mockk(relaxed = true), vedtakServiceMock, mockk(relaxed = true))
 
     @Test
     fun `person med behandling som kan automatisk revurderes`() {


### PR DESCRIPTION
Det er dessverre mye problemer ved kall mot sigrun i preprod.
For å ikke ødelegge for testingen, så featuretoggles kallet for å slippe unødvendige problemer. Det går helt fint å disable dette, da dette kallet kun brukes til å sjekk om bruker har næringsinntekt.