### PR TITLE
Beregner nye inntektsperioder ved automatisk revurdering basert på a-inntekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -83,7 +83,7 @@ class AutomatiskRevurderingService(
         }
 
         val vedtak = vedtakService.hentVedtak(sisteIverksatteBehandlingId)
-        if (vedtak.perioder?.perioder?.size != 1 && vedtak.inntekter?.inntekter?.size != 1) { // Denne valideringen kan fjernes når logikken for å sette revurderes fra-dato er forbedret
+        if (vedtak.perioder?.perioder?.size != 1) { // Denne valideringen kan fjernes når logikken for å sette revurderes fra-dato er forbedret
             logger.info("behandlingId: $sisteIverksatteBehandlingId har flere vedtaksperioder og kan derfor ikke automatisk revurderes")
             return false
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningRequest.kt
@@ -38,6 +38,8 @@ data class Inntektsperiode(
             (this.dagsats ?: BigDecimal.ZERO).multiply(BeregningUtils.DAGSATS_ANTALL_DAGER) +
             (this.månedsinntekt ?: BigDecimal.ZERO).multiply(BeregningUtils.ANTALL_MÅNEDER_ÅR)
 
+    fun avledForventetMånedsinntekt(): Int = totalinntekt().toInt() / 12
+
     /**
      * Dersom den eksisterende årsinntekten er g-omregnet til nærmeste 100,
      * så skal vi ikke nedjustere denne til nærmeste 1000

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/util/DatoUtil.kt
@@ -87,4 +87,6 @@ fun YearMonth.formaterYearMonthTilMånedÅr(): String {
     return yearMonth.format(formatter)
 }
 
-fun YearMonth.isEqualOrAfter(other: YearMonth) = this == other || this.isAfter(other)
+fun YearMonth.isEqualOrAfter(other: YearMonth?) = other == null || this == other || this.isAfter(other)
+
+fun YearMonth.isEqualOrBefore(other: YearMonth) = this == other || this.isBefore(other)

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -89,23 +89,6 @@ class AutomatiskRevurderingServiceTest {
     }
 
     @Test
-    fun `skal finne første måned med 10 prosent endring i inntekt`() {
-        val inntekterFørsteTreMåneder = inntektsmåneder(YearMonth.now().minusMonths(12), inntektListe = listOf(inntekt(1000.0))).take(3)
-        val inntekterMånedFireTilSeks = inntektsmåneder(YearMonth.now().minusMonths(9), inntektListe = listOf(inntekt(1050.0))).take(3)
-        val inntekterSyvTilNi = inntektsmåneder(YearMonth.now().minusMonths(6), inntektListe = listOf(inntekt(1400.0))).take(3)
-        val inntekterSisteTreMåneder = inntektsmåneder(YearMonth.now().minusMonths(3), inntektListe = listOf(inntekt(2000.0))).take(3)
-
-        val inntekter = inntekterFørsteTreMåneder + inntekterMånedFireTilSeks + inntekterSyvTilNi + inntekterSisteTreMåneder
-        val inntektResponse = InntektResponse(inntekter)
-
-        val månedOgInntektMed10ProsentØkning = inntektResponse.førsteMånedOgInntektMed10ProsentØkning(YearMonth.now().minusMonths(9))
-
-        assertThat(månedOgInntektMed10ProsentØkning).isNotNull
-        assertThat(månedOgInntektMed10ProsentØkning?.first).isEqualTo(YearMonth.now().minusMonths(6))
-        assertThat(månedOgInntektMed10ProsentØkning?.second).isEqualTo(1400.0)
-    }
-
-    @Test
     fun `skal fjerne ef overgangstønad og beregne forventet inntekt hvor den filtrerer bort ugyldige måneder`() {
         val inntekterSisteTreMånederOvergangsstønad = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(16000.0, InntektType.YTELSE_FRA_OFFENTLIGE, "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere")))
         val inntekterSisteTreMånederFastlønn = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0)))

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -20,6 +20,8 @@ import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
+import no.nav.familie.ef.sak.repository.lagInntektResponseFraMånedsinntekter
+import no.nav.familie.ef.sak.repository.lagInntektResponseFraMånedsinntekterFraDouble
 import no.nav.familie.ef.sak.repository.vedtak
 import no.nav.familie.ef.sak.testutil.VedtakHelperService
 import no.nav.familie.ef.sak.testutil.VilkårHelperService
@@ -33,6 +35,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
 import java.time.YearMonth
 
 class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
@@ -115,13 +118,59 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         val førsteFom = vedtaksperioder?.first()?.periode?.fom
         val inntektsperioder = vedtak.inntekter?.inntekter
 
-        // Har ikke mocket inntekt-response, revurderes fra-dato blir derfor satt lik som fradato i forrige behandling
-        assertThat(førsteFom).isEqualTo(YearMonth.of(2025, 1))
-        assertThat(inntektsperioder?.first()?.inntekt?.toInt()).isEqualTo(420_000)
+        assertThat(førsteFom).isEqualTo(YearMonth.now().minusMonths(2))
+        assertThat(inntektsperioder?.first()?.månedsinntekt?.toInt()).isEqualTo(35_000)
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(opprettOppgaveTask.payload)
         assertThat(data.mappeId).isEqualTo(63)
         assertThat(data.beskrivelse).isEqualTo("Automatisk opprettet revurdering som følge av inntektskontroll")
+    }
+
+    @Test
+    fun `Sett revurderes fra dato måneden etter inntektsøkning - opprett inntektsperioder for hver måned tilbake i tid`() {
+        val innmeldtMånedsinntekt = listOf(10_000, 10_500, 15_000, 15_000, 15_000)
+        val vedtakTom = YearMonth.now().plusMonths(11)
+
+        val forventetInntektIVedtak =
+            mapOf(
+                (YearMonth.now().minusMonths(innmeldtMånedsinntekt.size.toLong()) to 10_000),
+            )
+        val vedtak = vedtak(forventetInntektIVedtak, vedtakTom)
+        val inntektResponse = lagInntektResponseFraMånedsinntekter(innmeldtMånedsinntekt)
+
+        val oppdatertVedtakMedNyePerioder = behandleAutomatiskInntektsendringTask.oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(vedtak, inntektResponse)
+
+        assertThat(oppdatertVedtakMedNyePerioder.first().periode.fom).isEqualTo(YearMonth.now().minusMonths(2))
+        assertThat(oppdatertVedtakMedNyePerioder.first().periode.tom).isEqualTo(vedtakTom)
+
+        val oppdatertInntekt = behandleAutomatiskInntektsendringTask.oppdaterInntektMedNyBeregnetForventetInntekt(vedtak, inntektResponse, oppdatertVedtakMedNyePerioder.first().periode.fom)
+        assertThat(oppdatertInntekt.first().periode.fom).isEqualTo(YearMonth.now().minusMonths(2))
+        assertThat(oppdatertInntekt.first().månedsinntekt).isEqualTo(BigDecimal(15_000))
+    }
+
+    @Test
+    fun `to eksisterende inntektsperioder - sett revurderes fra måneden etter 10 prosent endring`() {
+        // Vedtak fra August 2024 -> Juli 2027
+        // Inntektsperioder: August 54 534, September 39129
+        // Beregnet ny forventet inntekt: 43796
+        val innmeldtMånedsinntekt = listOf(54534.36, 39129.14, 36361.58, 37609.86, 41796.68, 43213.59, 44122.90, 44052.95, 43213.59)
+        val vedtakTom = YearMonth.now().plusMonths(11)
+
+        val forventetInntektIVedtak =
+            mapOf(
+                (YearMonth.now().minusMonths(innmeldtMånedsinntekt.size.toLong()) to 54534),
+                (YearMonth.now().minusMonths(innmeldtMånedsinntekt.size.toLong() - 1) to 39129),
+            )
+        val vedtak = vedtak(forventetInntektIVedtak, vedtakTom)
+        val inntektResponse = lagInntektResponseFraMånedsinntekterFraDouble(innmeldtMånedsinntekt)
+
+        val oppdatertVedtakMedNyePerioder = behandleAutomatiskInntektsendringTask.oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(vedtak, inntektResponse)
+
+        assertThat(oppdatertVedtakMedNyePerioder.first().periode.fom).isEqualTo(YearMonth.now().minusMonths(3))
+        assertThat(oppdatertVedtakMedNyePerioder.first().periode.tom).isEqualTo(vedtakTom)
+
+        val oppdatertInntekt = behandleAutomatiskInntektsendringTask.oppdaterInntektMedNyBeregnetForventetInntekt(vedtak, inntektResponse, oppdatertVedtakMedNyePerioder.first().periode.fom)
+        assertThat(oppdatertInntekt.size).isEqualTo(3)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Denne PR'n løser følgende:
- Tar høyde for forventet inntekt i forrige vedtak ved beregning av 10% endring i inntekt for å sette rett revurderingsdato
- Lager inntektsperioder i det nye vedtaket basert på faktisk inntjent inntekt. Ved en revurdering legger saksbehandler alltid inn hva bruker faktisk har tjent siden revurderingens fra-dato for at utbetalingen skal bli helt riktig. En svakhet i koden her er at det alltid vil bli opprettet en inntektsperiode pr måned, men det trengs ikke i de tilfellene hvor det er samme beløp hver måned. Dette kan forbedres i egen PR.
- Preutfyller inntektsperioder med månedsinntekt fremfor årsinntekt, da det er denne som som oftest brukes av saksbehandlerne.

Har forbedret oppsettet slik at det er enklere å lage flere test-caser for beregning av revurderes fra dato / 10% høyere inntekt enn forventet inntekt.

