### PR TITLE
Oppdaterer steg på behandling ved gjenbruk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
@@ -106,6 +106,7 @@ class VurderingController(
 
         val (_, metadata) = vurderingService.hentGrunnlagOgMetadata(request.behandlingId)
         val gjenbruktVilkårResponse = gjenbrukVilkårService.gjenbrukInngangsvilkårVurderingOgSamværsavtale(request.behandlingId, behandlingForGjenbruk.id, request.vilkårId, metadata.barn)
+        vurderingStegService.oppdaterStegOgKategoriPåBehandling(request.behandlingId)
         return Ressurs.success(gjenbruktVilkårResponse.tilDto())
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingStegService.kt
@@ -87,7 +87,7 @@ class VurderingStegService(
         return oppdatertVilkår
     }
 
-    private fun oppdaterStegOgKategoriPåBehandling(behandlingId: UUID) {
+    fun oppdaterStegOgKategoriPåBehandling(behandlingId: UUID) {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         val lagredeVilkårsvurderinger = vilkårsvurderingRepository.findByBehandlingId(behandlingId)
 
@@ -104,7 +104,7 @@ class VurderingStegService(
                 if (it.key.gjelderFlereBarn()) {
                     utledResultatForVilkårSomGjelderFlereBarn(it.value)
                 } else {
-                    it.value.single().resultat
+                    it.value.first().resultat
                 }
             }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Steg ble ikke oppdatert ved bruk av gjenbruk, dette førte til en bug at når man sletter ett vilkår og gjenbruker blir ikke steg verdi oppdatert. Dermed kan man få feilmelding som sier man mangler besvarelse på et vilkår når alle er oppfylt.

[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24612)