### PR TITLE
Automatisk revurdering: Fikser at måned for kontroll og år-måned for tidspunkt for økning i inntekt blir satt riktig i inntektsbegrunnelse

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektResponseTest.kt
@@ -5,19 +5,19 @@ import no.nav.familie.ef.sak.amelding.InntektResponse
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.repository.inntektsperiode
 import no.nav.familie.ef.sak.repository.vedtak
+import no.nav.familie.ef.sak.testutil.JsonFilUtil.Companion.lesFil
 import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
-import java.nio.charset.StandardCharsets
 import java.time.YearMonth
 
 class InntektResponseTest {
     @Test
     fun `finn førsteMånedMed10ProsentInntektsøkning`() {
-        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
+        val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
         val inntektV2ResponseJsonModifisert = inntektV2ResponseJson.replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
 
@@ -31,7 +31,7 @@ class InntektResponseTest {
 
     @Test
     fun `finn førsteMånedMed10ProsentInntektsøkning - ignorer månedsinntekt tilsvarende årsinntekt på en halv g`() {
-        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
+        val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
         val inntektV2ResponseJsonModifisert = inntektV2ResponseJson.replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
 
@@ -42,7 +42,7 @@ class InntektResponseTest {
 
     @Test
     fun `returner false hvis det finnes en måned med total inntekt som gir årsinntekt som er høyere enn fem og en halv G`() {
-        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
+        val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektLønnsinntektMedOvergangsstønadOgSykepenger.json")
         val inntektV2ResponseJsonModifisert = inntektV2ResponseJson.replace("57500.0", "100").replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
         val inntektV2ResponseJsonModifisertForHøyInntekt = inntektV2ResponseJson.replace("57500.0", "99999").replace("2025-05", YearMonth.now().minusMonths(1).toString()).replace("2025-04", YearMonth.now().minusMonths(2).toString())
 
@@ -58,7 +58,7 @@ class InntektResponseTest {
 
     @Test
     fun `beregn forventet inntekt med feriepenger - vanlig case med fastlønn hvor feriepenger og trekk i lønn for ferie skal ignoreres`() {
-        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektFulltÅrMedFeriepenger.json")
+        val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektFulltÅrMedFeriepenger.json")
         val inntektV2ResponseJsonModifisert =
             inntektV2ResponseJson
                 .replace("2020-05", YearMonth.now().minusMonths(3).toString())
@@ -72,7 +72,7 @@ class InntektResponseTest {
 
     @Test
     fun `beregn forventet inntekt - ikke ta med måned hvor det er kun feriepenger registrert`() {
-        val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektFastlønnMedEnMånedMedKunFeriepenger.json")
+        val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektFastlønnMedEnMånedMedKunFeriepenger.json")
         val inntektV2ResponseJsonModifisert =
             inntektV2ResponseJson
                 .replace("2020-05", YearMonth.now().minusMonths(3).toString())
@@ -81,12 +81,5 @@ class InntektResponseTest {
 
         val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJsonModifisert)
         assertThat(inntektResponse.harMånedMedBareFeriepenger(YearMonth.now().minusMonths(4))).isTrue
-    }
-
-    fun lesRessurs(name: String): String {
-        val resource =
-            this::class.java.classLoader.getResource(name)
-                ?: throw IllegalArgumentException("Resource not found: $name")
-        return resource.readText(StandardCharsets.UTF_8)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/amelding/InntektServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.sak.amelding.ekstern.ArbeidOgInntektClient
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.testutil.JsonFilUtil.Companion.lesFil
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -37,7 +38,7 @@ class InntektServiceTest {
     inner class ParseInntektV2Reponse {
         @Test
         internal fun `parser generell inntektv2 response med riktig data struktur`() {
-            val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektGenerellResponse.json")
+            val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektGenerellResponse.json")
             val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
 
             val forventetMåned = YearMonth.of(2020, 3)
@@ -49,7 +50,7 @@ class InntektServiceTest {
 
         @Test
         internal fun `parser inntektv2 response med forskjellige inntekt typer`() {
-            val inntektV2ResponseJson: String = lesRessurs("json/inntekt/InntektFlereInntektTyperResponse.json")
+            val inntektV2ResponseJson: String = lesFil("json/inntekt/InntektFlereInntektTyperResponse.json")
             val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
 
             val forventeteInntektTyper =
@@ -80,7 +81,7 @@ class InntektServiceTest {
         @Test
         internal fun `skal hente årsinntekt og summere riktig`() {
             val inntektV2ResponseJson: String =
-                lesRessurs("json/inntekt/InntektFulltÅrMedFeriepenger.json")
+                lesFil("json/inntekt/InntektFulltÅrMedFeriepenger.json")
             val inntektResponse = objectMapper.readValue<InntektResponse>(inntektV2ResponseJson)
 
             every { aMeldingInntektClient.hentInntekt(any(), any(), any()) } returns inntektResponse
@@ -93,12 +94,5 @@ class InntektServiceTest {
 
             assertEquals(130056, årsinntekt)
         }
-    }
-
-    fun lesRessurs(name: String): String {
-        val resource =
-            this::class.java.classLoader.getResource(name)
-                ?: throw IllegalArgumentException("Resource not found: $name")
-        return resource.readText(StandardCharsets.UTF_8)
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/GOmregningTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/GOmregningTestUtil.kt
@@ -87,14 +87,15 @@ class GOmregningTestUtil {
         behandlingId: UUID,
         fagsakId: UUID,
         fom: YearMonth = YearMonth.of(2024, 6),
+        beløp: Int = 23023,
     ) {
         val månedsperiode = Månedsperiode(fom, YearMonth.of(fom.year + 1, 12))
-        val inntektsperiode = inntektsperiode(månedsperiode = månedsperiode, BigDecimal(23023))
+        val inntektsperiode = inntektsperiode(månedsperiode = månedsperiode, BigDecimal(beløp))
         lagSøknadOgVilkårOgVedtak(behandlingId, fagsakId, inntektsperiode)
         val tilkjentYtelse = lagreTilkjentYtelseForInntektsperiode(behandlingId, inntektsperiode)
 
         assertThat(tilkjentYtelse.andelerTilkjentYtelse).hasSize(1)
-        assertThat(inntektsperiode.totalinntekt().toInt()).isEqualTo(276276)
+        assertThat(inntektsperiode.totalinntekt().toInt()).isEqualTo(beløp * 12)
 
         mockTestMedGrunnbeløpFra2025 {
             omregningService.utførGOmregning(fagsakId)

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InntektClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/InntektClientMock.kt
@@ -33,12 +33,6 @@ class InntektClientMock {
         val mockResponseHøyArbeidsinntekt = objectMapper.readValue<InntektResponse>(mockResponseHøyArbeidsinntektJson)
         every { mockk.hentInntekt("2", any(), any()) } returns mockResponseHøyArbeidsinntekt
 
-        val inntekterPerMånedLavInntekt = listOf(inntekt(2000.0), inntekt(10000.0))
-        val inntektsmånederLavInntekt = inntektsmåneder(fraOgMedMåned = YearMonth.now().minusMonths(12), tilOgMedMåned = YearMonth.now().minusMonths(4), inntektListe = inntekterPerMånedLavInntekt)
-        val inntekterPerMånedHøyInntekt = listOf(inntekt(25000.0), inntekt(10000.0))
-        val inntektsmånederHøyInntekt = inntektsmåneder(fraOgMedMåned = YearMonth.now().minusMonths(3), inntektListe = inntekterPerMånedHøyInntekt)
-        every { mockk.hentInntekt("3", any(), any()) } returns InntektResponse(inntektsmånederLavInntekt + inntektsmånederHøyInntekt)
-
         return mockk
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/SigrunClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/SigrunClientMock.kt
@@ -37,13 +37,8 @@ class SigrunClientMock {
                 LocalDate.of(2022, 12, 31).toString(),
             )
 
-        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, 700_000, 0)
-
         every { mockk.hentBeregnetSkatt(any(), any()) } returns beregnetSkattMockResponse
         every { mockk.hentSummertSkattegrunnlag(any(), any()) } returns summertSkattegrunnlagMockResponse
-        every { mockk.hentPensjonsgivendeInntekt(any(), any()) } answers {
-            PensjonsgivendeInntektResponse(firstArg(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
-        }
 
         return mockk
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/næringsinntektskontroll/NæringsinntektKontrollServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/næringsinntektskontroll/NæringsinntektKontrollServiceTest.kt
@@ -11,17 +11,18 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.beregning.Inntektsperiode
 import no.nav.familie.ef.sak.brev.BrevClient
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
+import no.nav.familie.ef.sak.infrastruktur.config.InntektClientMock
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.oppgave.OppgaveClient
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.lagInntektResponseFraMånedsinntekter
 import no.nav.familie.ef.sak.repository.vedtak
 import no.nav.familie.ef.sak.sigrun.ekstern.PensjonsgivendeInntektForSkatteordning
 import no.nav.familie.ef.sak.sigrun.ekstern.PensjonsgivendeInntektResponse
 import no.nav.familie.ef.sak.sigrun.ekstern.SigrunClient
 import no.nav.familie.ef.sak.sigrun.ekstern.Skatteordning
-import no.nav.familie.ef.sak.testutil.kjørSomLeader
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
 import no.nav.familie.ef.sak.tilkjentytelse.domain.AndelTilkjentYtelse
 import no.nav.familie.ef.sak.vedtak.VedtakRepository
@@ -70,6 +71,9 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
     private lateinit var sigrunClient: SigrunClient
 
     @Autowired
+    private lateinit var inntektClientMock: InntektClientMock
+
+    @Autowired
     private lateinit var kafkaMeldingSlot: CapturingSlot<String>
 
     @Autowired
@@ -78,7 +82,6 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var brevClient: BrevClient
 
-    private val personIdent = "1"
     private val oppdaterOppgaveSlot = slot<Oppgave>()
     private val behandlingIds = mutableListOf<UUID>()
     private val finnOppgaveRequest =
@@ -94,146 +97,139 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
     fun setup() {
         kafkaMeldingSlot.clear()
         behandlingIds.clear()
-
-        every { oppgaveClient.hentOppgaver(finnOppgaveRequest) } returns FinnOppgaveResponseDto(1, listOf(lagEksternTestOppgave()))
-        every { oppgaveClient.oppdaterOppgave(capture(oppdaterOppgaveSlot)) } returns 9
-        every { oppgaveClient.finnOppgaveMedId(9) } returns lagEksternTestOppgave()
         every { brevClient.genererNæringsinntektUtenEndringNotat(any()) } returns ByteArray(0)
     }
 
-    private fun lagEksternTestOppgave(personIdent: String = "1"): Oppgave = Oppgave(id = 9, tilordnetRessurs = null, oppgavetype = Oppgavetype.Fremlegg.toString(), fristFerdigstillelse = LocalDate.of(YearMonth.now().year, 12, 15).toString(), mappeId = 107, identer = listOf(OppgaveIdentV2(personIdent, IdentGruppe.FOLKEREGISTERIDENT)))
+    private fun lagEksternTestOppgave(id: Long): Oppgave = Oppgave(id = id, tilordnetRessurs = null, oppgavetype = Oppgavetype.Fremlegg.toString(), fristFerdigstillelse = LocalDate.of(YearMonth.now().year, 12, 15).toString(), mappeId = 107, identer = listOf(OppgaveIdentV2(id.toString(), IdentGruppe.FOLKEREGISTERIDENT)))
 
     @Test
     fun `Bruker har 10 prosent endring i inntekt - virkelighetsnært eksempel med andeler`() {
-        every { oppgaveClient.hentOppgaver(finnOppgaveRequest) } returns FinnOppgaveResponseDto(1, listOf(lagEksternTestOppgave("2")))
-        every { oppgaveClient.finnOppgaveMedId(9) } returns lagEksternTestOppgave("2")
-        lagreTestdataForPersonIdent("2") // Har høy inntekt i mock
-        lagreAndelerTilkjentYtelseForPersonIdent("2")
+        val id = setupMocksMedNæringsinntekt(700_000)
+        lagreAndelerTilkjentYtelseForPersonIdent(id.toString())
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(LocalDate.now().year - 1, 9)
-            assertThat(kafkaMeldingSlot.isCaptured).isTrue
-            assertThat(oppdaterOppgaveSlot.captured.fristFerdigstillelse).isEqualTo(LocalDate.of(LocalDate.now().year + 1, 1, 11).toString())
-            assertThat(oppgaveRepository.findByBehandlingIdAndType(behandlingIds.last(), Oppgavetype.Fremlegg)?.size).isEqualTo(1)
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.MINIMUM_TI_PROSENT_ENDRING_I_INNTEKT)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(LocalDate.now().year - 1, id)
+        assertThat(kafkaMeldingSlot.isCaptured).isTrue
+        assertThat(oppdaterOppgaveSlot.captured.fristFerdigstillelse).isEqualTo(LocalDate.of(LocalDate.now().year + 1, 1, 11).toString())
+        assertThat(oppgaveRepository.findByBehandlingIdAndType(behandlingIds.last(), Oppgavetype.Fremlegg)?.size).isEqualTo(1)
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.MINIMUM_TI_PROSENT_ENDRING_I_INNTEKT)
     }
 
     @Test
     fun `Bruker har under 10 prosent endring i inntekt - virkelighetsnært eksempel med andeler`() {
-        lagreTestdataForPersonIdent(personIdent)
-        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, 90_000, 0)
-        every { sigrunClient.hentPensjonsgivendeInntekt(any(), any()) } answers {
-            PensjonsgivendeInntektResponse(firstArg(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
-        }
-
+        val id = setupMocksMedNæringsinntekt(90_000)
         lagreAndelerTilkjentYtelseForPersonIdent()
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(oppdaterOppgaveSlot.captured.status).isEqualTo(StatusEnum.FERDIGSTILT)
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.UENDRET_INNTEKT)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(YearMonth.now().minusYears(2).year, id)
+        assertThat(oppdaterOppgaveSlot.captured.status).isEqualTo(StatusEnum.FERDIGSTILT)
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.UENDRET_INNTEKT)
     }
 
     @Test
     fun `Bruker har under 10 prosent endring i inntekt med løpende stønad - skal få beskjed`() {
-        lagreTestdataForPersonIdent(personIdent)
-        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, 60_000, 0)
-        every { sigrunClient.hentPensjonsgivendeInntekt(any(), any()) } answers {
-            PensjonsgivendeInntektResponse(firstArg(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
-        }
+        val id = setupMocksMedNæringsinntekt(60_000)
         val fom = LocalDate.of(YearMonth.now().year - 1, 1, 1)
         val tom = LocalDate.of(YearMonth.now().year + 1, 6, 30)
-        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, personIdent, behandlingIds[3], 60_000, 0, 494))
-        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, id.toString(), behandlingIds[3], 60_000, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = id.toString(), startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(kafkaMeldingSlot.isCaptured).isTrue
-            assertThat(oppdaterOppgaveSlot.isCaptured).isTrue
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.MINIMUM_TI_PROSENT_ENDRING_I_INNTEKT)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(YearMonth.now().minusYears(2).year, id)
+        assertThat(kafkaMeldingSlot.isCaptured).isTrue
+        assertThat(oppdaterOppgaveSlot.isCaptured).isTrue
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.MINIMUM_TI_PROSENT_ENDRING_I_INNTEKT)
     }
 
     @Test
     fun `Bruker har innvilget overgangsstønad midt i fjoråret og forventet inntekt må beregnes riktig`() {
-        lagreTestdataForPersonIdent(personIdent)
-        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, 100_000, 0)
-        every { sigrunClient.hentPensjonsgivendeInntekt(any(), any()) } answers {
-            PensjonsgivendeInntektResponse(firstArg(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
-        }
+        val id = setupMocksMedNæringsinntekt(100_000)
         val toÅrTilbakeITid = YearMonth.of(LocalDate.now().year - 2, LocalDate.now().month).atDay(1)
         val sluttenAvNesteMåned = YearMonth.now().plusMonths(1).atEndOfMonth()
-        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, toÅrTilbakeITid, sluttenAvNesteMåned, personIdent, behandlingIds[3], 100_000, 0, 494))
-        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, toÅrTilbakeITid, sluttenAvNesteMåned, id.toString(), behandlingIds[3], 100_000, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = id.toString(), startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(kafkaMeldingSlot.isCaptured).isTrue
-            assertThat(oppdaterOppgaveSlot.isCaptured).isTrue
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.UENDRET_INNTEKT)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(toÅrTilbakeITid.year, id)
+        assertThat(kafkaMeldingSlot.isCaptured).isTrue
+        assertThat(oppdaterOppgaveSlot.isCaptured).isTrue
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.UENDRET_INNTEKT)
     }
 
     @Test
     fun `Bruker har under 4 mnd med overgangsstønad for fjoråret, og skal dermed ikke kontrolleres`() {
-        lagreTestdataForPersonIdent(personIdent)
+        val id = setupMocksMedNæringsinntekt(90_000)
         val fom = LocalDate.of(YearMonth.now().year - 1, 5, 1)
         val tom = LocalDate.of(YearMonth.now().year - 1, 6, 30)
-        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, personIdent, behandlingIds[3], 75200, 0, 494))
-        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, id.toString(), behandlingIds[3], 75200, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = id.toString(), startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
 
-        kjørSomLeader {
-            assertThat(kafkaMeldingSlot.isCaptured).isFalse()
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.KONTROLLERES_IKKE)
-        }
+        assertThat(kafkaMeldingSlot.isCaptured).isFalse()
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, id)
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.KONTROLLERES_IKKE)
     }
 
     @Test
     fun `Bruker har under 4 mnd med overgangsstønad for dette året, og skal ikke ha fremleggsoppgave`() {
-        lagreTestdataForPersonIdent(personIdent)
+        val id = setupMocksMedNæringsinntekt(90_000)
         val fom = LocalDate.of(YearMonth.now().year, 5, 1)
         val tom = LocalDate.of(YearMonth.now().year, 6, 30)
-        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, personIdent, behandlingIds[3], 75200, 0, 494))
-        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, id.toString(), behandlingIds[3], 75200, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = id.toString(), startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(oppgaveRepository.findAll()).isEmpty()
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.KONTROLLERES_IKKE)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, id)
+        assertThat(oppgaveRepository.findAll()).isEmpty()
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.KONTROLLERES_IKKE)
     }
 
     @Test
     fun `Bruker oppfyller ikke aktivitetskravet og det skal dermed bes om regnskap med varsel til bruker`() {
-        lagreTestdataForPersonIdent(personIdent)
-        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, 0, 0)
-        every { sigrunClient.hentPensjonsgivendeInntekt(any(), any()) } answers {
-            PensjonsgivendeInntektResponse(firstArg(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
-        }
+        val id = setupMocksMedNæringsinntekt()
         val fom = LocalDate.of(YearMonth.now().year - 1, 5, 1)
         val tom = LocalDate.of(YearMonth.now().year - 1, 9, 30)
-        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, personIdent, behandlingIds[3], 0, 0, 494))
-        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
+        val andelTilkjentYtelse = (lagAndelTilkjentYtelse(22761, fom, tom, id.toString(), behandlingIds[3], 0, 0, 494))
+        val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = listOf(andelTilkjentYtelse), behandlingId = behandlingIds[3], personident = id.toString(), startdato = LocalDate.of(2022, 9, 1), grunnbeløpsmåned = YearMonth.of(2024, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
 
-        kjørSomLeader {
-            næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, 9)
-            assertThat(kafkaMeldingSlot.captured).contains("regnskap")
-            assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.OPPFYLLER_IKKE_AKTIVITETSPLIKT)
-        }
+        næringsinntektKontrollService.kontrollerInntektForSelvstendigNæringsdrivende(2023, id)
+        assertThat(kafkaMeldingSlot.captured).contains("regnskap")
+        assertThat(næringsinntektKontrollRepository.findAll().first().utfall).isEqualTo(NæringsinntektKontrollUtfall.OPPFYLLER_IKKE_AKTIVITETSPLIKT)
     }
 
     @Test
     fun `Påminnelse om testing av selvstendig næringsdrivende (se favrokort NAV-24146)`() {
         assertThat(LocalDate.now()).isBefore(LocalDate.of(2025, 10, 2))
     }
