### PR TITLE
Forbedring av beregning av forventet inntekt

### DIFF
--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
 import no.nav.familie.ef.sak.vedtak.domain.PeriodeWrapper
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
+import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
@@ -28,7 +29,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.verify
 import java.time.YearMonth
 import java.util.UUID
 
@@ -115,26 +115,28 @@ class AutomatiskRevurderingServiceTest {
     @Test
     fun `skal fjerne ef overgangstønad og beregne forventet inntekt hvor den filtrerer bort ugyldige måneder`() {
         val inntekterSisteTreMånederOvergangsstønad = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(16000.0, InntektType.YTELSE_FRA_OFFENTLIGE, "overgangsstoenadTilEnsligMorEllerFarSomBegynteAaLoepe1April2014EllerSenere")))
-        val inntekterSisteTreMånederFastlønn = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(5000.0)))
-        val inntekterSisteTreMånederFastlønn2 = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(1000.0)))
+        val inntekterSisteTreMånederFastlønn = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(15000.0)))
+        val inntekterSisteTreMånederFastlønn2 = inntektsmåneder(YearMonth.now().minusMonths(3), YearMonth.now().plusMonths(1), inntektListe = listOf(inntekt(10000.0)))
         val inntekterFraSeksMånederTilTreMånederSidenFastlønn = inntektsmåneder(YearMonth.now().minusMonths(6), inntektListe = listOf(inntekt(1400.0))).take(3)
 
         val inntekter = inntekterSisteTreMånederOvergangsstønad + inntekterSisteTreMånederFastlønn + inntekterSisteTreMånederFastlønn2 + inntekterFraSeksMånederTilTreMånederSidenFastlønn
         val inntektResponse = InntektResponse(inntekter)
 
         val inntekterUtenOvergangsstønad = inntektResponse.inntektsmånederFraOgMedÅrMåned(YearMonth.now().minusMonths(6))
-        val forventetInntekt = inntektResponse.forventetMånedsinntekt()
+        val forrigeVedtak = vedtak(UUID.randomUUID(), Månedsperiode(YearMonth.now().minusMonths(10), YearMonth.now().plusMonths(10)))
+        val forventetInntekt = inntektResponse.forventetMånedsinntekt(forrigeVedtak)
 
         assertThat(inntekterUtenOvergangsstønad.size).isEqualTo(15)
-        assertThat(forventetInntekt).isEqualTo(6000)
+        assertThat(forventetInntekt).isEqualTo(25000)
     }
 
     @Test
     fun `beregn forventetMånedsinntekt`() {
-        val inntekterSisteTreMåneder = inntektsmåneder(YearMonth.now().minusMonths(3), inntektListe = listOf(inntekt(2000.0))).take(3)
+        val inntekterSisteTreMåneder = inntektsmåneder(YearMonth.now().minusMonths(3), inntektListe = listOf(inntekt(20000.0))).take(3)
 
         val inntektResponse = InntektResponse(inntekterSisteTreMåneder)
 
-        assertThat(inntektResponse.forventetMånedsinntekt()).isEqualTo(2000)
+        val forrigeVedtak = vedtak(UUID.randomUUID(), Månedsperiode(YearMonth.now().minusMonths(10), YearMonth.now().plusMonths(10)))
+        assertThat(inntektResponse.forventetMånedsinntekt(forrigeVedtak)).isEqualTo(20000)
     }
 }


### PR DESCRIPTION
Dersom det er økning i inntekt 3 måneder tilbake, skal ikke den måneden tas med i beregning av forventet inntekt, altså ikke være med i snitt-beregningen. Vedtaket vil gjelde fra måneden etter, og det vil derfor bli feil å ta med måneden i beregningen. Revurderes fradato vil være måneden etter, og det skal derfor beregnes forventet inntekt for to siste måneder i stedet for tre siste måneder.

[Samlekort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-26164)