### PR TITLE
Legger tilbake "FULLMAKT" for BrevMottaker enum

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/domain/Brevmottakere.kt
@@ -17,6 +17,7 @@ data class Brevmottakere(
 enum class MottakerRolle {
     BRUKER,
     VERGE,
+    FULLMAKT,
     FULLMEKTIG,
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -502,6 +502,7 @@ fun PeriodeMedBeløp.tilPeriodeMedBeløpDto(): PeriodeMedBeløpDto =
 
 fun MottakerRolle.tilIverksettDto(): Brevmottaker.MottakerRolle =
     when (this) {
+        MottakerRolle.FULLMAKT -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.FULLMEKTIG -> Brevmottaker.MottakerRolle.FULLMEKTIG
         MottakerRolle.VERGE -> Brevmottaker.MottakerRolle.VERGE
         MottakerRolle.BRUKER -> Brevmottaker.MottakerRolle.BRUKER


### PR DESCRIPTION
# Legger tilbake "FULLMAKT" for BrevMottaker enum

### Hvorfor er denne endringen nødvendig? ✨ 

Loggene viser at en saksbehandler har sendt en sak til beslutter, der vi nå fikk en feil. Det virker som at enkelte behandlinger fortsatt har den tidligere tiltenkt ubrukte verdien "FULLMAKT".

Eksempel:

`Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `no.nav.familie.ef.sak.brev.domain.MottakerRolle` from String "FULLMAKT": not one of the values accepted for Enum class: [VERGE, BRUKER, FULLMEKTIG]`

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25725).

Denne PRen er en del av en bredre oppgave og depender på denne → PRen.

### Verdt å nevne

Har ikke testet noe spesielt, men har snakket med fagressurs som har vært i dialog med saksbehandler og håpet er at saksbehandler kan prøve på nytt med behandlingen. 