### PR TITLE
Fyll ut periodebegrunnelse automatisk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -242,7 +242,6 @@ class BehandleAutomatiskInntektsendringTask(
         inntektResponse: InntektResponse,
         forrigeVedtak: Vedtak,
     ): String {
-
         val førsteMånedMed10ProsentEndring =
             inntektsperioder
                 .minBy { it.periode.fom }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -194,12 +194,12 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
 
     val forventetInntektsbegrunnelse =
         """
-            Forventet årsinntekt fra februar 2025: 288 000 kroner.
-            - 10 % opp: 26 400 kroner per måned.
-            - 10 % ned: 21 600 kroner per måned.
-            
-            Inntekten i februar 2025 er 28 000 kroner. Inntekten har økt minst 10 prosent denne måneden. Stønaden beregnes på nytt fra måneden etter.
-               
-            Fra og med juni 2025 er stønaden beregnet ut ifra gjennomsnittlig inntekt i mars, april og mai.
+        Forventet årsinntekt fra februar 2025: 288 000 kroner.
+        - 10 % opp: 26 400 kroner per måned.
+        - 10 % ned: 21 600 kroner per måned.
+        
+        Inntekten i februar 2025 er 28 000 kroner. Inntekten har økt minst 10 prosent denne måneden. Stønaden beregnes på nytt fra måneden etter.
+           
+        Fra og med juni 2025 er stønaden beregnet ut ifra gjennomsnittlig inntekt i mars, april og mai.
         """.trimIndent()
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -194,12 +194,12 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
 
     val forventetInntektsbegrunnelse =
         """
-        Forventet årsinntekt fra juni 2025: 29 333 kroner.
-        - 10 % opp: 32 266 kroner per måned.
-        - 10 % ned: 26 399 kroner per måned.
-        
-        Inntekten i februar 2025 er 28 000 kroner. Inntekten har økt minst 10 prosent denne måneden. Stønaden beregnes på nytt fra måneden etter.
-           
-        Fra og med juni 2025 er stønaden beregnet ut ifra gjennomsnittlig inntekt i mars, april og mai.
+            Forventet årsinntekt fra februar 2025: 288 000 kroner.
+            - 10 % opp: 26 400 kroner per måned.
+            - 10 % ned: 21 600 kroner per måned.
+            
+            Inntekten i februar 2025 er 28 000 kroner. Inntekten har økt minst 10 prosent denne måneden. Stønaden beregnes på nytt fra måneden etter.
+               
+            Fra og med juni 2025 er stønaden beregnet ut ifra gjennomsnittlig inntekt i mars, april og mai.
         """.trimIndent()
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -177,7 +177,8 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
 
         val oppdatertInntekt = oppdatertVedtak.inntekter?.inntekter ?: emptyList()
         assertThat(oppdatertInntekt.size).isEqualTo(4)
-
+        assertThat(oppdatertVedtak.periodeBegrunnelse).isEqualTo("Overgangsstønaden endres fra måneden etter minst 10 prosent økning i inntekt.")
+        assertThat(oppdatertVedtak.inntektBegrunnelse?.replace('\u00A0', ' ')).isEqualTo(forventetInntektsbegrunnelse) // Replace non-breaking space -> space
         val gjennomsnittSiste3Mnd = (28_000 + 30_000 + 30_000) / 3
 
         val forventedeInntektsperioderINyttVedtak =
@@ -190,4 +191,15 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
 
         assertThat(oppdatertInntekt).isEqualTo(forventedeInntektsperioderINyttVedtak)
     }
+
+    val forventetInntektsbegrunnelse =
+        """
+        Forventet årsinntekt fra juni 2025: 29 333 kroner.
+        - 10 % opp: 32 266 kroner per måned.
+        - 10 % ned: 26 399 kroner per måned.
+        
+        Inntekten i februar 2025 er 28 000 kroner. Inntekten har økt minst 10 prosent denne måneden. Stønaden beregnes på nytt fra måneden etter.
+           
+        Fra og med juni 2025 er stønaden beregnet ut ifra gjennomsnittlig inntekt i mars, april og mai.
+        """.trimIndent()
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Inntektsbegrunnelse skal inneholde en del informasjon om hvordan det er kommet frem til revurderingsdato og forventet inntekt. Malen som er laget her skal oppfylle krav til dette og følger det slik saksbehandler gjør i de vanligste sakene.