### PR TITLE
Ny ingress inntekt

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -97,6 +97,9 @@ spec:
           namespace: nom
         - application: repr-api
           namespace: repr
+        - application: ikomp-q2
+          namespace: team-inntekt
+          cluster: dev-fss
       external:
         - host: api-gw-q1.oera.no
         - host: familie-oppdrag.dev-fss-pub.nais.io
@@ -104,6 +107,7 @@ spec:
         - host: familie-ef-infotrygd.dev-fss-pub.nais.io
         - host: familie-ef-proxy.dev-fss-pub.nais.io
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
+        - host: ikomp-q2.dev-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -97,9 +97,6 @@ spec:
           namespace: nom
         - application: repr-api
           namespace: repr
-        - application: ikomp-q2
-          namespace: team-inntekt
-          cluster: dev-fss
       external:
         - host: api-gw-q1.oera.no
         - host: familie-oppdrag.dev-fss-pub.nais.io

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -94,6 +94,9 @@ spec:
           namespace: nom
         - application: repr-api
           namespace: repr
+        - application: ikomp
+          namespace: team-inntekt
+          cluster: prod-fss
       external:
         - host: api-gw.oera.no
         - host: familie-oppdrag.prod-fss-pub.nais.io
@@ -101,6 +104,7 @@ spec:
         - host: familie-ef-infotrygd.prod-fss-pub.nais.io
         - host: familie-ef-proxy.prod-fss-pub.nais.io
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
+        - host: ikomp.prod-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -94,9 +94,6 @@ spec:
           namespace: nom
         - application: repr-api
           namespace: repr
