### PR TITLE
Slette ubrukt enum mottaker rolle FULLMAKT

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
@@ -17,7 +17,6 @@ data class Brevmottakere(
 enum class MottakerRolle {
     BRUKER,
     VERGE,
-    FULLMAKT,
     FULLMEKTIG,
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -498,7 +498,6 @@ fun PeriodeMedBeløp.tilPeriodeMedBeløpDto(): PeriodeMedBeløpDto =
 
 fun MottakerRolle.tilIverksettDto(): Brevmottaker.MottakerRolle =
     when (this) {
-        MottakerRolle.FULLMAKT -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.FULLMEKTIG -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.VERGE -> Brevmottaker.MottakerRolle.VERGE
         MottakerRolle.BRUKER -> Brevmottaker.MottakerRolle.BRUKER


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Kan slette ubrukt mottaker roller enum 'FULLMAKT' da den ikke blir sendt med fra frontend lenger 'FULLMEKTIG' brukes i stedet.