### PR TITLE
klargjør tasks for automatisk utsending av brev om videre aktivitet

### DIFF
--- a/doc/BrevUtsending_Aktivitetskrav_Innhenting_README.md
+++ b/doc/BrevUtsending_Aktivitetskrav_Innhenting_README.md
@@ -23,6 +23,11 @@ Velg `true` om du ønsker å lagre ned tasks for generering og utsending av brev
 I tillegg er man nødt til å [gå inn i unleash og aktivere feature toggle for automatisk brevinnhenting av aktivitetsplikt for prod miljøet.](https://teamfamilie-unleash-web.iap.nav.cloud.nais.io/projects/default/features/familie.ef.sak.automatiske-brev-innhenting-aktivitetsplikt)
 
 ### Teknisk
+
+Før man iverksetter automatisk utsending må man huske å manuelt oppdatere enkelte datoer i koden: 
+1. `oppgaveAktivitetspliktFrist` i `AutomatiskBrevInnhentingAktivitetspliktService` i `familie-ef-sak`
+2. `FRIST_OPPFØLGINGSOPPGAVE` og `FRIST_OPPRINNELIG_OPPGAVE` i `OppdaterAktivitetspliktInnhentingOppgaveTask` i `familie-ef-iverksett`
+
 Ved `liveRun` satt til `true` ved innsending av `POST-request` vil følgende skje:
 1. Det gjøres et søk etter oppgaver med frist satt til `17.05`, tema `ENF` og mappe `64 Utdanning` uten en tilordnet ressurs
 2. Deretter lagres det ned en task av typen`SendAktivitetspliktBrevTilIverksettTask` med ansvar for å generere brev og 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktService.kt
@@ -20,7 +20,7 @@ class AutomatiskBrevInnhentingAktivitetspliktService(
 ) {
     val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    val oppgaveAktivitetspliktFrist = LocalDate.parse("2024-05-17")
+    val oppgaveAktivitetspliktFrist = LocalDate.parse("2025-05-17")
 
     @Transactional
     fun opprettTasks(

--- a/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktServiceTest.kt
@@ -31,7 +31,7 @@ internal class AutomatiskBrevInnhentingAktivitetspliktServiceTest {
         every { oppgaveService.finnMapper(any<String>()) } returns listOf(MappeDto(1, "64 Utdanning", "4489"))
     }
 
-    val gjeldendeFrist = "2024-05-17"
+    val gjeldendeFrist = "2025-05-17"
 
     @Test
     fun `Skal opprette tasks for oppgaver`() {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Klargjør datoer i tasks for automatisk brevutsending i forbindelse med [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25096)

Det er planlagt at brevutsendingen skal skje 20. juni

Iverksett:
* https://github.com/navikt/familie-ef-iverksett/pull/1036