### PR TITLE
Bugfix: Finn inntektsmappe for BehandleSak oppgavene til Automatisk revurdering av inntekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.behandling.revurdering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
-import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
@@ -16,7 +16,6 @@ import kotlin.collections.set
     beskrivelse = "Automatisk revurdering av inntekt - Brukes av endepunktet revurder-personer-med-inntektsendringer-automatisk i forvaltning i personhendelse",
 )
 class OpprettAutomatiskRevurderingFraForvaltningTask(
-    private val featureToggleService: FeatureToggleService,
     private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val revurderingService: RevurderingService,
 ) : AsyncTaskStep {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
+import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
@@ -54,6 +55,7 @@ class RevurderingService(
     private val vedtakService: VedtakService,
     private val nyeBarnService: NyeBarnService,
     private val tilordnetRessursService: TilordnetRessursService,
+    private val oppgaveService: OppgaveService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -129,7 +131,7 @@ class RevurderingService(
                     behandlingId = revurdering.id,
                     saksbehandler = saksbehandler,
                     beskrivelse = if (erAutomatiskRevurdering) "Automatisk opprettet revurdering som følge av inntektskontroll" else "Revurdering i ny løsning",
-                    mappeId = if (erAutomatiskRevurdering) GOSYS_MAPPE_ID_INNTEKTSKONTROLL else null,
+                    mappeId = if (erAutomatiskRevurdering) oppgaveService.finnMappeGittMappenavn(mappeNavn = "63 Innte", personIdent = fagsak.hentAktivIdent()) else null,
                 ),
             ),
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -496,4 +496,17 @@ class OppgaveService(
     private fun List<no.nav.familie.ef.sak.oppgave.Oppgave>?.oppgaveSistEndret(): no.nav.familie.ef.sak.oppgave.Oppgave? = this?.sortedBy { it.sistEndret() }?.last()
 
     private fun no.nav.familie.ef.sak.oppgave.Oppgave.sistEndret(): LocalDateTime = this.sporbar.endret.endretTid
+
+    fun finnMappeGittMappenavn(
+        mappeNavn: String,
+        personIdent: String,
+    ): Long? {
+        val enhetsnummer =
+            arbeidsfordelingService.hentNavEnhetId(personIdent, BehandleSak)
+                ?: ENHET_NR_NAY // Hvis vi ikke finner enhet, så bruker vi NAY som fallback
+
+        val mapperResponse = oppgaveClient.finnMapper(enhetsnummer, 1000)
+        val mappe = mapperResponse.mapper.find { it.navn.contains(mappeNavn) }
+        return mappe?.id?.toLong()
+    }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -12,14 +12,10 @@ import no.nav.familie.ef.sak.behandling.revurdering.BehandleAutomatiskInntektsen
 import no.nav.familie.ef.sak.behandling.revurdering.PayloadBehandleAutomatiskInntektsendringTask
 import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingsRepository
-import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
-import no.nav.familie.ef.sak.behandlingsflyt.steg.VentePåStatusFraIverksettSteg
-import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.YEAR_MONTH_MAX
 import no.nav.familie.ef.sak.infrastruktur.config.InntektClientMock
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
-import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.repository.behandling
@@ -30,11 +26,9 @@ import no.nav.familie.ef.sak.repository.lagInntektResponseFraMånedsinntekter
 import no.nav.familie.ef.sak.repository.vedtak
 import no.nav.familie.ef.sak.testutil.VedtakHelperService
 import no.nav.familie.ef.sak.testutil.VilkårHelperService
-import no.nav.familie.ef.sak.vedtak.VedtakRepository
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.kontrakter.felles.Månedsperiode
-import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -46,9 +40,6 @@ import java.util.UUID
 class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var oppgaveService: OppgaveService
-
-    @Autowired
-    private lateinit var fagsakRepository: FagsakRepository
 
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
@@ -69,9 +60,6 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
     private lateinit var vedtakService: VedtakService
 
     @Autowired
-    private lateinit var vedtakRepository: VedtakRepository
-
-    @Autowired
     private lateinit var årsakRevurderingsRepository: ÅrsakRevurderingsRepository
 
     @Autowired
@@ -90,19 +78,7 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
     lateinit var barnRepository: BarnRepository
 
     @Autowired
-    private lateinit var rolleConfig: RolleConfig
-
-    @Autowired
     private lateinit var inntektClientMock: InntektClientMock
-
-    @Autowired
-    private lateinit var taskService: TaskService
-
-    @Autowired
-    private lateinit var ventePåStatusFraIverksettSteg: VentePåStatusFraIverksettSteg
-
-    @Autowired
-    private lateinit var stegService: StegService
 
     @Autowired
     private lateinit var gOmregningTestUtil: GOmregningTestUtil
@@ -158,8 +134,6 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
         val inntektResponse = lagInntektResponseFraMånedsinntekter(innmeldtMånedsinntekt)
 
         every { inntektClientMock.inntektClient().hentInntekt("321", any(), any()) } returns inntektResponse
-
-        every { oppgaveService.finnMappeGittMappenavn(any(), any()) } returns 63L
 
         behandleAutomatiskInntektsendringTask.doTask(opprettetTask)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ef.sak.infrastruktur.config.InntektClientMock
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
@@ -43,6 +44,9 @@ import java.time.YearMonth
 import java.util.UUID
 
 class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
+    @Autowired
+    private lateinit var oppgaveService: OppgaveService
+
     @Autowired
     private lateinit var fagsakRepository: FagsakRepository
 
@@ -154,6 +158,8 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
         val inntektResponse = lagInntektResponseFraMånedsinntekter(innmeldtMånedsinntekt)
 
         every { inntektClientMock.inntektClient().hentInntekt("321", any(), any()) } returns inntektResponse
+
+        every { oppgaveService.finnMappeGittMappenavn(any(), any()) } returns 63L
 
         behandleAutomatiskInntektsendringTask.doTask(opprettetTask)
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -130,7 +130,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(opprettOppgaveTask.payload)
-        assertThat(data.mappeId).isEqualTo(63)
+        assertThat(data.mappeId).isNull() //Blir satt på senere tidspunkt
         assertThat(data.beskrivelse).isEqualTo("Automatisk opprettet revurdering som følge av inntektskontroll")
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -130,7 +130,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
 
         val opprettOppgaveTask = taskService.findAll().first { it.type == OpprettOppgaveForOpprettetBehandlingTask.TYPE }
         val data = objectMapper.readValue<OpprettOppgaveTaskData>(opprettOppgaveTask.payload)
-        assertThat(data.mappeId).isNull() //Blir satt på senere tidspunkt
+        assertThat(data.mappeId).isNull() // Blir satt på senere tidspunkt
         assertThat(data.beskrivelse).isEqualTo("Automatisk opprettet revurdering som følge av inntektskontroll")
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/RevurderingServiceTest.kt
@@ -35,13 +35,14 @@ internal class RevurderingServiceTest {
             taskService = mockk(),
             barnService = mockk(),
             fagsakService = fagsakService,
+            årsakRevurderingService = mockk(),
             årsakRevurderingSteg = mockk(),
             stegService = mockk(),
-            årsakRevurderingService = mockk(),
             kopierVedtakService = mockk(),
             vedtakService = mockk(),
             nyeBarnService = mockk(),
             tilordnetRessursService = mockk(),
+            oppgaveService = mockk(),
         )
 
     @BeforeEach


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var lagt inn feil mappeId. Denne PR'n sørger for å finne riktig mappe som oppgaven skal knyttes til. Mappen er merket med "63 Inntektskontroll". Det er dessverre skrivefeil i preprod på mappenavnet (Inntekstkontroll) - derfor ble mappenavnet som søkes på "63 Innte" for å få treff i både prod og preprod.