### PR TITLE
Dersom noe er revurdert manuelt siste 3 måneder skal det ikke med i inntektskontrollen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -177,8 +177,12 @@ interface BehandlingRepository :
         """
         SELECT DISTINCT pi.ident 
         FROM gjeldende_iverksatte_behandlinger gib 
+            JOIN behandling b on gib.id = b.id
+            LEFT JOIN behandling forrige_behandling on b.forrige_behandling_id=forrige_behandling.id
             JOIN person_ident pi ON gib.fagsak_person_id=pi.fagsak_person_id
-        WHERE gib.stonadstype=:stønadstype AND (vedtakstidspunkt < ('now'::timestamp - make_interval(months := :antallMåneder)) OR arsak IN ('MIGRERING', 'G_OMREGNING'))
+        WHERE gib.stonadstype=:stønadstype 
+            AND (gib.vedtakstidspunkt < ('now'::timestamp - make_interval(months := :antallMåneder)) 
+                OR (b.arsak IN ('MIGRERING', 'G_OMREGNING') AND forrige_behandling.vedtakstidspunkt < ('now'::timestamp - make_interval(months := :antallMåneder))))
         AND EXISTS(SELECT 1 FROM andel_tilkjent_ytelse aty
                                JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
              WHERE ty.id = aty.tilkjent_ytelse

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -223,7 +223,7 @@ class VedtakController(
 
     @GetMapping("/personerMedAktivStonadIkkeManueltRevurdertSisteMaaneder")
     @ProtectedWithClaims(issuer = "azuread", claimMap = ["roles=access_as_application"]) // Familie-ef-personhendelse bruker denne
-    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteToMåneder(
+    fun hentPersonerMedAktivStonadIkkeManueltRevurdertSisteMåneder(
         @RequestParam antallMaaneder: Int = 3,
     ): Ressurs<List<String>> =
         if (environment.activeProfiles.contains("prod")) {

--- a/src/test/kotlin/testutil/TestoppsettService.kt
+++ b/src/test/kotlin/testutil/TestoppsettService.kt
@@ -1,5 +1,9 @@
 package no.nav.familie.ef.sak.testutil
 
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat.INNVILGET
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.FERDIGSTILT
 import no.nav.familie.ef.sak.fagsak.FagsakPersonRepository
 import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
@@ -7,15 +11,20 @@ import no.nav.familie.ef.sak.fagsak.domain.FagsakDomain
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.fagsak.domain.tilFagsakMedPerson
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakPerson
 import org.springframework.context.annotation.Profile
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
 
 @Profile("integrasjonstest || local")
 @Service
 class TestoppsettService(
     private val fagsakPersonRepository: FagsakPersonRepository,
     private val fagsakRepository: FagsakRepository,
+    private val behandlingRepository: BehandlingRepository,
 ) {
     fun opprettPerson(ident: String) = fagsakPersonRepository.insert(FagsakPerson(identer = setOf(PersonIdent(ident))))
 
@@ -34,6 +43,22 @@ class TestoppsettService(
                     sporbar = fagsak.sporbar,
                 ),
             ).tilFagsakMedPerson(person.identer)
+    }
+
+    fun lagreFagsakOgBehandlingForPersonIdent(
+        personIdent: String,
+        vedtakstidspunkt: LocalDateTime? = null,
+    ): Behandling {
+        val personMedGOmregningBehandling = fagsakPerson(identer = setOf(PersonIdent(personIdent)))
+        val fagsak = lagreFagsak(fagsak(person = personMedGOmregningBehandling))
+        val behandling =
+            behandling(
+                fagsak,
+                resultat = INNVILGET,
+                vedtakstidspunkt = vedtakstidspunkt,
+                status = FERDIGSTILT,
+            )
+        return behandlingRepository.insert(behandling)
     }
 
     private fun hentEllerOpprettPerson(fagsak: Fagsak): FagsakPerson =


### PR DESCRIPTION
Dette gjelder både for opprettelse av oppgaver ved inntektsendring og automatisk revurdering.

Denne endringen filtrerer ut behandlinger som har blitt revurdert rett før g-omregning, altså at vedtakstidspunkt er mindre enn 3 mnd på behandling før g-omregning. Det er linket til en behandling i favro-oppgaven som er et eksempel på hva som vil bli filtrert ut med denne endringen. Denne ble forsøkt automatisk revurdert, men ble henlagt, da den hadde vært revurdert nylig.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25696