### PR TITLE
Bugfix: Skal sette årsinntekt i riktig felt i ny behandling

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -127,10 +127,10 @@ class BehandleAutomatiskInntektsendringTask(
         forrigeVedtak: Vedtak,
         inntektResponse: InntektResponse,
     ): List<Inntektsperiode> {
-        val forventetInntekt = inntektResponse.forventetMånedsinntekt()
+        val forventetÅrsinntekt = inntektResponse.forventetMånedsinntekt() * 12
         val inntekterMinimum3MndTilbake = forrigeVedtak.inntekter?.inntekter?.filter { it.periode.fomDato <= YearMonth.now().minusMonths(3).atDay(1) } ?: emptyList()
         val nyesteInntektsperiode = inntekterMinimum3MndTilbake.maxBy { it.periode.fomDato }
-        val oppdatertInntektsperiode = nyesteInntektsperiode.copy(inntekt = BigDecimal(forventetInntekt))
+        val oppdatertInntektsperiode = nyesteInntektsperiode.copy(inntekt = BigDecimal(forventetÅrsinntekt))
         return forrigeVedtak.inntekter
             ?.inntekter
             ?.minus(nyesteInntektsperiode)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -116,7 +116,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val inntektsperioder = vedtak.inntekter?.inntekter
 
         assertThat(førsteFom).isEqualTo(YearMonth.now().minusMonths(2)) // Revurderes fra
-        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(35_000)
+        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(opprettOppgaveTask.payload)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Setter årsinntekt riktig i behandling som blir automatisk opprettet. 