### PR TITLE
Forsøk på raskere deploy til dev

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    name: Build, push and deploy to dev-gcp
+    name: Build and push docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
   deploy:
-    name: Deploy to GCP
+    name: Deploy to dev
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -B --no-transfer-progress package -DskipTests --settings .m2/maven-settings.xml --file pom.xml
       - uses: nais/docker-build-push@791ebb6f74b82849c742a9bc9c97abe44c6c111f # ratchet:nais/docker-build-push@v0
         id: docker-push
         with:
@@ -46,3 +46,18 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .deploy/preprod.yaml
           IMAGE: ${{ needs.build.outputs.image }}
+  test:
+    name: Run tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Run Maven tests
+        run: mvn -B --no-transfer-progress test --settings .m2/maven-settings.xml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -B --no-transfer-progress package -DskipTests --settings .m2/maven-settings.xml --file pom.xml
       - uses: nais/docker-build-push@791ebb6f74b82849c742a9bc9c97abe44c6c111f # ratchet:nais/docker-build-push@v0
         id: docker-push
         with:
@@ -44,7 +44,7 @@ jobs:
           WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
-  deploy:
+  deploy-dev:
     name: Deploy to GCP
     needs: build
     runs-on: ubuntu-latest
@@ -56,7 +56,28 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .deploy/preprod.yaml
           IMAGE: ${{ needs.build.outputs.image }}
-      - name: Deploy til prod-gcp
+  test:
+    name: Run tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # ratchet:actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Run Maven tests
+        run: mvn -B --no-transfer-progress test --settings .m2/maven-settings.xml
+  deploy-prod:
+    name: Deploy til prod-gcp
+    needs: [deploy-dev, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nais/deploy/actions/deploy@d30ad2c21d7862e22d45cac6accfbf42bbbc0f39 # ratchet:nais/deploy/actions/deploy@v2
+      - name: Deploy to prod
         uses: nais/deploy/actions/deploy@d30ad2c21d7862e22d45cac6accfbf42bbbc0f39 # ratchet:nais/deploy/actions/deploy@v2
         env:
           CLUSTER: prod-gcp


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Forsøker å redusere deploy-tid. Ved deploy til dev kjøres tester og selve deploy i parallell. Det vil si at testene kan feile og allikevel blir det deployet til dev, men det kan se ut til at man kan spare 2-3 min på å gjøre det slik.

Ved deploy til prod kjøres også deploy til dev og enhetstester parallelt, men begge må ha kjørt ferdig uten feil før det deployes til prod. Usikker på hvor mye tid det er å hente her, men vi kan teste om dette hjelper.