### PR TITLE
Skal ha saksbehandlernavn på oppfølgingsbrev som sendes ut automatisk

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/oppfølgingsoppgave/OppfølgingsoppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppfølgingsoppgave/OppfølgingsoppgaveServiceTest.kt
@@ -13,8 +13,10 @@ import no.nav.familie.ef.sak.behandling.oppgaveforopprettelse.OppgaverForOpprett
 import no.nav.familie.ef.sak.behandling.oppgaverforferdigstilling.OppgaverForFerdigstillingRepository
 import no.nav.familie.ef.sak.brev.BrevClient
 import no.nav.familie.ef.sak.brev.BrevmottakereService
+import no.nav.familie.ef.sak.brev.BrevsignaturService
 import no.nav.familie.ef.sak.brev.FamilieDokumentClient
 import no.nav.familie.ef.sak.brev.FrittståendeBrevService
+import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.BehandlingOppsettUtil.iverksattFørstegangsbehandling
 import no.nav.familie.ef.sak.felles.util.BehandlingOppsettUtil.iverksattRevurdering
 import no.nav.familie.ef.sak.iverksett.IverksettClient
@@ -54,6 +56,8 @@ internal class OppfølgingsoppgaveServiceTest {
     private val frittståendeBrevService = mockk<FrittståendeBrevService>()
     private val personopplysningerService = mockk<PersonopplysningerService>()
     private val brevmottakereService = mockk<BrevmottakereService>()
+    private val fagsakService = mockk<FagsakService>()
+    private val brevsignaturService = mockk<BrevsignaturService>()
 
     private var oppfølgingsoppgaveService =
         spyk(
@@ -70,6 +74,8 @@ internal class OppfølgingsoppgaveServiceTest {
                 frittståendeBrevService,
                 personopplysningerService,
                 brevmottakereService,
+                brevsignaturService,
+                fagsakService,
             ),
         )
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bug meldt om i Teams, hvor brev signeres med Vedtaksløsningen når det ikke skulle vært det. Dette gjelder oppfølgingsbrev som saksbehandler må krysse av for ved sending til beslutter.


https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd