### PR TITLE
Ikke hent tidligere vedtak hvis folkeregisteridentifikator er tom

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderService.kt
@@ -33,7 +33,7 @@ class TidligereVedtaksperioderService(
      * @param folkeregisteridentifikatorer for 1 person
      */
     fun hentTidligereVedtaksperioder(folkeregisteridentifikatorer: List<Folkeregisteridentifikator>): TidligereVedtaksperioder {
-        return if(folkeregisteridentifikatorer.isNotEmpty() && folkeregisteridentifikatorer.any { it.metadata.historisk == false }){
+        return if (folkeregisteridentifikatorer.isNotEmpty() && folkeregisteridentifikatorer.any { it.metadata.historisk == false }) {
             val aktivIdent = folkeregisteridentifikatorer.gjeldende().ident
             val alleIdenter = folkeregisteridentifikatorer.map { it.ident }.toSet()
             val tidligereInnvilgetVedtak =
@@ -43,7 +43,7 @@ class TidligereVedtaksperioderService(
                 sak = hentTidligereInnvilgedeVedtakEf(alleIdenter),
                 historiskPensjon = historiskPensjonService.hentHistoriskPensjon(aktivIdent, alleIdenter).harPensjonsdata(),
             )
-        } else{
+        } else {
             // Ikke hent tidligere vedtaksperioder for personer uten folkeregisteridentifikatorer (f.eks. andre foreldre med NPID hentet fra relasjon til barn)
             TidligereVedtaksperioder(infotrygd = TidligereInnvilgetVedtak(false, false, false))
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
@@ -135,6 +135,18 @@ internal class TidligereVedtaksperioderServiceTest {
     }
 
     @Test
+    internal fun `Hvis en person ikke har folkeregisteridentifikatos skal vi ikke prøve å hente ut tidligere vedtak`() {
+        val tidligereVedtaksperioder = service.hentTidligereVedtaksperioder(emptyList())
+        assertThat(tidligereVedtaksperioder.sak).isNull()
+        assertThat(tidligereVedtaksperioder.historiskPensjon).isNull()
+        assertThat(tidligereVedtaksperioder.infotrygd.harTidligereOvergangsstønad).isFalse()
+        verify(exactly = 0) { fagsakPersonService.finnPerson(any()) }
+        verify(exactly = 0) { fagsakService.finnFagsakerForFagsakPersonId(any()) }
+        verify(exactly = 0) { behandlingService.finnSisteIverksatteBehandling(any()) }
+        verify(exactly = 0) { tilkjentYtelseService.hentForBehandling(any()) }
+    }
+
+    @Test
     internal fun `Skal filtrere bort opphør`() {
         val andel2 = andel.copy(erOpphør = true)
         every { andelsHistorikkService.hentHistorikk(fagsaker.overgangsstønad!!.id, null) } returns
@@ -326,7 +338,7 @@ internal class TidligereVedtaksperioderServiceTest {
                 GrunnlagsdataPeriodeHistorikkOvergangsstønad(
                     fom = LocalDate.of(2022, 5, 1),
                     tom = LocalDate.of(2022, 9, 30),
-                    periodeType = VedtaksperiodeType.SANKSJON,
+                    periodeType = SANKSJON,
                     aktivitet = AktivitetType.FORSØRGER_I_ARBEID,
                     beløp = 5555,
                     inntekt = 5555,
@@ -335,7 +347,7 @@ internal class TidligereVedtaksperioderServiceTest {
                 GrunnlagsdataPeriodeHistorikkOvergangsstønad(
                     fom = LocalDate.of(2024, 2, 1),
                     tom = LocalDate.of(2024, 3, 31),
-                    periodeType = VedtaksperiodeType.SANKSJON,
+                    periodeType = SANKSJON,
                     aktivitet = AktivitetType.FORSØRGER_I_ARBEID,
                     beløp = 4444,
                     inntekt = 4444,
@@ -344,7 +356,7 @@ internal class TidligereVedtaksperioderServiceTest {
                 GrunnlagsdataPeriodeHistorikkOvergangsstønad(
                     fom = LocalDate.of(2023, 3, 1),
                     tom = LocalDate.of(2023, 7, 31),
-                    periodeType = VedtaksperiodeType.SANKSJON,
+                    periodeType = SANKSJON,
                     aktivitet = AktivitetType.FORSØRGER_I_ARBEID,
                     beløp = 3333,
                     inntekt = 3333,

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/TidligereVedtaksperioderServiceTest.kt
@@ -135,7 +135,7 @@ internal class TidligereVedtaksperioderServiceTest {
     }
 
     @Test
-    internal fun `Hvis en person ikke har folkeregisteridentifikatos skal vi ikke prøve å hente ut tidligere vedtak`() {
+    internal fun `Hvis en person ikke har folkeregisteridentifikator skal vi ikke prøve å hente ut tidligere vedtak`() {
         val tidligereVedtaksperioder = service.hentTidligereVedtaksperioder(emptyList())
         assertThat(tidligereVedtaksperioder.sak).isNull()
         assertThat(tidligereVedtaksperioder.historiskPensjon).isNull()


### PR DESCRIPTION
Dette kan skje dersom vi f.eks. prøver å sjekke annen forelder som bare er registrert med NPID og er hentet fra relasjon til barn.

### Hvorfor er denne endringen nødvendig? ✨
Vi får f.eks ikke opprettet grunlagsdata dersom vi har andre foreldre som kun er registrert med NPID. 

Testet i preprod her: Får etter fiks laget og iverksatt behandling.
https://ensligmorellerfar.ansatt.dev.nav.no/behandling/b8eb8076-7275-45da-9750-54ab0418d7f3/inngangsvilkar

Laget ny favro-oppgave for å fjerne lenker til annen forelder i UI:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25735

