### PR TITLE
Midlertidig nedgradering av surefire-versjon for at maven skal rapportere byggfeil dersom en cucumber-test feiler.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Feilen i nyeste versjon av surefire er diskutert her: https://github.com/cucumber/cucumber-jvm/issues/2984