-        - application: ikomp
-          namespace: team-inntekt
-          cluster: prod-fss
       external:
         - host: api-gw.oera.no
         - host: familie-oppdrag.prod-fss-pub.nais.io

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
@@ -23,7 +23,7 @@ class InntektController(
     private val tilgangService: TilgangService,
     private val inntektService: InntektService,
 ) {
-    //    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Fjerner midlertidig for å teste manuelle kall
+    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     @PostMapping("inntektv2/{fagsakid}")
     fun hentInntekt(
         @PathVariable("fagsakid") fagsakId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
@@ -23,8 +23,8 @@ class InntektController(
     private val tilgangService: TilgangService,
     private val inntektService: InntektService,
 ) {
+    //    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Fjerner midlertidig for å teste manuelle kall
     @PostMapping("inntektv2/{fagsakid}")
-    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     fun hentInntekt(
         @PathVariable("fagsakid") fagsakId: UUID,
         @RequestBody inntektRequestBody: InntektRequestBody,

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektController.kt
@@ -23,8 +23,8 @@ class InntektController(
     private val tilgangService: TilgangService,
     private val inntektService: InntektService,
 ) {
-    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     @PostMapping("inntektv2/{fagsakid}")
+    @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"])
     fun hentInntekt(
         @PathVariable("fagsakid") fagsakId: UUID,
         @RequestBody inntektRequestBody: InntektRequestBody,

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/AMeldingInntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/AMeldingInntektClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.amelding.ekstern
 
-import no.nav.familie.ef.sak.amelding.HentInntektPayload
 import no.nav.familie.ef.sak.amelding.InntektResponse
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.PersonIdent
@@ -16,24 +15,13 @@ import java.time.YearMonth
 
 @Component
 class AMeldingInntektClient(
-    @Value("\${FAMILIE_EF_PROXY_URL}") private val uri: URI,
+    @Value("\${INNTEKT_URL}") private val uri: URI,
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "inntekt") {
-    private fun lagInntektUri(
-        fom: YearMonth,
-        tom: YearMonth,
-    ) = UriComponentsBuilder
-        .fromUri(uri)
-        .pathSegment("api/inntekt")
-        .queryParam("fom", fom)
-        .queryParam("tom", tom)
-        .build()
-        .toUri()
-
     private val genererInntektV2Uri =
         UriComponentsBuilder
             .fromUri(uri)
-            .pathSegment("api/inntekt/v2")
+            .pathSegment("rest/inntekt/v2")
             .build()
             .toUri()
 
@@ -55,16 +43,26 @@ class AMeldingInntektClient(
         personIdent: String,
         månedFom: YearMonth,
         månedTom: YearMonth,
-    ): InntektResponse =
-        postForEntity(
+    ): InntektResponse {
+        val payload =
+            genererInntektRequest(
+                personIdent = personIdent,
+                månedFom = månedFom,
+                månedTom = månedTom,
+            )
+
+        val headers =
+            HttpHeaders().apply {
+                contentType = MediaType.APPLICATION_JSON
+                accept = listOf(MediaType.APPLICATION_JSON)
+            }
+
+        return postForEntity(
             uri = genererInntektV2Uri,
-            payload =
-                HentInntektPayload(
-                    personIdent = personIdent,
-                    månedFom = månedFom,
-                    månedTom = månedTom,
-                ),
+            payload = payload,
+            httpHeaders = headers,
         )
+    }
 
     fun genererAInntektUrl(personIdent: String): String =
         postForEntity(
@@ -83,4 +81,16 @@ class AMeldingInntektClient(
                 accept = listOf(MediaType.TEXT_PLAIN)
             },
         )
+
+    private fun genererInntektRequest(
+        personIdent: String,
+        månedFom: YearMonth,
+        månedTom: YearMonth,
+    ) = mapOf(
+        "personident" to personIdent,
+        "filter" to "StoenadEnsligMorEllerFarA-inntekt",
+        "formaal" to "StoenadEnsligMorEllerFar",
+        "maanedFom" to månedFom,
+        "maanedTom" to månedTom,
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/AMeldingInntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/AMeldingInntektClient.kt
@@ -21,7 +21,7 @@ class AMeldingInntektClient(
     private val genererInntektV2Uri =
         UriComponentsBuilder
             .fromUri(uri)
-            .pathSegment("rest/inntekt/v2")
+            .pathSegment("rest/v2/inntekt")
             .build()
             .toUri()
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -197,6 +197,24 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      inntektskomponenten:
+        resource-url: ${INNTEKT_URL}
+        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
+        grant-type: urn:ietf:params:oauth:grant-type:jwt-bearer
+        scope: ${INNTEKT_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
+      inntektskomponenten-clientcredentials:
+        resource-url: ${INNTEKT_URL}
+        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
+        grant-type: client_credentials
+        scope: ${INNTEKT_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
 
 PDL_SCOPE: api://${DEPLOY_ENV}-fss.pdl.pdl-api/.default
 REPR_API_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
@@ -210,6 +228,7 @@ FAMILIE_INTEGRASJONER_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-integra
 HISTORISK_PENSJON_SCOPE: api://${DEPLOY_ENV}-gcp.historisk.historisk-pensjon/.default
 FAMILIE_KS_SAK_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ks-sak/.default
 SKJERMEDE_PERSONER_SCOPE: api://${DEPLOY_ENV}-gcp.nom.skjermede-personer-pip/.default
+INNTEKT_SCOPE: api://${DEPLOY_ENV}-fss.team-inntekt.ikomp-q2/.default
 
 spring:
   mvc:
@@ -288,6 +307,7 @@ HISTORISK_PENSJON_URL: http://historisk-pensjon.historisk
 FAMILIE_KS_SAK_URL: http://familie-ks-sak
 FRONTEND_OPPGAVE_URL: https://ensligmorellerfar.intern.nav.no/oppgavebenk
 SKJERMEDE_PERSONER_URL: http://skjermede-personer-pip.nom
+INNTEKT_URL: https://ikomp-q2.${ON_PREM_URL_ENV}-fss-pub.nais.io
 
 GYLDIGE_SERVICE_BRUKERE: srvArena
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

* Skal gå mot ny ingress i stedet for via proxy.

_Inntektskomponenten kjører nå på Nais. Den er tilgjengelig fra både gcp og fss. Må bruke Entra ID, da sts ikke er videreført i nais versjonen av Inntektskomponenten._