### PR TITLE
Sjekk for høy inntekt delautomatisering inntektsendringer

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -84,7 +84,7 @@ data class InntektResponse(
             .distinctBy { it.måned }
             .size == 3
 
-    val harInntektOverSisteTreMåneder =
+    val finnesHøyMånedsinntektSomIkkeGirOvergangsstønad =
         inntektsmåneder.any { totalInntektForÅrMåned(it.måned) * 12 > finnGrunnbeløp(it.måned).grunnbeløp.toInt() * 5.5 }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -58,7 +58,7 @@ class AutomatiskRevurderingService(
             return false
         }
 
-        if (aMeldingInntektClient.hentInntekt(personIdent, YearMonth.now().minusMonths(3), YearMonth.now()).harInntektOverSisteTreMåneder) {
+        if (aMeldingInntektClient.hentInntekt(personIdent, YearMonth.now().minusMonths(3), YearMonth.now()).finnesHøyMånedsinntektSomIkkeGirOvergangsstønad) {
             logger.info("Har inntekt over 5.5G for fagsak ${fagsak.id}")
             return false
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
@@ -38,7 +38,7 @@ class InntektResponseTest {
     }
 
     @Test
-    fun `returner false hvis det finnes en inntektperiode som er høyere enn fem og en halv G`() {
+    fun `returner false hvis det finnes en måned med total inntekt som gir årsinntekt som er høyere enn fem og en halv G`() {
         val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
         val inntektV2ResponseJsonModifisert = inntektV2ResponseJson.replace("57500.0", "100").replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
         val inntektV2ResponseJsonModifisertForHøyInntekt = inntektV2ResponseJson.replace("57500.0", "99999").replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
@@ -46,8 +46,8 @@ class InntektResponseTest {
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
         val inntektResponseForHøyInntekt = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisertForHøyInntekt)
 
-        val lavInntekt = inntektResponse.harInntektOverSisteTreMåneder
-        val forHøyInntekt = inntektResponseForHøyInntekt.harInntektOverSisteTreMåneder
+        val lavInntekt = inntektResponse.finnesHøyMånedsinntektSomIkkeGirOvergangsstønad
+        val forHøyInntekt = inntektResponseForHøyInntekt.finnesHøyMånedsinntektSomIkkeGirOvergangsstønad
 
         assertThat(lavInntekt).isFalse()
         assertThat(forHøyInntekt).isTrue()


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Sjekker nå om person har inntekt over 5.5G ved delautomatisert inntektsendringer, blir i det tilfelle ikke opprettet revurdering