### PR TITLE
Tar med inntektsbegrunnelse dersom bruker har hatt feriepenge-utbetaling siste 3 måneder, og at det ikke tas med i beregningen av forventet inntekt.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -37,6 +37,13 @@ data class InntektResponse(
 
     fun harMånedMedBareFeriepenger(fraOgMedÅrMåned: YearMonth): Boolean = antallMånederUtenFeriepenger(fraOgMedÅrMåned) < 3
 
+    fun finnesFeriepengerFraOgMedÅrMåned(fraOgMedÅrMåned: YearMonth): Boolean =
+        inntektsmånederFraOgMedÅrMåned(fraOgMedÅrMåned)
+            .filter { it.måned.isEqualOrAfter(fraOgMedÅrMåned) && it.måned.isBefore(YearMonth.now()) }
+            .any { it.inntektListe.any { it.beskrivelse.contains("ferie", true) } }
+
+
+
     fun totalInntektForÅrMåned(årMåned: YearMonth): Int =
         inntektsmånederFraOgMedÅrMåned(årMåned)
             .filter { it.måned == årMåned }

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektResponse.kt
@@ -42,8 +42,6 @@ data class InntektResponse(
             .filter { it.måned.isEqualOrAfter(fraOgMedÅrMåned) && it.måned.isBefore(YearMonth.now()) }
             .any { it.inntektListe.any { it.beskrivelse.contains("ferie", true) } }
 
-
-
     fun totalInntektForÅrMåned(årMåned: YearMonth): Int =
         inntektsmånederFraOgMedÅrMåned(årMåned)
             .filter { it.måned == årMåned }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -300,11 +300,12 @@ class BehandleAutomatiskInntektsendringTask(
         // har feriepenger siste 3 mnd -> generer en tekst hvis ikke, få tom tekst. Append tekst alltid.
         val harFeriepenger = inntektResponse.finnesFeriepengerFraOgMedÅrMåned(YearMonth.now().minusMonths(3))
 
-        val finnesFeriepengerTekst = if (harFeriepenger) {
-            "Bruker har fått utbetalt feriepenger i løpet av siste tre måneder, dette ignoreres i beregningen av forventet inntekt.\n"
-        } else {
-            ""
-        }
+        val finnesFeriepengerTekst =
+            if (harFeriepenger) {
+                "Bruker har fått utbetalt feriepenger i løpet av siste tre måneder, dette ignoreres i beregningen av forventet inntekt.\n"
+            } else {
+                ""
+            }
 
         val forventetInntekt = inntektsperioder.maxBy { it.periode.fom }
         val forventetInntektFraMåned = forventetInntekt.periode.fom

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -297,6 +297,15 @@ class BehandleAutomatiskInntektsendringTask(
 
         val beløpFørsteMåned10ProsentEndring = inntektResponse.totalInntektForÅrMåned(førsteMånedMed10ProsentEndring)
 
+        // har feriepenger siste 3 mnd -> generer en tekst hvis ikke, få tom tekst. Append tekst alltid.
+        val harFeriepenger = inntektResponse.finnesFeriepengerFraOgMedÅrMåned(YearMonth.now().minusMonths(3))
+
+        val finnesFeriepengerTekst = if (harFeriepenger) {
+            "Bruker har fått utbetalt feriepenger i løpet av siste tre måneder, dette ignoreres i beregningen av forventet inntekt.\n"
+        } else {
+            ""
+        }
+
         val forventetInntekt = inntektsperioder.maxBy { it.periode.fom }
         val forventetInntektFraMåned = forventetInntekt.periode.fom
 
@@ -311,7 +320,8 @@ class BehandleAutomatiskInntektsendringTask(
                 
                 Inntekten i ${førsteMånedMed10ProsentEndring.tilNorskFormat()} er ${beløpFørsteMåned10ProsentEndring.tilNorskFormat()} kroner. Bruker har inntekt over 1/2 G denne måneden og alle månedene etter dette.
                 Stønaden beregnes på nytt fra måneden etter inntekten oversteg 1/2 G.
-                """.trimIndent()
+                $finnesFeriepengerTekst
+                """.trimIndent().trimEnd()
         }
 
         val tekst =
@@ -325,7 +335,7 @@ class BehandleAutomatiskInntektsendringTask(
             Inntekten i ${førsteMånedMed10ProsentEndring.tilNorskFormat()} er ${beløpFørsteMåned10ProsentEndring.tilNorskFormat()} kroner. Inntekten har økt minst 10 prosent denne måneden og alle månedene etter dette. Stønaden beregnes på nytt fra måneden etter 10 prosent økning.
             
             Har lagt til grunn faktisk inntekt bakover i tid. Fra og med ${forventetInntektFraMåned.tilNorskFormat()} er stønaden beregnet ut ifra gjennomsnittlig inntekt for ${forventetInntektFraMåned.minusMonths(3).månedTilNorskFormat()}, ${forventetInntektFraMåned.minusMonths(2).månedTilNorskFormat()} og ${forventetInntektFraMåned.minusMonths(1).månedTilNorskFormat()}.
-            
+            $finnesFeriepengerTekst
             A-inntekt er lagret.
             """.trimIndent()
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -358,7 +358,6 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
         assertThat(oppdatertVedtak.inntektBegrunnelse?.replace('\u00A0', ' ')).isEqualTo(forventetInntektsbegrunnelseMedFeriepenger)
     }
 
-
     val forventetInntektsbegrunnelseMedFeriepenger =
         """
         Periode som er kontrollert: ${YearMonth.now().minusMonths(6).tilNorskFormat()} til ${YearMonth.now().minusMonths(1).tilNorskFormat()}.


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Implementeres etter ønske fra saksbehandlere. Må testes i preprod og ta en avsjekk med fag om teksten, men dette kan gjøres etter merge.