### PR TITLE
Legger til 'FULLMEKTIG' og lar 'FULLMAKT' bli slik at ef-sak kan være…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
@@ -18,6 +18,7 @@ enum class MottakerRolle {
     BRUKER,
     VERGE,
     FULLMAKT,
+    FULLMEKTIG,
 }
 
 data class BrevmottakerPerson(

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -499,6 +499,7 @@ fun PeriodeMedBeløp.tilPeriodeMedBeløpDto(): PeriodeMedBeløpDto =
 fun MottakerRolle.tilIverksettDto(): Brevmottaker.MottakerRolle =
     when (this) {
         MottakerRolle.FULLMAKT -> Brevmottaker.MottakerRolle.FULLMEKTIG
+        MottakerRolle.FULLMEKTIG -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.VERGE -> Brevmottaker.MottakerRolle.VERGE
         MottakerRolle.BRUKER -> Brevmottaker.MottakerRolle.BRUKER
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereRepositoryTest.kt
@@ -44,7 +44,7 @@ internal class BrevmottakereRepositoryTest : OppslagSpringRunnerTest() {
                             BrevmottakerOrganisasjon(
                                 organisasjonsnummer = "12345678",
                                 navnHosOrganisasjon = "Advokat",
-                                MottakerRolle.FULLMAKT,
+                                MottakerRolle.FULLMEKTIG,
                             ),
                         ),
                     ),

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereServiceTest.kt
@@ -5,7 +5,7 @@ import io.mockk.mockk
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerOrganisasjon
 import no.nav.familie.ef.sak.brev.domain.BrevmottakerPerson
 import no.nav.familie.ef.sak.brev.domain.MottakerRolle.BRUKER
-import no.nav.familie.ef.sak.brev.domain.MottakerRolle.FULLMAKT
+import no.nav.familie.ef.sak.brev.domain.MottakerRolle.FULLMEKTIG
 import no.nav.familie.ef.sak.brev.domain.MottakerRolle.VERGE
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
@@ -131,12 +131,12 @@ internal class BrevmottakereServiceTest {
                         BrevmottakerOrganisasjon(
                             organisasjonsnummer = "123",
                             navnHosOrganisasjon = "n",
-                            mottakerRolle = FULLMAKT,
+                            mottakerRolle = FULLMEKTIG,
                         ),
                         BrevmottakerOrganisasjon(
                             organisasjonsnummer = "123",
                             navnHosOrganisasjon = "n",
-                            mottakerRolle = FULLMAKT,
+                            mottakerRolle = FULLMEKTIG,
                         ),
                     ),
             )
@@ -177,12 +177,12 @@ internal class BrevmottakereServiceTest {
                     BrevmottakerOrganisasjon(
                         "C",
                         "C",
-                        FULLMAKT,
+                        FULLMEKTIG,
                     ),
                     BrevmottakerOrganisasjon(
                         "D",
                         "D",
-                        FULLMAKT,
+                        FULLMEKTIG,
                     ),
                 ),
         )

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevServiceTest.kt
@@ -80,7 +80,7 @@ internal class FrittståendeBrevServiceTest {
 
     @Nested
     inner class Mottakere {
-        private val organisasjon = BrevmottakerOrganisasjon("org1", "navn", MottakerRolle.FULLMAKT)
+        private val organisasjon = BrevmottakerOrganisasjon("org1", "navn", MottakerRolle.FULLMEKTIG)
         private val person = BrevmottakerPerson("ident", "navn", MottakerRolle.BRUKER)
 
         @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevmottakereRepositoryTest.kt
@@ -58,7 +58,7 @@ internal class FrittståendeBrevmottakereRepositoryTest : OppslagSpringRunnerTes
                             BrevmottakerOrganisasjon(
                                 organisasjonsnummer = "12345678",
                                 navnHosOrganisasjon = "Advokat",
-                                MottakerRolle.FULLMAKT,
+                                MottakerRolle.FULLMEKTIG,
                             ),
                         ),
                     ),


### PR DESCRIPTION
… bakoverkompatibel. Skal slette 'FULLMAKT' i annen PR

### Hvorfor er denne endringen nødvendig? ✨

Vi sender FULLMAKT fra frontend, denne mappes om til FULLMEKTIG. Vil endre FULLMAKT til FULLMEKTIG begge steder.