+
+    fun setupMocksMedNæringsinntekt(næringsinntekt: Int = 0): Long {
+        val id = Math.random().toLong()
+        lagreTestdataForPersonIdent(id.toString())
+        every { oppgaveClient.hentOppgaver(finnOppgaveRequest) } returns FinnOppgaveResponseDto(1, listOf(lagEksternTestOppgave(id)))
+        every { oppgaveClient.oppdaterOppgave(capture(oppdaterOppgaveSlot)) } returns id
+        every { oppgaveClient.finnOppgaveMedId(id) } returns lagEksternTestOppgave(id)
+        val pensjonsgivendeInntektForSkatteordning = PensjonsgivendeInntektForSkatteordning(Skatteordning.FASTLAND, LocalDate.now(), 0, 0, næringsinntekt, 0)
+        every { sigrunClient.hentPensjonsgivendeInntekt(id.toString(), any()) } answers {
+            PensjonsgivendeInntektResponse(id.toString(), secondArg(), listOf(pensjonsgivendeInntektForSkatteordning))
+        }
+        every { inntektClientMock.inntektClient().hentInntekt(id.toString(), any(), any()) } returns lagInntektResponseFraMånedsinntekter(listOf(0))
+        return id
+    }
+
+    val vedtaksperiodeJsonList =
+        listOf(
+            """[{"datoFra":"${LocalDate.now().year - 2}-09-01","datoTil":"${LocalDate.now().year - 1}-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE"}]""",
+            """[{"datoFra":"${LocalDate.now().year - 1}-02-01","datoTil":"${LocalDate.now().year - 1}-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE","sanksjonsårsak":null}]""",
+            """[{"datoFra":"${LocalDate.now().year - 1}-08-01","datoTil":"${LocalDate.now().year}-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
+            """[{"datoFra":"${LocalDate.now().year}-05-01","datoTil":"${LocalDate.now().year}-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
+        )
+
+    val inntektsperiodeJsonList =
+        listOf(
+            """[{"startDato":"${LocalDate.now().year - 2}-09-01","sluttDato":"+999999999-12-31","inntekt":146000,"samordningsfradrag":0}]""",
+            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-02","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":96000,"samordningsfradrag":0}]""",
+            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-08","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":72000,"samordningsfradrag":0}]""",
+            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-05","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":75200,"samordningsfradrag":0}]""",
+        )
 
     private fun lagreTestdataForPersonIdent(personIdent: String) {
         val fagsakTilknyttetPersonIdent = fagsak(setOf(PersonIdent(personIdent)))
@@ -258,20 +254,4 @@ internal class NæringsinntektKontrollServiceTest : OppslagSpringRunnerTest() {
         val tilkjentYtelse = lagTilkjentYtelse(andelerTilkjentYtelse = andelerTilkjentYtelse, behandlingId = behandlingIds[3], personident = personIdent, startdato = LocalDate.of(LocalDate.now().year - 2, 9, 1), grunnbeløpsmåned = YearMonth.of(LocalDate.now().year, 5))
         tilkjentYtelseRepository.insert(tilkjentYtelse)
     }
-
-    val vedtaksperiodeJsonList =
-        listOf(
-            """[{"datoFra":"${LocalDate.now().year - 2}-09-01","datoTil":"${LocalDate.now().year - 1}-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE"}]""",
-            """[{"datoFra":"${LocalDate.now().year - 1}-02-01","datoTil":"${LocalDate.now().year - 1}-07-31","aktivitet":"FORSØRGER_I_ARBEID","periodeType":"HOVEDPERIODE","sanksjonsårsak":null}]""",
-            """[{"datoFra":"${LocalDate.now().year - 1}-08-01","datoTil":"${LocalDate.now().year}-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
-            """[{"datoFra":"${LocalDate.now().year}-05-01","datoTil":"${LocalDate.now().year}-07-31","aktivitet":"FORLENGELSE_MIDLERTIDIG_SYKDOM","periodeType":"FORLENGELSE","sanksjonsårsak":null}]""",
-        )
-
-    val inntektsperiodeJsonList =
-        listOf(
-            """[{"startDato":"${LocalDate.now().year - 2}-09-01","sluttDato":"+999999999-12-31","inntekt":146000,"samordningsfradrag":0}]""",
-            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-02","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":96000,"samordningsfradrag":0}]""",
-            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-08","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":72000,"samordningsfradrag":0}]""",
-            """[{"startDato":null,"sluttDato":null,"periode":{"fom":"${LocalDate.now().year - 1}-05","tom":"999999999-12"},"dagsats":0,"månedsinntekt":0,"inntekt":75200,"samordningsfradrag":0}]""",
-        )
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/DomainUtil.kt
@@ -572,7 +572,7 @@ fun inntektsperiode(
     år: Int = 2021,
     startDato: LocalDate = LocalDate.of(år, 1, 1),
     sluttDato: LocalDate = LocalDate.of(år, 12, 1),
-    inntekt: BigDecimal = BigDecimal.valueOf(100000),
+    inntekt: BigDecimal = BigDecimal.valueOf(100_000),
     samordningsfradrag: BigDecimal = BigDecimal.valueOf(0),
     dagsats: BigDecimal? = BigDecimal.valueOf(0),
     månedsinntekt: BigDecimal? = null,

--- a/src/test/kotlin/testutil/JsonFilUtil.kt
+++ b/src/test/kotlin/testutil/JsonFilUtil.kt
@@ -1,0 +1,69 @@
+package no.nav.familie.ef.sak.testutil
+
+import com.fasterxml.jackson.databind.JsonNode
+import no.nav.familie.kontrakter.felles.objectMapper
+import java.nio.charset.StandardCharsets
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+
+class JsonFilUtil {
+    companion object {
+        fun lesFil(name: String): String =
+            this::class.java.classLoader
+                .getResource(name)!!
+                .readText(StandardCharsets.UTF_8)
+
+        private val ymFormatter = DateTimeFormatter.ofPattern("uuuu-MM")
+
+        fun oppdaterMåneder(
+            json: String,
+            windowMonths: Long = 6,
+        ): String {
+            // 1) Finn alle YearMonth-forekomster i JSON-tekstfelter
+            val months = mutableListOf<YearMonth>()
+            runCatching { objectMapper.readTree(json) }
+                .onSuccess { collectYearMonths(it, months) }
+                .onFailure { return json } // hvis ikke gyldig JSON, gjør ingenting
+
+            if (months.isEmpty()) return json
+
+            // 2) Forankre på største (nyeste) måned i malen
+            val maxInTemplate = months.maxOrNull()!!
+            val delta = ChronoUnit.MONTHS.between(maxInTemplate, YearMonth.now())
+
+            if (delta == 0L) return json // allerede "i rute"
+
+            // 3) Bestem hvilke måneder vi faktisk skal flytte (max, max-1, ..., max-window)
+            val toShift: List<YearMonth> = (0..windowMonths).map { maxInTemplate.minusMonths(it) }
+
+            // 4) Ren streng-replace i synkende rekkefølge for å unngå kjedereplassering
+            var out = json
+            toShift.sortedDescending().forEach { ym ->
+                val from = ym.format(ymFormatter)
+                val to = ym.plusMonths(delta).format(ymFormatter)
+                out = out.replace(from, to)
+            }
+            return out
+        }
+
+        private fun collectYearMonths(
+            node: JsonNode,
+            out: MutableList<YearMonth>,
+        ) {
+            when {
+                node.isTextual -> {
+                    val text = node.textValue()
+                    try {
+                        out += YearMonth.parse(text, ymFormatter)
+                    } catch (_: DateTimeParseException) {
+                        // ikke en yyyy-MM tekstverdi; ignorer
+                    }
+                }
+                node.isArray -> node.forEach { collectYearMonths(it, out) }
+                node.isObject -> node.fields().forEachRemaining { (_, v) -> collectYearMonths(v, out) }
+            }
+        }
+    }
+}

--- a/src/test/resources/json/inntekt/InntektResponseØktInntektSamtidigMedGOmregning.json
+++ b/src/test/resources/json/inntekt/InntektResponseØktInntektSamtidigMedGOmregning.json
@@ -1,0 +1,408 @@
+{
+  "data": [
+    {
+      "maaned": "2025-02",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-02-06T07:37:29.883Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 9740.99,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 42,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -876.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-02",
+      "opplysningspliktig": "995599550",
+      "underenhet": "995599550",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-02-20T17:05:53.873Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 23255.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -2092.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-04",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-04-08T06:21:23.459Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 682.62,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 3,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -61.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-04",
+      "opplysningspliktig": "995599550",
+      "underenhet": "995599550",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-04-29T04:36:00.454Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 23255.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": {
+            "type": "Etterbetalingsperiode"
+          },
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 23255.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -4184.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-05",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-05-08T07:34:30.087Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 9329.14,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 41,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -839.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-05",
+      "opplysningspliktig": "995599550",
+      "underenhet": "995599550",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-05-20T17:21:24.299Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 23255.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -2092.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-06",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-06-06T07:32:01.55Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 11629.57,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 51,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -1046.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-06",
+      "opplysningspliktig": "995599550",
+      "underenhet": "995599550",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-06-21T01:59:58.921Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 4181.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "ferietilleggDagpengerVedArbeidsloeshet",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 1150.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": {
+            "type": "Etterbetalingsperiode"
+          },
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        },
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 24405.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -103.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-07",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-07-08T10:50:03.699Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 12232.25,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 52,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -1100.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-07",
+      "opplysningspliktig": "995599550",
+      "underenhet": "995599550",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-07-21T15:32:18.861Z",
+      "inntektListe": [
+        {
+          "type": "YtelseFraOffentlige",
+          "beloep": 24405.0,
+          "fordel": "kontantytelse",
+          "beskrivelse": "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": false,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": null,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -2196.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    },
+    {
+      "maaned": "2025-08",
+      "opplysningspliktig": "999999998",
+      "underenhet": "999999997",
+      "norskident": "01010199999",
+      "oppsummeringstidspunkt": "2025-08-06T12:13:06.267Z",
+      "inntektListe": [
+        {
+          "type": "Loennsinntekt",
+          "beloep": 8773.27,
+          "fordel": "kontantytelse",
+          "beskrivelse": "timeloenn",
+          "inngaarIGrunnlagForTrekk": true,
+          "utloeserArbeidsgiveravgift": true,
+          "skatteOgAvgiftsregel": null,
+          "opptjeningsperiodeFom": null,
+          "opptjeningsperiodeTom": null,
+          "tilleggsinformasjon": null,
+          "manuellVurdering": false,
+          "antall": 37,
+          "skattemessigBosattLand": null,
+          "opptjeningsland": null
+        }
+      ],
+      "forskuddstrekkListe": [
+        {
+          "beloep": -789.0,
+          "beskrivelse": "ordinaert"
+        }
+      ],
+      "avvikListe": []
+    }
+  ]
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Feil oppdaget i prod ved forrige kjøring. Setter dato riktig i tilfeller hvor det er g-omregning i samme måned som første måned bruker har 10% inntektsøkning.

Fikk en del problemer med mocking av inntekt-kall, hvor det feilet ved bygging, men ikke når tester kjørte isolert. Det er derfor en del endringer i mocking og tester generelt som er relatert til inntekt. Forhåpentligvis vil ikke andre få samme problem som meg fremover ved bygging som følge av at mocking nå spesifikt gjøres i test, og at det ikke lenger skal mockes så mye generelt som skal gjelde på tvers av tester.