### PR TITLE
Ikke kompiler i test steget

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -60,4 +60,4 @@ jobs:
           java-version: '21'
           cache: 'maven'
       - name: Run Maven tests
-        run: mvn -B --no-transfer-progress test --settings .m2/maven-settings.xml
+        run: mvn -B --no-transfer-progress test -DskipCompile --settings .m2/maven-settings.xml

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -45,7 +45,7 @@ jobs:
     outputs:
       image: ${{ steps.docker-push.outputs.image }}
   deploy-dev:
-    name: Deploy to GCP
+    name: Deploy to dev
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -70,7 +70,7 @@ jobs:
           java-version: '21'
           cache: 'maven'
       - name: Run Maven tests
-        run: mvn -B --no-transfer-progress test --settings .m2/maven-settings.xml
+        run: mvn -B --no-transfer-progress test -DskipCompile --settings .m2/maven-settings.xml
   deploy-prod:
     name: Deploy til prod-gcp
     needs: [deploy-dev, test]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Forsøkte på upload/download artifact for å slippe å kompilere på nytt, men det tok for mye tid med I/O. 
Fant ut at det er mulig med skipCompile i mvn test, noe som er greit, da compile har blitt gjort i build-steget.

Litt vanskelig å teste dette generelt, da github gir veldig varierende ytelse fra gang til gang. Men som nevnt i tidligere PRs så kan vi teste med dette og eventuelt rulle tilbake om det ikke er noe særlig forbedringer.