### PR TITLE
Rettet tekst i inntektsbegrunnelse etter tilbakemelding fra fag

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -305,12 +305,12 @@ class BehandleAutomatiskInntektsendringTask(
         if (forrigeForventetÅrsinntekt == 0) {
             return """
                 Forventet årsinntekt i ${førsteMånedMed10ProsentEndring.tilNorskFormat()}: ${forrigeForventetÅrsinntekt.tilNorskFormat()} kroner.
-                    - Månedsinntekten tilsvarer 1/2 G i året eller over: ${(Grunnbeløpsperioder.nyesteGrunnbeløp.perMnd.toInt() / 2).tilNorskFormat()} kroner
+                    - Månedsinntekt 1/2 G: ${(Grunnbeløpsperioder.nyesteGrunnbeløp.perMnd.toInt() / 2).tilNorskFormat()} kroner
                 
                 Mottar uredusert stønad.
                 
-                Inntekten i ${førsteMånedMed10ProsentEndring.tilNorskFormat()} er ${beløpFørsteMåned10ProsentEndring.tilNorskFormat()} kroner. Har inntekt over 1/2 G på ${(Grunnbeløpsperioder.finnGrunnbeløp(førsteMånedMed10ProsentEndring).perMnd.toInt() / 2).tilNorskFormat()} kroner denne måneden og alle månedene etter dette.
-                Stønaden beregnes på nytt fra måneden etter inntekten oversteg ${(Grunnbeløpsperioder.finnGrunnbeløp(førsteMånedMed10ProsentEndring).perMnd.toInt() / 2).tilNorskFormat()} kroner.
+                Inntekten i ${førsteMånedMed10ProsentEndring.tilNorskFormat()} er ${beløpFørsteMåned10ProsentEndring.tilNorskFormat()} kroner. Bruker har inntekt over 1/2 G denne måneden og alle månedene etter dette.
+                Stønaden beregnes på nytt fra måneden etter inntekten oversteg 1/2 G.
                 """.trimIndent()
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -339,11 +339,11 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
     val forventetInntektsbegrunnelseForrigeVedtak0ForventetInntekt =
         """
         Forventet årsinntekt i desember 2024: 0 kroner.
-            - Månedsinntekten tilsvarer 1/2 G i året eller over: 5 423 kroner
+            - Månedsinntekt 1/2 G: 5 423 kroner
         
         Mottar uredusert stønad.
         
-        Inntekten i desember 2024 er 12 000 kroner. Har inntekt over 1/2 G på 5 168 kroner denne måneden og alle månedene etter dette.
-        Stønaden beregnes på nytt fra måneden etter inntekten oversteg 5 168 kroner.
+        Inntekten i desember 2024 er 12 000 kroner. Bruker har inntekt over 1/2 G denne måneden og alle månedene etter dette.
+        Stønaden beregnes på nytt fra måneden etter inntekten oversteg 1/2 G.
         """.trimIndent()
 }


### PR DESCRIPTION
Tekst er forenklet i caser hvor forrige behandling er en G-omregning.

[NAV-25696](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25696)