### PR TITLE
Gjenbruk samvaersavtale fix

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
@@ -101,13 +101,13 @@ class SamværsavtaleService(
                 )
             }
 
-        nyeSamværsavtaler.forEach {
-            val lagretSamværsavtale = hentSamværsavtaleEllerNull(it.behandlingId, it.behandlingBarnId)
+        nyeSamværsavtaler.forEach { nySamværsavtale ->
+            val lagretSamværsavtale = hentSamværsavtaleEllerNull(nySamværsavtale.behandlingId, nySamværsavtale.behandlingBarnId)
 
             if (lagretSamværsavtale == null) {
-                samværsavtaleRepository.insert(it)
+                samværsavtaleRepository.insert(nySamværsavtale)
             } else {
-                samværsavtaleRepository.update(it)
+                samværsavtaleRepository.update(lagretSamværsavtale.copy(uker = nySamværsavtale.uker))
             }
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleService.kt
@@ -101,7 +101,15 @@ class SamværsavtaleService(
                 )
             }
 
-        samværsavtaleRepository.insertAll(nyeSamværsavtaler)
+        nyeSamværsavtaler.forEach {
+            val lagretSamværsavtale = hentSamværsavtaleEllerNull(it.behandlingId, it.behandlingBarnId)
+
+            if (lagretSamværsavtale == null) {
+                samværsavtaleRepository.insert(it)
+            } else {
+                samværsavtaleRepository.update(it)
+            }
+        }
     }
 
     @Transactional


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fra [feil meldt inn på teams](https://teams.microsoft.com/l/message/19:55fb7a15fdad4fb29e568d7dc617b52e@thread.tacv2/1747741024028?tenantId=62366534-1ec3-4962-8869-9b5535279d0b&groupId=11014155-e8a7-46ad-8be0-b5c10a863a36&parentMessageId=1747741024028&teamName=Team%20enslig%20fors%C3%B8rger%20kontinuerlig%20forbedring&channelName=EF%20sak&createdTime=1747741024028)

Når man oppretter en ny behandling vil man først gjenbruke vilkår og samværsavtaler fra nærmeste egnede behandling på **samme** fagsak. Deretter vil man prøve å gjenbruke fra nærmeste egnede behandling **uavhengig** av fagsak. 

På grunn av dette er man ved gjenbruk nødt til å sjekke om samværsavtalen man prøver å gjenbruke har en entitet i databasen fra før. I såfall må vi gjøre en `update` i stedet for `insert`