### PR TITLE
Avgrens revurderes fra dato til med forrige vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -27,14 +27,15 @@ data class InntektResponse(
             ?.toPair()
 
     fun inntektsmånederUtenEfYtelser(minimumsdato: YearMonth): List<Inntektsmåned> =
-        inntektsmåneder.filter { inntektsmåned ->
-            inntektsmåned.inntektListe.all {
-                it.type != InntektType.YTELSE_FRA_OFFENTLIGE &&
-                    it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
-            } &&
-                inntektsmåned.måned.isBefore(YearMonth.now()) &&
-                inntektsmåned.måned.isEqualOrAfter(minimumsdato)
-        }.sortedBy { it.måned }
+        inntektsmåneder
+            .filter { inntektsmåned ->
+                inntektsmåned.inntektListe.all {
+                    it.type != InntektType.YTELSE_FRA_OFFENTLIGE &&
+                        it.beskrivelse != "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere"
+                } &&
+                    inntektsmåned.måned.isBefore(YearMonth.now()) &&
+                    inntektsmåned.måned.isEqualOrAfter(minimumsdato)
+            }.sortedBy { it.måned }
 
     fun forventetMånedsinntekt() =
         if (harTreForrigeInntektsmåneder) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -34,7 +34,7 @@ data class InntektResponse(
             } &&
                 inntektsmåned.måned.isBefore(YearMonth.now()) &&
                 inntektsmåned.måned.isEqualOrAfter(minimumsdato)
-        }
+        }.sortedBy { it.måned }
 
     fun forventetMånedsinntekt() =
         if (harTreForrigeInntektsmåneder) {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -127,10 +127,10 @@ class BehandleAutomatiskInntektsendringTask(
         forrigeVedtak: Vedtak,
         inntektResponse: InntektResponse,
     ): List<Inntektsperiode> {
-        val forventetInntekt = inntektResponse.forventetMånedsinntekt()
+        val forventetÅrsinntekt = inntektResponse.forventetMånedsinntekt() * 12
         val inntekterMinimum3MndTilbake = forrigeVedtak.inntekter?.inntekter?.filter { it.periode.fomDato <= YearMonth.now().minusMonths(3).atDay(1) } ?: emptyList()
         val nyesteInntektsperiode = inntekterMinimum3MndTilbake.maxBy { it.periode.fomDato }
-        val oppdatertInntektsperiode = nyesteInntektsperiode.copy(inntekt = BigDecimal(forventetInntekt))
+        val oppdatertInntektsperiode = nyesteInntektsperiode.copy(inntekt = BigDecimal(forventetÅrsinntekt))
         return forrigeVedtak.inntekter
             ?.inntekter
             ?.minus(nyesteInntektsperiode)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.beregning.Inntektsperiode
 import no.nav.familie.ef.sak.beregning.tilInntekt
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
@@ -30,6 +31,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
 import java.util.Properties
+import java.util.UUID
 
 @Service
 @TaskStepBeskrivelse(
@@ -57,47 +59,75 @@ class BehandleAutomatiskInntektsendringTask(
                 personIdenter = setOf(personIdent),
                 stønadstype = StønadType.OVERGANGSSTØNAD,
             )
-        secureLogger.info("Kan opprette automatisk inntektsendringsbehandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak?.id}")
+        if (fagsak == null) {
+            throw IllegalStateException("Finner ikke fagsak for personIdent=$personIdent på stønadstype=${StønadType.OVERGANGSSTØNAD} under automatisk inntektsendring")
+        }
+        secureLogger.info("Kan opprette automatisk inntektsendringsbehandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak.id}")
 
         if (toggle) {
-            if (fagsak != null) {
-                val behandling =
-                    revurderingService.opprettRevurderingManuelt(
-                        RevurderingDto(
-                            fagsakId = fagsak.id,
-                            behandlingsårsak = BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING,
-                            kravMottatt = LocalDate.now(),
-                            vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
-                        ),
-                    )
-                val inntektResponse = automatiskRevurderingService.lagreInntektResponse(personIdent, behandling.id)
-                val forrigeBehandling = behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it) } ?: throw IllegalStateException("Burde vært en forrigeBehandlingId etter automatisk revurdering for behandlingId: ${behandling.id}")
-                val forrigeVedtak = vedtakService.hentVedtak(forrigeBehandling.id)
-
-                val perioder = oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(forrigeVedtak, inntektResponse)
-                val inntektsperioder = oppdaterInntektMedNyBeregnetForventetInntekt(forrigeVedtak, inntektResponse)
-                val innvilgelseOvergangsstønad =
-                    InnvilgelseOvergangsstønad(
-                        periodeBegrunnelse = forrigeVedtak.periodeBegrunnelse,
-                        inntektBegrunnelse = forrigeVedtak.inntektBegrunnelse,
-                        perioder = perioder.fraDomene(),
-                        inntekter = inntektsperioder.tilInntekt() ?: emptyList(),
-                        samordningsfradragType = forrigeVedtak.samordningsfradragType,
-                    )
-
-                årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.AUTOMATISK_OPPRETTET_BEHANDLING, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
-                vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
-                logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")
-            } else {
-                secureLogger.error("Finner ikke fagsak for personIdent=$personIdent på stønadstype=${StønadType.OVERGANGSSTØNAD} under automatisk inntektsendring")
-            }
+            opprettAutomatiskRevurderingForInntektsendring(fagsak.id, personIdent)
         } else {
-            val inntektResponse = automatiskRevurderingService.hentInntektResponse(personIdent)
-            val inntektPrMåned = inntektResponse.inntektsmåneder.map { LogInntekt(it.måned, it.totalInntekt()) }
-            secureLogger.info("Månedlig inntekt for fagsak eksternId=${fagsak?.eksternId} : $inntektPrMåned")
-            val forventetInntekt = inntektResponse.forventetMånedsinntekt()
-            logger.info("Toggle for automatisering av inntekt er AV. Ville opprettet revurdering for fagsak eksternId=${fagsak?.eksternId} med en forventetInntekt på $forventetInntekt og revurdert fra dato: ${inntektResponse.revurderesFraDato()}")
+            logAutomatiskRevurderingForInntektsendring(fagsak, personIdent)
         }
+    }
+
+    private fun opprettAutomatiskRevurderingForInntektsendring(
+        fagsakId: UUID,
+        personIdent: String,
+    ) {
+        val behandling =
+            revurderingService.opprettRevurderingManuelt(
+                RevurderingDto(
+                    fagsakId = fagsakId,
+                    behandlingsårsak = BehandlingÅrsak.AUTOMATISK_INNTEKTSENDRING,
+                    kravMottatt = LocalDate.now(),
+                    vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
+                ),
+            )
+        val inntektResponse = automatiskRevurderingService.lagreInntektResponse(personIdent, behandling.id)
+        val forrigeBehandling = behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it) } ?: throw IllegalStateException("Burde vært en forrigeBehandlingId etter automatisk revurdering for behandlingId: ${behandling.id}")
+        val forrigeVedtak = vedtakService.hentVedtak(forrigeBehandling.id)
+
+        val perioder = oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(forrigeVedtak, inntektResponse)
+        val inntektsperioder = oppdaterInntektMedNyBeregnetForventetInntekt(forrigeVedtak, inntektResponse)
+        val innvilgelseOvergangsstønad =
+            InnvilgelseOvergangsstønad(
+                periodeBegrunnelse = forrigeVedtak.periodeBegrunnelse,
+                inntektBegrunnelse = forrigeVedtak.inntektBegrunnelse,
+                perioder = perioder.fraDomene(),
+                inntekter = inntektsperioder.tilInntekt(),
+                samordningsfradragType = forrigeVedtak.samordningsfradragType,
+            )
+
+        årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.AUTOMATISK_OPPRETTET_BEHANDLING, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
+        vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
+        logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")
+    }
+
+    private fun logAutomatiskRevurderingForInntektsendring(
+        fagsak: Fagsak,
+        personIdent: String,
+    ) {
+        val inntektResponse = automatiskRevurderingService.hentInntektResponse(personIdent)
+        val inntektPrMåned = inntektResponse.inntektsmåneder.map { LogInntekt(it.måned, it.totalInntekt()) }
+        secureLogger.info("Månedlig inntekt for fagsak eksternId=${fagsak.eksternId} : $inntektPrMåned")
+        val forventetInntekt = inntektResponse.forventetMånedsinntekt()
+        val behandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
+        val startdatoForrigeVedtak =
+            if (behandling != null) {
+                vedtakService
+                    .hentVedtak(behandling.id)
+                    .perioder
+                    ?.perioder
+                    ?.firstOrNull()
+                    ?.periode
+                    ?.fom ?: YearMonth.now()
+            } else {
+                logger.info("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
+                YearMonth.now()
+            }
+
+        logger.info("Toggle for automatisering av inntekt er AV. Ville opprettet revurdering for fagsak eksternId=${fagsak.eksternId} med en forventetInntekt på $forventetInntekt og revurdert fra dato: ${inntektResponse.revurderesFraDato(startdatoForrigeVedtak)}")
     }
 
     private fun oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(
@@ -109,7 +139,7 @@ class BehandleAutomatiskInntektsendringTask(
             førstePeriode?.copy(
                 datoFra =
                     inntektResponse
-                        .førsteMånedOgInntektMed10ProsentØkning()
+                        .førsteMånedOgInntektMed10ProsentØkning(førstePeriode.periode.fom)
                         ?.first
                         ?.atDay(1)
                         ?.plusMonths(1) ?: førstePeriode.datoFra,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -28,7 +28,6 @@ import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.objectMapper
-import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -146,7 +145,6 @@ class RevurderingService(
 
     @Transactional
     fun opprettAutomatiskInntektsendringTask(personIdenter: List<String>) {
-
         val ukeÅr = LocalDate.now().let { "${it.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)}-${it.year}" }
 
         personIdenter.forEach { personIdent ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -146,9 +146,6 @@ class RevurderingService(
 
     @Transactional
     fun opprettAutomatiskInntektsendringTask(personIdenter: List<String>) {
-        if (LeaderClient.isLeader() != true) {
-            return
-        }
 
         val ukeÅr = LocalDate.now().let { "${it.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)}-${it.year}" }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -98,7 +98,7 @@ class AutomatiskRevurderingServiceTest {
         val inntekter = inntekterFørsteTreMåneder + inntekterMånedFireTilSeks + inntekterSyvTilNi + inntekterSisteTreMåneder
         val inntektResponse = InntektResponse(inntekter)
 
-        val månedOgInntektMed10ProsentØkning = inntektResponse.førsteMånedOgInntektMed10ProsentØkning()
+        val månedOgInntektMed10ProsentØkning = inntektResponse.førsteMånedOgInntektMed10ProsentØkning(YearMonth.now().minusMonths(9))
 
         assertThat(månedOgInntektMed10ProsentØkning).isNotNull
         assertThat(månedOgInntektMed10ProsentØkning?.first).isEqualTo(YearMonth.now().minusMonths(6))
@@ -115,7 +115,7 @@ class AutomatiskRevurderingServiceTest {
         val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2 + inntekterFraSeksMånederTilTreMånederSidenFastlønn
         val inntektResponse = InntektResponse(inntekter)
 
-        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederUtenEfYtelser()
+        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederUtenEfYtelser(YearMonth.now().minusMonths(6))
         val forventetInntekt = inntektResponse.forventetMånedsinntekt()
 
         assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(9)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -115,7 +115,8 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val førsteFom = vedtaksperioder?.first()?.periode?.fom
         val inntektsperioder = vedtak.inntekter?.inntekter
 
-        assertThat(førsteFom).isEqualTo(YearMonth.now().minusMonths(2)) // Revurderes fra
+        // Har ikke mocket inntekt-response, revurderes fra-dato blir derfor satt lik som fradato i forrige behandling
+        assertThat(førsteFom).isEqualTo(YearMonth.of(2025,2))
         assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -116,7 +116,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val inntektsperioder = vedtak.inntekter?.inntekter
 
         // Har ikke mocket inntekt-response, revurderes fra-dato blir derfor satt lik som fradato i forrige behandling
-        assertThat(førsteFom).isEqualTo(YearMonth.of(2025,1))
+        assertThat(førsteFom).isEqualTo(YearMonth.of(2025, 1))
         assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -116,7 +116,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val inntektsperioder = vedtak.inntekter?.inntekter
 
         // Har ikke mocket inntekt-response, revurderes fra-dato blir derfor satt lik som fradato i forrige behandling
-        assertThat(førsteFom).isEqualTo(YearMonth.of(2025,2))
+        assertThat(førsteFom).isEqualTo(YearMonth.of(2025,1))
         assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -116,7 +116,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val inntektsperioder = vedtak.inntekter?.inntekter
 
         assertThat(førsteFom).isEqualTo(YearMonth.now().minusMonths(2)) // Revurderes fra
-        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(35_000)
+        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(opprettOppgaveTask.payload)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å finne revurderes fra-dato er vi avhengige av at inntektresponse er sortert, lista fra a-inntekt kommer usortert, så hovedendringen er at det legges til sortering. I tillegg tas det høyde for at forrige innvilget behandling sin startdato ved beregning av revurderes fra-dato, slik at det ikke beregnes en dato som er før forrige innvilgelse.

Det ser ut som det er flere endringer enn det faktisk er, fordi jeg har lagt eksisterende kode i egne metode for å forbedre lesbarheten i `BehandleAutomatiskInntektsendringTask`