### PR TITLE
Gjør om sjekken som finner første måned med 10 prosent endring til å …

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
@@ -1,0 +1,47 @@
+package no.nav.familie.ef.sak.no.nav.familie.ef.sak.amelding
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.amelding.InntektResponse
+import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.repository.inntektsperiode
+import no.nav.familie.ef.sak.repository.vedtak
+import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
+import no.nav.familie.kontrakter.felles.Månedsperiode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.nio.charset.StandardCharsets
+import java.time.YearMonth
+
+class InntektResponseTest {
+    @Test
+    fun `finn førsteMånedMed10ProsentInntektsøkning`() {
+        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
+        inntektV2ResponseJson.replace("2025-04", YearMonth.now().minusMonths(2).toString())
+        inntektV2ResponseJson.replace("2025-05", YearMonth.now().minusMonths(1).toString())
+        val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
+
+        val vedtak = vedtak(InntektWrapper(listOf(inntektsperiode(Månedsperiode(YearMonth.now().minusMonths(6), YearMonth.now().plusMonths(1)), BigDecimal.valueOf(57500)))))
+        val inntektUtenOvergangsstønad = inntektResponse.førsteMånedMed10ProsentInntektsøkning(vedtak)
+        assertThat(inntektUtenOvergangsstønad).isEqualTo(YearMonth.now().minusMonths(1))
+    }
+
+    @Test
+    fun `finn førsteMånedMed10ProsentInntektsøkning - ignorer månedsinntekt tilsvarende årsinntekt på en halv g`() {
+        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
+        inntektV2ResponseJson.replace("2025-04", YearMonth.now().minusMonths(2).toString())
+        inntektV2ResponseJson.replace("2025-05", YearMonth.now().minusMonths(1).toString())
+        val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
+
+        val vedtak = vedtak(InntektWrapper(listOf(inntektsperiode(Månedsperiode(YearMonth.now().minusMonths(6), YearMonth.now().plusMonths(1)), BigDecimal.valueOf(0)))))
+        val inntektUtenOvergangsstønad = inntektResponse.førsteMånedMed10ProsentInntektsøkning(vedtak)
+        assertThat(inntektUtenOvergangsstønad).isEqualTo(YearMonth.now().minusMonths(1))
+    }
+
+    fun lesRessurs(name: String): String {
+        val resource =
+            this::class.java.classLoader.getResource(name)
+                ?: throw IllegalArgumentException("Resource not found: $name")
+        return resource.readText(StandardCharsets.UTF_8)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -98,10 +98,10 @@ class AutomatiskRevurderingServiceTest {
         val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2 + inntekterFraSeksMånederTilTreMånederSidenFastlønn
         val inntektResponse = InntektResponse(inntekter)
 
-        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederUtenEfYtelser(YearMonth.now().minusMonths(6))
+        val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederFraOgMedÅrMåned(YearMonth.now().minusMonths(6))
         val forventetInntekt = inntektResponse.forventetMånedsinntekt()
 
-        assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(9)
+        assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(12)
         assertThat(forventetInntekt).isEqualTo(6000)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapperTest.kt
@@ -4,7 +4,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Fødsel
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.fødested
 import no.nav.familie.ef.sak.testutil.PdlTestdataHelper.fødselsdato
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
 internal class GrunnlagsdataMapperTest {

--- a/src/test/resources/json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json
+++ b/src/test/resources/json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json
@@ -1,0 +1,133 @@
+{
+  "data": [
+    {
+      "maaned": "2025-04",
+      "opplysningspliktig": "999999999",
+      "underenhet": "999999999",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-05-14T12:59:10.747Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 366.0,
+          "fordel": "naturalytelse",
+          "beskrivelse": "elektroniskKommunikasjon",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": "2025-05-01",
+          "opptjeningsperiodeTom": "2025-05-31",
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -15623.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-05",
+      "opplysningspliktig": "999999999",
+      "underenhet": "999999999",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-05-14T12:59:10.747Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 366.0,
+          "fordel": "naturalytelse",
+          "beskrivelse": "elektroniskKommunikasjon",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": "2025-05-01",
+          "opptjeningsperiodeTom": "2025-05-31",
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "Loennsinntekt",
+          "beloep": 57500.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "fastloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": "2025-05-01",
+          "opptjeningsperiodeTom": "2025-05-31",
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -15623.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-05",
+      "opplysningspliktig": "999999999",
+      "underenhet": "999999999",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-06-02T16:29:21.794Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 10355.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "feriepengerSykepenger",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 4056.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -1095.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    }
+  ],
+  "harTreForrigeInntektsmåneder": true
+}


### PR DESCRIPTION
…kreve at alle påfølgende måneder har minimum 10 prosent endring også.

Tar nå høyde for at det kommer flere innslag av samme måned i inntektresponse. Ved beregning av total inntekt slås dette sammen.

### Hvorfor er denne endringen nødvendig? ✨
Forbedringer etter kjøring i prod