### PR TITLE
Ikke automatisk revurder personer med nylig avsluttet arbeidsforhold

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.behandling.revurdering
 
 import no.nav.familie.ef.sak.amelding.InntektResponse
 import no.nav.familie.ef.sak.amelding.ekstern.AMeldingInntektClient
+import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdService
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.oppgave.OppgaveService
@@ -32,6 +33,7 @@ class AutomatiskRevurderingService(
     private val grunnlagsdataInntektRepository: GrunnlagsdataInntektRepository,
     private val vedtakService: VedtakService,
     private val environment: Environment,
+    private val arbeidsforholdService: ArbeidsforholdService
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
@@ -55,6 +57,11 @@ class AutomatiskRevurderingService(
 
         if (behandlingService.finnesÅpenBehandling(fagsak.id)) {
             logger.info("Finnes åpen behandling for fagsak ${fagsak.id}")
+            return false
+        }
+
+        if ( arbeidsforholdService.finnesAvsluttetArbeidsforholdSisteAntallMåneder(personIdent,4)){
+            logger.info("Finnes arbeidsforhold for fagsak ${fagsak.id}")
             return false
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -53,7 +53,6 @@ class BehandleAutomatiskInntektsendringTask(
     private val årsakRevurderingsRepository: ÅrsakRevurderingsRepository,
     private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val featureToggleService: FeatureToggleService,
-    private val arbeidsforholdClient: ArbeidsforholdClient,
 ) : AsyncTaskStep {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingEtterGOmregningTest.kt
@@ -93,7 +93,6 @@ class AutomatiskRevurderingEtterGOmregningTest : OppslagSpringRunnerTest() {
                 årsakRevurderingsRepository = årsakRevurderingsRepository,
                 automatiskRevurderingService = automatiskRevurderingService,
                 featureToggleService = featureToggleService,
-                arbeidsforholdClient = arbeidsforholdClient,
             )
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingServiceTest.kt
@@ -28,7 +28,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.verify
 import java.time.YearMonth
 import java.util.UUID
 
@@ -36,7 +35,7 @@ class AutomatiskRevurderingServiceTest {
     val behandlingServiceMock = mockk<BehandlingService>(relaxed = true)
     val oppgaveServiceMock = mockk<OppgaveService>(relaxed = true)
     val vedtakServiceMock = mockk<VedtakService>(relaxed = true)
-    val automatiskRevurderingService = AutomatiskRevurderingService(mockk(relaxed = true), mockk(relaxed = true), behandlingServiceMock, oppgaveServiceMock, mockk(relaxed = true), mockk(relaxed = true), vedtakServiceMock, mockk(relaxed = true))
+    val automatiskRevurderingService = AutomatiskRevurderingService(mockk(relaxed = true), mockk(relaxed = true), behandlingServiceMock, oppgaveServiceMock, mockk(relaxed = true), mockk(relaxed = true), vedtakServiceMock, mockk(relaxed = true), mockk(relaxed = true))
 
     @Test
     fun `person med behandling som kan automatisk revurderes`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTaskTest.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.amelding.InntektResponse
 import no.nav.familie.ef.sak.arbeidsforhold.ArbeidsforholdClientTest.Companion.arbeidsforholdClient
 import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdClient
+import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdService
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
@@ -51,7 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
 import java.time.YearMonth
 
-class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
+class BehandleAutomatiskInntektsendringTaskTest() : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var behandlingRepository: BehandlingRepository
 
@@ -88,9 +89,6 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var inntektClientMock: InntektClientMock
 
-    @Autowired
-    private lateinit var arbeidsforholdClient: ArbeidsforholdClient
-
     private val personIdent = "3"
     private val fagsak = fagsak(identer = fagsakpersoner(setOf(personIdent)))
 
@@ -108,7 +106,6 @@ class BehandleAutomatiskInntektsendringTaskTest : OppslagSpringRunnerTest() {
                 årsakRevurderingsRepository = årsakRevurderingsRepository,
                 automatiskRevurderingService = automatiskRevurderingService,
                 featureToggleService = featureToggleService,
-                arbeidsforholdClient = arbeidsforholdClient,
             )
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Lagt til sjekk for om person har nylig avsluttet arbeidsforhold. Ogsså litt divers opprydning ettersom arbeidsforhold service hadde blitt lagt til med en feil til BehandleAutomatiskInntektsendringTask

