### PR TITLE
Gjør det enklere å teste inntektskontroll i preprod ved at det ikke må være 3 måneder siden forrige innvilgelse for at testperson blir med

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -220,13 +220,12 @@ class VedtakController(
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
     fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(
         @RequestParam antallMaaneder: Int = 3,
-    ): Ressurs<List<String>> {
-        return if (environment.activeProfiles.contains("prod")) {
+    ): Ressurs<List<String>> =
+        if (environment.activeProfiles.contains("prod")) {
             Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = antallMaaneder))
         } else {
             Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 0))
         }
-    }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
 import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
+import no.nav.familie.leader.Environment
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -55,6 +56,7 @@ class VedtakController(
     private val nullstillVedtakService: NullstillVedtakService,
     private val angreSendTilBeslutterService: AngreSendTilBeslutterService,
     private val tilordnetRessursService: TilordnetRessursService,
+    private val environment: org.springframework.core.env.Environment,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -218,7 +220,13 @@ class VedtakController(
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
     fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(
         @RequestParam antallMaaneder: Int = 3,
-    ): Ressurs<List<String>> = Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = antallMaaneder))
+    ): Ressurs<List<String>> {
+        return if (environment.activeProfiles.contains("prod")) {
+            Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = antallMaaneder))
+        } else {
+            Ressurs.success(behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 0))
+        }
+    }
 
     @PostMapping("/gjeldendeIverksatteBehandlingerMedInntekt")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/BehandlingRepositoryTest.kt
@@ -98,6 +98,14 @@ internal class BehandlingRepositoryTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `skal finne alle personer med aktiv stønad uten krav til tid siden forrige innvilgelse - brukes i preprod for testing`() {
+        val fagsak = lagrePersonMedVedtak("2", 0)
+        val resultat = behandlingRepository.finnPersonerMedAktivStonadIkkeRevurdertSisteMåneder(antallMåneder = 0)
+        assertThat(resultat.size).isEqualTo(1)
+        assertThat(resultat).containsAll(listOf("2"))
+    }
+
+    @Test
     fun `skal finne ferdigstilte behandlinger med utdatert G-beløp som må behandles manuelt`() {
         lagrePersonMedVedtak("2", 3)
         val resultat = behandlingRepository.finnFerdigstilteBehandlingerMedUtdatertGBelopSomMåBehandlesManuelt(Grunnbeløpsperioder.nyesteGrunnbeløp.periode.fomDato)


### PR DESCRIPTION
Det krever endring av vedtaksdato i db hver gang en skal teste en ny bruker uten denne endringen.