### PR TITLE
Liten tekstendring i inntektsbegrunnelse ved automatisk revurdering av inntekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -302,7 +302,7 @@ class BehandleAutomatiskInntektsendringTask(
 
         if (forrigeForventetÅrsinntekt == 0) {
             return """
-                Forventet årsinntekt fra ${førsteMånedMed10ProsentEndring.tilNorskFormat()}: ${forrigeForventetÅrsinntekt.tilNorskFormat()} kroner.
+                Forventet årsinntekt i ${førsteMånedMed10ProsentEndring.tilNorskFormat()}: ${forrigeForventetÅrsinntekt.tilNorskFormat()} kroner.
                     - Månedsinntekten tilsvarer 1/2 G i året eller over: ${(Grunnbeløpsperioder.nyesteGrunnbeløp.perMnd.toInt() / 2).tilNorskFormat()} kroner
                 
                 Mottar uredusert stønad.
@@ -316,7 +316,7 @@ class BehandleAutomatiskInntektsendringTask(
             """
             Periode som er kontrollert: ${inntektResponse.inntektsmåneder.minBy { it.måned }.måned.tilNorskFormat()} til ${inntektResponse.inntektsmåneder.maxBy { it.måned }.måned.tilNorskFormat()}.
             
-            Forventet årsinntekt fra ${førsteMånedMed10ProsentEndring.tilNorskFormat()}: ${forrigeForventetÅrsinntekt.tilNorskFormat()} kroner.
+            Forventet årsinntekt i ${førsteMånedMed10ProsentEndring.tilNorskFormat()}: ${forrigeForventetÅrsinntekt.tilNorskFormat()} kroner.
             - 10 % opp: ${tiProsentOppOgNed.opp.tilNorskFormat()} kroner per måned.
             - 10 % ned: ${tiProsentOppOgNed.ned.tilNorskFormat()} kroner per måned.
             ${tekstTypeForGOmregningOppOgNed(forrigeBehandlingGOmregning, forrigeForventetÅrsinntektG, tiProsentOppOgNedG)}

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -195,7 +195,7 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
         Periode som er kontrollert: ${YearMonth.now().minusMonths(12).tilNorskFormat()} til ${
             YearMonth.now().minusMonths(1).tilNorskFormat()}.
         
-        Forventet årsinntekt fra ${YearMonth.now().minusMonths(4).tilNorskFormat()}: 276 000 kroner.
+        Forventet årsinntekt i ${YearMonth.now().minusMonths(4).tilNorskFormat()}: 276 000 kroner.
         - 10 % opp: 25 300 kroner per måned.
         - 10 % ned: 20 700 kroner per måned.
         

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -323,7 +323,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         """
         Periode som er kontrollert: juli 2024 til juni 2025.
         
-        Forventet årsinntekt fra mars 2025: 144 000 kroner.
+        Forventet årsinntekt i mars 2025: 144 000 kroner.
         - 10 % opp: 13 200 kroner per måned.
         - 10 % ned: 10 800 kroner per måned.
         
@@ -336,7 +336,7 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
 
     val forventetInntektsbegrunnelseForrigeVedtak0ForventetInntekt =
         """
-        Forventet årsinntekt fra desember 2024: 0 kroner.
+        Forventet årsinntekt i desember 2024: 0 kroner.
             - Månedsinntekten tilsvarer 1/2 G i året eller over: 5 423 kroner
         
         Mottar uredusert stønad.


### PR DESCRIPTION
Etter tilbakemelding fra fag etter forrige kjøring