### PR TITLE
Skal ikke ta med feriepenger i beregningen av forventet inntekt.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -58,7 +58,8 @@ class AutomatiskRevurderingService(
             return false
         }
 
-        if (aMeldingInntektClient.hentInntekt(personIdent, YearMonth.now().minusMonths(3), YearMonth.now()).finnesHøyMånedsinntektSomIkkeGirOvergangsstønad) {
+        val inntektSisteTreMåneder = aMeldingInntektClient.hentInntekt(personIdent, YearMonth.now().minusMonths(3), YearMonth.now())
+        if (inntektSisteTreMåneder.finnesHøyMånedsinntektSomIkkeGirOvergangsstønad) {
             logger.info("Har inntekt over 5.5G for fagsak ${fagsak.id}")
             return false
         }
@@ -90,6 +91,11 @@ class AutomatiskRevurderingService(
         val vedtak = vedtakService.hentVedtak(sisteIverksatteBehandlingId)
         if (vedtak.perioder?.perioder?.size != 1) { // Denne valideringen kan fjernes når logikken for å sette revurderes fra-dato er forbedret
             logger.info("behandlingId: $sisteIverksatteBehandlingId har flere vedtaksperioder og kan derfor ikke automatisk revurderes")
+            return false
+        }
+
+        if (inntektSisteTreMåneder.harMånedMedBareFeriepenger(YearMonth.now().minusMonths(3))) {
+            logger.info("Bruker har en måned med bare feriepenger, og skal dermed ikke automatisk revurderes. BehandlingId: $sisteIverksatteBehandlingId")
             return false
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
@@ -67,6 +67,7 @@ class InntektResponseTest {
 
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
         assertThat(inntektResponse.forventetMånedsinntekt()).isEqualTo(10333)
+        assertThat(inntektResponse.harMånedMedBareFeriepenger(YearMonth.now().minusMonths(4))).isFalse
     }
 
     @Test
@@ -74,13 +75,12 @@ class InntektResponseTest {
         val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektFastlønnMedEnMånedMedKunFeriepenger.json")
         val inntektV2ResponseJsonModifisert =
             inntektV2ResponseJson
-                .replace("2020-04", YearMonth.now().minusMonths(4).toString())
                 .replace("2020-05", YearMonth.now().minusMonths(3).toString())
                 .replace("2020-06", YearMonth.now().minusMonths(2).toString()) // Feriepenger som ignoreres
                 .replace("2020-07", YearMonth.now().minusMonths(1).toString())
 
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
-        assertThat(inntektResponse.forventetMånedsinntekt()).isEqualTo(11333)
+        assertThat(inntektResponse.harMånedMedBareFeriepenger(YearMonth.now().minusMonths(4))).isTrue
     }
 
     fun lesRessurs(name: String): String {

--- a/src/test/resources/json/inntekt/InntektFastlønnMedEnMånedMedKunFeriepenger.json
+++ b/src/test/resources/json/inntekt/InntektFastlønnMedEnMånedMedKunFeriepenger.json
@@ -151,7 +151,7 @@
       "inntektListe": [
         {
           "type": "Loennsinntekt",
-          "beloep": 10000,
+          "beloep": 12000,
           "fordel": "kontantytelse",
           "beskrivelse": "fastloenn",
           "inngaarIGrunnlagForTrekk": true,


### PR DESCRIPTION
Skal i første omgang ikke automatisk revurdere tilfeller hvor det er kun feriepenger en måned. Det vanligste er at det er registrert fastlønn i tillegg til feriepenger.