### PR TITLE
Migrere fra SecureLogs til Team Logs med generell logger

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/arbeidsforhold/LoggArbeidsforholdForPersonTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/arbeidsforhold/LoggArbeidsforholdForPersonTask.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.arbeidsforhold
 
 import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
@@ -18,12 +18,14 @@ import java.util.Properties
 class LoggArbeidsforholdForPersonTask(
     private val arbeidsforholdClient: ArbeidsforholdClient,
 ) : AsyncTaskStep {
+    private val logger = Logg.getLogger(this::class)
+
     override fun doTask(task: Task) {
         val personIdent = task.payload
-        secureLogger.info("Logg arbeidsforhold for person $personIdent")
+        logger.info("Logg arbeidsforhold for person $personIdent")
         val arbeidsforhold = arbeidsforholdClient.hentArbeidsforhold(personIdent)
         arbeidsforhold.forEach { arbeidsforhold ->
-            secureLogger.info("Arbeidsforhold for person $personIdent: $arbeidsforhold")
+            logger.info("Arbeidsforhold for person $personIdent: $arbeidsforhold")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/avstemming/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/avstemming/AvstemmingService.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ef.sak.avstemming
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.kontrakter.ef.iverksett.AndelTilkjentYtelseDto
 import no.nav.familie.kontrakter.ef.iverksett.KonsistensavstemmingDto
 import no.nav.familie.kontrakter.ef.iverksett.KonsistensavstemmingTilkjentYtelseDto
 import no.nav.familie.kontrakter.felles.ef.StønadType
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
@@ -16,7 +16,7 @@ class AvstemmingService(
     private val iverksettClient: IverksettClient,
     private val tilkjentYtelseService: TilkjentYtelseService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun konsistensavstemOppdrag(
         stønadstype: StønadType,

--- a/src/main/kotlin/no/nav/familie/ef/sak/avstemming/KonsistensavstemmingScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/avstemming/KonsistensavstemmingScheduler.kt
@@ -2,12 +2,12 @@ package no.nav.familie.ef.sak.avstemming
 
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingPayload
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingTask
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.prosessering.util.isOptimisticLocking
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.Version
@@ -23,7 +23,7 @@ import kotlin.random.Random
 class KonsistensavstemmingScheduler(
     private val konsistensavstemmingService: KonsistensavstemmingService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Scheduled(cron = "0 0 0/12 * * *")
     fun opprettTasks() {
@@ -45,7 +45,7 @@ class KonsistensavstemmingService(
     private val repository: KonsistensavstemmingJobbRepository,
     private val taskService: TaskService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(KonsistensavstemmingService::class)
 
     @Transactional
     fun opprettTasks() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingPåVentService.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveSubtype
@@ -25,8 +26,6 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -43,7 +42,7 @@ class BehandlingPåVentService(
     private val oppgaveService: OppgaveService,
     private val tilordnetRessursService: TilordnetRessursService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun settPåVent(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingService.kt
@@ -26,6 +26,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.minside.AktiverMikrofrontendTask
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
@@ -36,7 +37,6 @@ import no.nav.familie.kontrakter.ef.iverksett.BehandlingKategori
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -53,7 +53,7 @@ class BehandlingService(
     private val featureToggleService: FeatureToggleService,
     private val tilordnetRessursService: TilordnetRessursService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun hentAktivIdent(behandlingId: UUID): String = behandlingRepository.finnAktivIdent(behandlingId)
 
@@ -171,7 +171,7 @@ class BehandlingService(
         status: BehandlingStatus,
     ): Behandling {
         val behandling = hentBehandling(behandlingId)
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer status på behandling $behandlingId " +
                 "fra ${behandling.status} til $status",
         )
@@ -183,7 +183,7 @@ class BehandlingService(
         kategori: BehandlingKategori,
     ): Behandling {
         val behandling = hentBehandling(behandlingId)
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer kategori på behandling $behandlingId " +
                 "fra ${behandling.kategori} til $kategori",
         )
@@ -198,7 +198,7 @@ class BehandlingService(
         feilHvis(behandling.status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke endre forrigeBehandlingId når behandlingen er låst"
         }
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer forrigeBehandlingId på behandling $behandlingId " +
                 "fra ${behandling.forrigeBehandlingId} til $forrigeBehandlingId",
         )
@@ -210,7 +210,7 @@ class BehandlingService(
         steg: StegType,
     ): Behandling {
         val behandling = hentBehandling(behandlingId)
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} endrer steg på behandling $behandlingId " +
                 "fra ${behandling.steg} til $steg",
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/NyeBarnService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.behandling.migrering.OpprettOppgaveForMigrertFødtB
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
 import no.nav.familie.ef.sak.opplysninger.mapper.MatchetBehandlingBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
@@ -20,8 +21,6 @@ import no.nav.familie.kontrakter.ef.personhendelse.NyttBarnÅrsak
 import no.nav.familie.kontrakter.felles.PersonIdent
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.relational.core.conversion.DbActionExecutionException
 import org.springframework.stereotype.Service
@@ -36,7 +35,7 @@ class NyeBarnService(
     private val barnService: BarnService,
     private val taskService: TaskService,
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun finnNyeEllerUtenforTerminFødteBarn(personIdent: PersonIdent): NyeBarnDto {
         val personIdenter = personService.hentPersonIdenter(personIdent.ident).identer()

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/FinnBehandlingerMedGammelGTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/FinnBehandlingerMedGammelGTask.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ef.sak.behandling.grunnbelop
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -21,7 +21,7 @@ class FinnBehandlingerMedGammelGTask(
     val behandlingRepository: BehandlingRepository,
     val tilkjentYtelseService: TilkjentYtelseService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     private val uaktuelleBehandlinger = listOf("4d4de67b-f87b-4b6b-8524-aa92b3ebb870")
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTask.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.behandling.grunnbelop
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.OmregningService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
@@ -11,8 +12,6 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -32,7 +31,7 @@ class GOmregningTask(
     private val omregningService: OmregningService,
     private val taskService: TaskService,
 ) : AsyncTaskStep {
-    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val fagsakId = objectMapper.readValue<GOmregningPayload>(task.payload).fagsakId

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/GOmregningTaskService.kt
@@ -4,8 +4,7 @@ import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder.nyesteGrunnbeløpGyl
 import no.nav.familie.ef.sak.fagsak.FagsakRepository
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import org.springframework.context.annotation.Profile
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.relational.core.conversion.DbActionExecutionException
@@ -19,7 +18,7 @@ class GOmregningTaskServiceScheduler(
     private val gOmregningTaskService: GOmregningTaskService,
     private val featureToggleService: FeatureToggleService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(this::class)
 
     @Scheduled(cron = "\${G_OMREGNING_CRON_EXPRESSION}")
     fun opprettGOmregningTaskForBehandlingerMedUtdatertG() {
@@ -35,7 +34,7 @@ class GOmregningTaskService(
     private val gOmregningTask: GOmregningTask,
     private val featureToggleService: FeatureToggleService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(javaClass.kotlin)
 
     fun opprettGOmregningTaskForBehandlingerMedUtdatertG(): Int {
         logger.info("Starter opprettelse av tasker for G-omregning.")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/AutomatiskMigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/AutomatiskMigreringService.kt
@@ -1,14 +1,12 @@
 package no.nav.familie.ef.sak.behandling.migrering
 
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -20,7 +18,7 @@ class AutomatiskMigreringService(
     private val infotrygdReplikaClient: InfotrygdReplikaClient,
     private val taskService: TaskService,
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun migrerAutomatisk(antall: Int) {
@@ -56,16 +54,16 @@ class AutomatiskMigreringService(
     fun migrerPersonAutomatisk(personIdent: String) {
         val migreringStatus = migreringsstatusRepository.findByIdOrThrow(personIdent)
         if (migreringStatus.status == MigreringResultat.OK) {
-            secureLogger.info("Allerede migrert")
+            logger.info("Allerede migrert")
             return
         }
         try {
-            secureLogger.info("Automatisk migrering av ident=$personIdent")
+            logger.info("Automatisk migrering av ident=$personIdent")
             migreringService.migrerOvergangsstønadAutomatisk(personIdent)
             migreringsstatusRepository.update(migreringStatus.copy(status = MigreringResultat.OK, årsak = null))
-            secureLogger.info("Automatisk migrering av ident=$personIdent utført=OK")
+            logger.info("Automatisk migrering av ident=$personIdent utført=OK")
         } catch (e: MigreringException) {
-            secureLogger.warn("Kan ikke migrere ident=$personIdent årsak=${e.type} msg=${e.årsak}")
+            logger.warn("Kan ikke migrere ident=$personIdent årsak=${e.type} msg=${e.årsak}")
             migreringsstatusRepository.update(migreringStatus.copy(status = MigreringResultat.FEILET, årsak = e.type))
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -255,7 +255,7 @@ class InfotrygdPeriodeValideringService(
         personIdent: String,
     ) {
         perioder.perioder.find { it.personIdent != personIdent }?.let {
-            logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd")
+            logger.vanligWarn("Det finnes perioder med ulike fødselsnummer i infotrygd")
             logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
         }
     }
@@ -265,7 +265,7 @@ class InfotrygdPeriodeValideringService(
         personIdent: String,
     ) {
         sakerForOvergangsstønad.find { it.personIdent != personIdent }?.let {
-            logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd")
+            logger.vanligWarn("Det finnes perioder med ulike fødselsnummer i infotrygd")
             logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/InfotrygdPeriodeValideringService.kt
@@ -9,12 +9,12 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdAktivitetstype.TILMELDT_SOM_REELL_ARBEIDSSØKER
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSak
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResultat
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakType
 import no.nav.familie.kontrakter.felles.ef.StønadType
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -26,8 +26,7 @@ class InfotrygdPeriodeValideringService(
     private val behandlingService: BehandlingService,
     private val featureToggleService: FeatureToggleService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun validerKanOppretteBehandlingGittInfotrygdData(fagsak: Fagsak) {
         if (!behandlingService.finnesBehandlingForFagsak(fagsak.id)) {
@@ -257,7 +256,7 @@ class InfotrygdPeriodeValideringService(
     ) {
         perioder.perioder.find { it.personIdent != personIdent }?.let {
             logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd")
-            secureLogger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
+            logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
         }
     }
 
@@ -267,7 +266,7 @@ class InfotrygdPeriodeValideringService(
     ) {
         sakerForOvergangsstønad.find { it.personIdent != personIdent }?.let {
             logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd")
-            secureLogger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
+            logger.warn("Det finnes perioder med ulike fødselsnummer i infotrygd - fnrInfotrygd=${it.personIdent} fnrGjeldende=$personIdent ")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
@@ -92,7 +92,7 @@ class MigreringService(
                 val fagsakPerson = fagsakPersonService.hentPerson(fagsakPersonId)
                 hentGjeldendePeriodeOgValiderState(fagsakPerson, StønadType.OVERGANGSSTØNAD, kjøremåned)
             } catch (e: MigreringException) {
-                logger.info("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
+                logger.vanligInfo("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
                 logger.info("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
                 return MigreringInfo(
                     kanMigreres = false,
@@ -135,7 +135,7 @@ class MigreringService(
                 ignorerFeilISimulering = request.ignorerFeilISimulering,
             )
         } catch (e: MigreringException) {
-            logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
+            logger.vanligWarn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
             logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
             throw ApiFeil(e.årsak, HttpStatus.BAD_REQUEST)
         }
@@ -159,7 +159,7 @@ class MigreringService(
                 ignorerFeilISimulering = request.ignorerFeilISimulering,
             )
         } catch (e: MigreringException) {
-            logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
+            logger.vanligWarn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
             logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
             throw ApiFeil(e.årsak, HttpStatus.BAD_REQUEST)
         }
@@ -403,7 +403,7 @@ class MigreringService(
                 "sistePeriodenTom=$overførtNyLøsningOpphørsdato " +
                 "sisteSummertePeriodeTom=${sisteSummertePerioden.stønadsperiode.tom} " +
                 "opphørsmåned=$opphørsmåned"
-        logger.warn(logMessage)
+        logger.vanligWarn(logMessage)
         val periodeInformasjon =
             perioder.perioder
                 .sortedWith(compareBy<InfotrygdPeriode>({ it.stønadId }, { it.vedtakId }, { it.stønadFom }).reversed())

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/MigreringService.kt
@@ -28,6 +28,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.iverksett.IverksettingDtoMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
@@ -54,7 +55,6 @@ import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
 import no.nav.familie.kontrakter.felles.simulering.BetalingType
 import no.nav.familie.kontrakter.felles.simulering.PosteringType
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -81,8 +81,7 @@ class MigreringService(
     private val infotrygdPeriodeValideringService: InfotrygdPeriodeValideringService,
     private val barnRepository: BarnRepository,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun hentMigreringInfo(
         fagsakPersonId: UUID,
@@ -94,7 +93,7 @@ class MigreringService(
                 hentGjeldendePeriodeOgValiderState(fagsakPerson, StønadType.OVERGANGSSTØNAD, kjøremåned)
             } catch (e: MigreringException) {
                 logger.info("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
-                secureLogger.info("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
+                logger.info("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
                 return MigreringInfo(
                     kanMigreres = false,
                     e.årsak,
@@ -137,7 +136,7 @@ class MigreringService(
             )
         } catch (e: MigreringException) {
             logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
-            secureLogger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
+            logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
             throw ApiFeil(e.årsak, HttpStatus.BAD_REQUEST)
         }
     }
@@ -161,7 +160,7 @@ class MigreringService(
             )
         } catch (e: MigreringException) {
             logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId årsak=${e.type}")
-            secureLogger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
+            logger.warn("Kan ikke migrere fagsakPerson=$fagsakPersonId - ${e.årsak}")
             throw ApiFeil(e.årsak, HttpStatus.BAD_REQUEST)
         }
     }
@@ -178,7 +177,7 @@ class MigreringService(
         val fagsak = fagsakService.hentEllerOpprettFagsak(personIdent, stønadType)
         val periode = hentGjeldendePeriodeOgValiderState(fagsakPerson, stønadType, kjøremåned)
         if (kunAktivStønad && YearMonth.now() > periode.stønadsperiode.tom) {
-            secureLogger.info("Har ikke aktiv stønad $periode")
+            logger.info("Har ikke aktiv stønad $periode")
             throw MigreringException(
                 "Har ikke aktiv stønad (${periode.stønadsperiode.tom})",
                 MigreringExceptionType.INGEN_AKTIV_STØNAD,
@@ -412,7 +411,7 @@ class MigreringService(
                     "InfotrygdPeriode(stønadId=${it.stønadId}, vedtakId=${it.vedtakId}, kode=${it.kode}, " +
                         "stønadFom=${it.stønadFom}, stønadTom=${it.stønadTom}, opphørsdato=${it.opphørsdato})"
                 }
-        secureLogger.info("$logMessage $periodeInformasjon")
+        logger.info("$logMessage $periodeInformasjon")
     }
 
     private fun hentGjeldendePeriodeOgValiderState(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/OpprettOppgaveForMigrertFødtBarnTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/migrering/OpprettOppgaveForMigrertFødtBarnTask.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.behandling.migrering
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.AktivitetspliktigAlder
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.OpprettOppfølgingsoppgaveForBarnFyltÅrTask
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.OpprettOppgavePayload
@@ -17,8 +18,6 @@ import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.util.VirkedagerProvider.nesteVirkedag
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.UUID
@@ -37,7 +36,7 @@ class OpprettOppgaveForMigrertFødtBarnTask(
     private val grunnlagsdataService: GrunnlagsdataService,
     private val taskService: TaskService,
 ) : AsyncTaskStep {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val data = objectMapper.readValue<OpprettOppgaveForMigrertFødtBarnTaskData>(task.payload)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/oppgavekontroll/BehandlingsoppgaveService.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ef.sak.behandling.oppgavekontroll
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -21,7 +21,7 @@ class BehandlingsoppgaveService(
     val fagsakService: FagsakService,
     val oppgaveService: OppgaveService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun opprettTask() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -49,7 +49,7 @@ class AutomatiskRevurderingService(
             }
 
         if (inntektForAlleÅr.harNæringsinntekt()) {
-            logger.info("Har næringsinntekt for fagsak ${fagsak.id}")
+            logger.vanligInfo("Har næringsinntekt for fagsak ${fagsak.id}")
             logger.info("Har næringsinntekt for fagsak ${fagsak.id} - InntektResponse: $inntektForAlleÅr")
             return false
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/AutomatiskRevurderingService.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.sak.amelding.ekstern.AMeldingInntektClient
 import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdService
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.GrunnlagsdataInntekt
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.inntekt.GrunnlagsdataInntektRepository
@@ -16,7 +17,6 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
-import org.slf4j.LoggerFactory
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import java.time.YearMonth
@@ -35,8 +35,7 @@ class AutomatiskRevurderingService(
     private val environment: Environment,
     private val arbeidsforholdService: ArbeidsforholdService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun kanAutomatiskRevurderes(personIdent: String): Boolean {
         val fagsak = fagsakService.finnFagsak(setOf(personIdent), StønadType.OVERGANGSSTØNAD) ?: return false
@@ -51,7 +50,7 @@ class AutomatiskRevurderingService(
 
         if (inntektForAlleÅr.harNæringsinntekt()) {
             logger.info("Har næringsinntekt for fagsak ${fagsak.id}")
-            secureLogger.info("Har næringsinntekt for fagsak ${fagsak.id} - InntektResponse: $inntektForAlleÅr")
+            logger.info("Har næringsinntekt for fagsak ${fagsak.id} - InntektResponse: $inntektForAlleÅr")
             return false
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -115,7 +115,7 @@ class BehandleAutomatiskInntektsendringTask(
 
         årsakRevurderingsRepository.insert(ÅrsakRevurdering(behandlingId = behandling.id, opplysningskilde = Opplysningskilde.AUTOMATISK_OPPRETTET_BEHANDLING, årsak = Revurderingsårsak.ENDRING_INNTEKT, beskrivelse = null))
         vedtakService.lagreVedtak(vedtakDto = innvilgelseOvergangsstønad, behandlingId = behandling.id, stønadstype = StønadType.OVERGANGSSTØNAD)
-        logger.info("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")
+        logger.vanligInfo("Opprettet behandling for automatisk inntektsendring: ${behandling.id}")
     }
 
     private fun sammenslåVedtak(
@@ -174,10 +174,10 @@ class BehandleAutomatiskInntektsendringTask(
             val forventetInntekt = inntektResponse.forventetMånedsinntekt(forrigeVedtak)
             val perioder = oppdaterFørsteVedtaksperiodeMedRevurderesFraDato(forrigeVedtak, inntektResponse)
             val inntektsperioder = oppdaterInntektMedNyBeregnetForventetInntekt(forrigeVedtak, inntektResponse, perioder.first().periode.fom)
-            logger.info("Ville opprettet inntektsperioder for fagsak eksternId: ${fagsak.eksternId} - nye inntektsperioder: " + inntektsperioder)
-            logger.info("Ville opprettet følgende vedtaksperioder for fagsak eksternId: ${fagsak.eksternId} - nye vedtaksperioder: $perioder med ny forventet månedsinntekt: $forventetInntekt")
+            logger.vanligInfo("Ville opprettet inntektsperioder for fagsak eksternId: ${fagsak.eksternId} - nye inntektsperioder: " + inntektsperioder)
+            logger.vanligInfo("Ville opprettet følgende vedtaksperioder for fagsak eksternId: ${fagsak.eksternId} - nye vedtaksperioder: $perioder med ny forventet månedsinntekt: $forventetInntekt")
         } else {
-            logger.info("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
+            logger.vanligInfo("Fant ikke siste iverksatte behandling for fagsakId: ${fagsak.id}")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/BehandleAutomatiskInntektsendringTask.kt
@@ -15,6 +15,7 @@ import no.nav.familie.ef.sak.felles.util.isEqualOrBefore
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
@@ -30,7 +31,6 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -54,8 +54,7 @@ class BehandleAutomatiskInntektsendringTask(
     private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val toggle = featureToggleService.isEnabled(Toggle.BEHANDLE_AUTOMATISK_INNTEKTSENDRING)
@@ -69,7 +68,7 @@ class BehandleAutomatiskInntektsendringTask(
         if (fagsak == null) {
             throw IllegalStateException("Finner ikke fagsak for personIdent=$personIdent på stønadstype=${StønadType.OVERGANGSSTØNAD} under automatisk inntektsendring")
         }
-        secureLogger.info("Kan opprette automatisk inntektsendringsbehandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak.id}")
+        logger.info("Kan opprette automatisk inntektsendringsbehandling med $personIdent stønadstype=${StønadType.OVERGANGSSTØNAD} faksakId ${fagsak.id}")
 
         if (toggle) {
             opprettAutomatiskRevurderingForInntektsendring(fagsak.id, personIdent)
@@ -160,7 +159,7 @@ class BehandleAutomatiskInntektsendringTask(
     ) {
         val inntektResponse = automatiskRevurderingService.hentInntektResponse(personIdent)
         val inntektPrMåned = inntektResponse.inntektsmåneder.map { LogInntekt(it.måned, it.totalInntekt()) }
-        secureLogger.info("Månedlig inntekt for fagsak eksternId=${fagsak.eksternId} : $inntektPrMåned")
+        logger.info("Månedlig inntekt for fagsak eksternId=${fagsak.eksternId} : $inntektPrMåned")
         val behandling = behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(fagsak.id)
         if (behandling != null) {
             val forrigeBehandling = behandling.forrigeBehandlingId?.let { behandlingService.hentBehandling(it) } ?: throw IllegalStateException("Burde vært en forrigeBehandlingId etter automatisk revurdering for behandlingId: ${behandling.id}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingFraForvaltningTask.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.sak.behandling.revurdering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import kotlin.collections.set
@@ -19,8 +19,7 @@ class OpprettAutomatiskRevurderingFraForvaltningTask(
     private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val revurderingService: RevurderingService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val personIdenter = objectMapper.readValue<PayloadOpprettAutomatiskRevurderingFraForvaltningTask>(task.payload).personIdenter
@@ -29,7 +28,7 @@ class OpprettAutomatiskRevurderingFraForvaltningTask(
                 automatiskRevurderingService.kanAutomatiskRevurderes(personIdent)
             }
 
-        secureLogger.info("Kan revurdere personIdenter: $identerForAutomatiskRevurdering - oppretter task for disse")
+        logger.info("Kan revurdere personIdenter: $identerForAutomatiskRevurdering - oppretter task for disse")
 
         if (identerForAutomatiskRevurdering.isNotEmpty()) {
             revurderingService.opprettAutomatiskInntektsendringTask(identerForAutomatiskRevurdering)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/OpprettAutomatiskRevurderingTask.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.sak.behandling.revurdering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.infrastruktur.config.ObjectMapperProvider.objectMapper
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import kotlin.collections.set
@@ -19,8 +19,7 @@ class OpprettAutomatiskRevurderingTask(
     private val automatiskRevurderingService: AutomatiskRevurderingService,
     private val revurderingService: RevurderingService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val personIdenter = objectMapper.readValue<PayloadOpprettAutomatiskRevurderingTask>(task.payload).personIdenter
@@ -29,7 +28,7 @@ class OpprettAutomatiskRevurderingTask(
                 automatiskRevurderingService.kanAutomatiskRevurderes(personIdent)
             }
 
-        secureLogger.info("Kan revurdere personIdenter: $identerForAutomatiskRevurdering - oppretter task for disse")
+        logger.info("Kan revurdere personIdenter: $identerForAutomatiskRevurdering - oppretter task for disse")
 
         if (identerForAutomatiskRevurdering.isNotEmpty()) {
             revurderingService.opprettAutomatiskInntektsendringTask(identerForAutomatiskRevurdering)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingService.kt
@@ -18,6 +18,7 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.oppgave.OppgaveService
@@ -32,12 +33,9 @@ import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
 import java.time.YearMonth
-import java.time.temporal.IsoFields
 import java.util.UUID
 
 @Service
@@ -58,7 +56,7 @@ class RevurderingService(
     private val tilordnetRessursService: TilordnetRessursService,
     private val oppgaveService: OppgaveService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun hentRevurderingsinformasjon(behandlingId: UUID): RevurderingsinformasjonDto = årsakRevurderingService.hentRevurderingsinformasjon(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -14,6 +14,7 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.min
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingService
@@ -43,7 +44,6 @@ import no.nav.familie.ef.sak.vedtak.historikk.erAktivVedtaksperiode
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.erSammenhengende
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.YearMonth
@@ -65,7 +65,7 @@ class BeregnYtelseSteg(
     private val validerOmregningService: ValiderOmregningService,
     private val oppfølgingsoppgaveService: OppfølgingsoppgaveService,
 ) : BehandlingSteg<VedtakDto> {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
     private val midlertidigOpphørFeilmelding = "Kan ikke starte vedtaket med opphørsperiode for en førstegangsbehandling"
 
     override fun stegType(): StegType = StegType.BEREGNE_YTELSE

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/FerdigstillBehandlingSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/FerdigstillBehandlingSteg.kt
@@ -6,9 +6,8 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
 import no.nav.familie.ef.sak.behandlingsflyt.task.PubliserVedtakshendelseTask
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,7 +15,7 @@ class FerdigstillBehandlingSteg(
     private val behandlingService: BehandlingService,
     private val taskService: TaskService,
 ) : BehandlingSteg<Void?> {
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     override fun utførSteg(
         saksbehandling: Saksbehandling,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SaksbehandlingsblankettSteg.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.behandlingsflyt.task.FerdigstillBehandlingTask
 import no.nav.familie.ef.sak.blankett.BlankettHelper.lagArkiverBlankettRequestMotNyLøsning
 import no.nav.familie.ef.sak.blankett.BlankettService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.journalføring.JournalpostClient
 import no.nav.familie.ef.sak.vedtak.TotrinnskontrollService
 import no.nav.familie.http.client.RessursException
@@ -17,7 +18,6 @@ import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerRequest
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.client.HttpClientErrorException
 
@@ -31,7 +31,7 @@ class SaksbehandlingsblankettSteg(
     private val behandlingService: BehandlingService,
     private val fagsakService: FagsakService,
 ) : BehandlingSteg<Void?> {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun utførSteg(
         saksbehandling: Saksbehandling,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
@@ -23,7 +23,6 @@ import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext.NAVIDENT_REGEX
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingService

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -179,7 +179,7 @@ class StegService(
         val rolleForSteg: BehandlerRolle = utledRolleForSteg(stegType, saksbehandling)
         val harTilgangTilSteg = SikkerhetContext.harTilgangTilGittRolle(rolleConfig, rolleForSteg)
 
-        logger.info("Starter håndtering av $stegType på behandling ${saksbehandling.id}")
+        logger.vanligInfo("Starter håndtering av $stegType på behandling ${saksbehandling.id}")
         logger.info(
             "Starter håndtering av $stegType på behandling " +
                 "${saksbehandling.id} med saksbehandler=[$saksbehandlerIdent]",

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/StegService.kt
@@ -10,12 +10,11 @@ import no.nav.familie.ef.sak.behandlingshistorikk.BehandlingshistorikkService
 import no.nav.familie.ef.sak.behandlingshistorikk.domain.Behandlingshistorikk
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.dto.BeslutteVedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.SendTilBeslutterDto
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -27,8 +26,7 @@ class StegService(
     private val rolleConfig: RolleConfig,
     private val behandlingshistorikkService: BehandlingshistorikkService,
 ) {
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun håndterFerdigstilleVedtakUtenBeslutter(
@@ -182,7 +180,7 @@ class StegService(
         val harTilgangTilSteg = SikkerhetContext.harTilgangTilGittRolle(rolleConfig, rolleForSteg)
 
         logger.info("Starter håndtering av $stegType på behandling ${saksbehandling.id}")
-        secureLogger.info(
+        logger.info(
             "Starter håndtering av $stegType på behandling " +
                 "${saksbehandling.id} med saksbehandler=[$saksbehandlerIdent]",
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveForOpprettetBehandlingTask.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.behandlingsflyt.task
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -12,7 +13,6 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
@@ -29,7 +29,7 @@ class OpprettOppgaveForOpprettetBehandlingTask(
     private val oppgaveService: OppgaveService,
     private val taskService: TaskService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     data class OpprettOppgaveTaskData(
         val behandlingId: UUID,

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/task/OpprettOppgaveTask.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.behandlingsflyt.task
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveSubtype
@@ -11,7 +12,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
@@ -27,7 +27,7 @@ class OpprettOppgaveTask(
     private val oppgaveService: OppgaveService,
     private val behandlingService: BehandlingService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     // Då payload er unik per task type, så settes unik inn
     data class OpprettOppgaveTaskData(

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/OmregningService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.behandlingsflyt.steg.BeregnYtelseSteg
 import no.nav.familie.ef.sak.behandlingsflyt.steg.StegType
 import no.nav.familie.ef.sak.behandlingsflyt.task.PollStatusFraIverksettTask
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.iverksett.IverksettingDtoMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
@@ -23,7 +24,6 @@ import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.slf4j.MarkerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -46,7 +46,7 @@ class OmregningService(
     private val søknadService: SøknadService,
     private val barnService: BarnService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun utførGOmregning(fagsakId: UUID) {
@@ -63,18 +63,12 @@ class OmregningService(
                 YearMonth.from(Grunnbeløpsperioder.nyesteGrunnbeløpGyldigFraOgMed),
             )
         if (innvilgelseOvergangsstønad.perioder.any { it.periodeType == VedtaksperiodeType.SANKSJON }) {
-            logger.warn(
-                MarkerFactory.getMarker("G-Omregning - Manuell"),
-                "Fagsak med id $fagsakId har sanksjon og må manuelt behandles",
-            )
+            logger.warn("G-Omregning - Manuell: Fagsak med id $fagsakId har sanksjon og må manuelt behandles")
             return null
         }
 
         if (innvilgelseOvergangsstønad.inntekter.any { (it.samordningsfradrag ?: BigDecimal.ZERO) > BigDecimal.ZERO }) {
-            logger.warn(
-                MarkerFactory.getMarker("G-Omregning - Manuell"),
-                "Fagsak med id $fagsakId har samordningsfradrag og må behandles manuelt.",
-            )
+            logger.warn("G-Omregning - Manuell: Fagsak med id $fagsakId har samordningsfradrag og må behandles manuelt.")
             return null
         }
         return innvilgelseOvergangsstønad

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringScheduler.kt
@@ -1,6 +1,6 @@
 package no.nav.familie.ef.sak.beregning.barnetilsyn.satsendring
 
-import org.slf4j.LoggerFactory
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service
 class BarnetilsynSatsendringScheduler(
     val barnetilsynSatsendringService: BarnetilsynSatsendringService,
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     // @Scheduled(initialDelay = 60 * 1000L, fixedDelay = 365 * 24 * 60 * 60 * 1000L) // Kjører ved oppstart av app
     fun opprettTask() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/barnetilsyn/satsendring/BarnetilsynSatsendringService.kt
@@ -3,12 +3,12 @@ package no.nav.familie.ef.sak.beregning.barnetilsyn.satsendring
 import no.nav.familie.ef.sak.beregning.barnetilsyn.BeløpsperiodeBarnetilsynDto
 import no.nav.familie.ef.sak.beregning.barnetilsyn.tilBeløpsperioderPerUtgiftsmåned
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.vedtak.dto.PeriodeMedBeløpDto
 import no.nav.familie.ef.sak.vedtak.dto.UtgiftsperiodeDto
 import no.nav.familie.ef.sak.vedtak.historikk.AndelHistorikkDto
 import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.YearMonth
@@ -20,7 +20,7 @@ class BarnetilsynSatsendringService(
     val vedtakHistorikkService: VedtakHistorikkService,
     val taskService: TaskService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun finnFagsakerSomSkalSatsendresMedNySatsDersomBaselineErOk() {
         val barnetilsynGjeldeneAvstemmingsfeil =

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/skolepenger/BeregningSkolepengerService.kt
@@ -9,7 +9,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.dto.SkolepengerUtgiftDto
 import no.nav.familie.ef.sak.vedtak.dto.SkoleårsperiodeSkolepengerDto
@@ -27,6 +27,8 @@ class BeregningSkolepengerService(
     private val behandlingService: BehandlingService,
     private val vedtakService: VedtakService,
 ) {
+    private val logger = Logg.getLogger(this::class)
+
     fun beregnYtelse(
         utgiftsperioder: List<SkoleårsperiodeSkolepengerDto>,
         behandlingId: UUID,
@@ -208,7 +210,7 @@ class BeregningSkolepengerService(
                 return
             }
         }
-        secureLogger.warn("Finner ikke noe som er endret mellom forrigePerioder=$forrigePerioder og nyePerioder=$perioder")
+        logger.warn("Finner ikke noe som er endret mellom forrigePerioder=$forrigePerioder og nyePerioder=$perioder")
         throw ApiFeil("Periodene er uendrede, finner ikke noe å opphøre", HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.behandling.dto.tilDto
 import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.brev.BrevClient
 import no.nav.familie.ef.sak.felles.domain.Fil
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadDatoerDto
@@ -16,7 +17,6 @@ import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.dto.VedtakDto
 import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -33,7 +33,7 @@ class BlankettService(
     private val grunnlagsdataService: GrunnlagsdataService,
     private val samværsavtaleService: SamværsavtaleService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun lagBlankett(behandlingId: UUID): ByteArray {
         logger.info("Start - lag saksbehandlingsblankett for behandlingId=$behandlingId")

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevsignaturService.kt
@@ -1,13 +1,13 @@
 package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.brev.dto.SignaturDto
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.vedtak.domain.VedtakErUtenBeslutter
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING.STRENGT_FORTROLIG_UTLAND
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,7 +15,7 @@ class BrevsignaturService(
     private val personopplysningerService: PersonopplysningerService,
     private val oppgaveClient: OppgaveClient,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun lagSaksbehandlerSignatur(
         personIdent: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.behandling.revurdering.RevurderingService
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -18,7 +19,6 @@ import no.nav.familie.kontrakter.felles.klage.KanIkkeOppretteRevurderingÅrsak
 import no.nav.familie.kontrakter.felles.klage.KanOppretteRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.OpprettRevurderingResponse
 import no.nav.familie.kontrakter.felles.klage.Opprettet
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -34,8 +34,7 @@ class EksternBehandlingService(
     private val revurderingService: RevurderingService,
     private val oppgaveService: OppgaveService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun harLøpendeStønad(personidenter: Set<String>): Boolean {
         val behandlingIDer = hentAlleBehandlingIDer(personidenter)
@@ -125,7 +124,7 @@ class EksternBehandlingService(
             OpprettRevurderingResponse(Opprettet(behandling.eksternId.toString()))
         } catch (e: Exception) {
             logger.error("Feilet opprettelse av revurdering for fagsak=${fagsak.id}, se secure logg for detaljer")
-            secureLogger.error("Feilet opprettelse av revurdering for fagsak=${fagsak.id}", e)
+            logger.error("Feilet opprettelse av revurdering for fagsak=${fagsak.id}", e)
             OpprettRevurderingResponse(IkkeOpprettet(IkkeOpprettetÅrsak.FEIL, e.message))
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingService.kt
@@ -123,7 +123,7 @@ class EksternBehandlingService(
             val behandling = revurderingService.opprettRevurderingManuelt(revurdering)
             OpprettRevurderingResponse(Opprettet(behandling.eksternId.toString()))
         } catch (e: Exception) {
-            logger.error("Feilet opprettelse av revurdering for fagsak=${fagsak.id}, se secure logg for detaljer")
+            logger.vanligError("Feilet opprettelse av revurdering for fagsak=${fagsak.id}, se secure logg for detaljer")
             logger.error("Feilet opprettelse av revurdering for fagsak=${fagsak.id}", e)
             OpprettRevurderingResponse(IkkeOpprettet(IkkeOpprettetÅrsak.FEIL, e.message))
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternStønadsperioderController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.ekstern.stønadsperiode.EksternStønadsperioderService
 import no.nav.familie.ef.sak.infotrygd.LøpendeOvergangsstønadAktivitetsperioder
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.PersonIdent
@@ -14,7 +15,6 @@ import no.nav.familie.kontrakter.felles.ef.EksternePerioderMedStønadstypeRespon
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderRequest
 import no.nav.familie.kontrakter.felles.ef.EksternePerioderResponse
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
@@ -35,7 +35,7 @@ class EksternStønadsperioderController(
     private val perioderForBarnetrygdService: PerioderForBarnetrygdService,
     private val tilgangService: TilgangService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     /**
      * Brukes av Arena
@@ -48,7 +48,7 @@ class EksternStønadsperioderController(
         try {
             Ressurs.success(eksternStønadsperioderService.hentPerioderForAlleStønader(request))
         } catch (e: Exception) {
-            secureLogger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
+            logger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
             Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
         }
 
@@ -63,7 +63,7 @@ class EksternStønadsperioderController(
         try {
             Ressurs.success(EksternePerioderResponse(perioder = eksternStønadsperioderService.hentPerioderForOvergangsstønad(request)))
         } catch (e: Exception) {
-            secureLogger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
+            logger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
             Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
         }
 
@@ -78,7 +78,7 @@ class EksternStønadsperioderController(
         try {
             Ressurs.success(EksternePerioderMedBeløpResponse(perioder = eksternStønadsperioderService.hentPerioderForOvergangsstønadMedBeløp(request)))
         } catch (e: Exception) {
-            secureLogger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
+            logger.error("Kunne ikke hente perioder for ${request.personIdent}", e)
             Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
         }
 
@@ -105,7 +105,7 @@ class EksternStønadsperioderController(
         try {
             Ressurs.success(eksternStønadsperioderService.hentPerioderForYtelser(request))
         } catch (e: Exception) {
-            secureLogger.error("Kunne ikke hente perioder for $request", e)
+            logger.error("Kunne ikke hente perioder for $request", e)
             Ressurs.failure("Henting av perioder for overgangsstønad feilet", error = e)
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/journalføring/AutomatiskJournalføringService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.journalføring.JournalføringHelper.utledNesteBehandlingstype
 import no.nav.familie.ef.sak.journalføring.JournalføringService
 import no.nav.familie.ef.sak.journalføring.JournalpostService
@@ -22,7 +23,6 @@ import no.nav.familie.kontrakter.felles.journalpost.Bruker
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -36,7 +36,7 @@ class AutomatiskJournalføringService(
     private val infotrygdService: InfotrygdService,
     private val behandlingService: BehandlingService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun automatiskJournalførTilBehandling(
@@ -88,10 +88,10 @@ class AutomatiskJournalføringService(
         fagsak: Fagsak?,
     ): Boolean =
         if (!harÅpenBehandling(behandlinger)) {
-            secureLogger.info("Kan automatisk journalføre for fagsak: ${fagsak?.id}")
+            logger.info("Kan automatisk journalføre for fagsak: ${fagsak?.id}")
             true
         } else {
-            secureLogger.info("Kan ikke automatisk journalføre for fagsak: ${fagsak?.id}")
+            logger.info("Kan ikke automatisk journalføre for fagsak: ${fagsak?.id}")
             false
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/fagsak/SøkService.kt
@@ -12,6 +12,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlPersonSøkHjelper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlSaksbehandlerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
@@ -26,7 +27,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.ef.sak.vilkår.dto.VilkårGrunnlagDto
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -43,7 +43,7 @@ class SøkService(
     private val vurderingService: VurderingService,
     private val personopplysningerService: PersonopplysningerService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun søkPersonForEksternFagsak(eksternFagsakId: Long): Søkeresultat {
         val fagsak =
@@ -148,7 +148,7 @@ class SøkService(
 
         val søkeKriterier = PdlPersonSøkHjelper.lagPdlPersonSøkKriterier(bostedsadresse)
         if (søkeKriterier.isEmpty()) {
-            secureLogger.error("Får ikke laget søkekriterer for $aktivIdent med bostedsadresse=$bostedsadresse")
+            logger.error("Får ikke laget søkekriterer for $aktivIdent med bostedsadresse=$bostedsadresse")
             throw Feil(
                 message = "Får ikke laget søkekriterer for bostedsadresse",
                 frontendFeilmelding = "Klarer ikke av å lage søkekriterer for bostedsadressen til person",

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/CachedKodeverkService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/CachedKodeverkService.kt
@@ -1,8 +1,8 @@
 package no.nav.familie.ef.sak.felles.kodeverk
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.kodeverk.InntektKodeverkDto
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
-import org.slf4j.LoggerFactory
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.cache.annotation.CacheConfig
 import org.springframework.cache.annotation.Cacheable
@@ -32,7 +32,7 @@ class CachedKodeverkService(
 class KodeverkInitializer(
     private val cachedKodeverkService: CachedKodeverkService,
 ) : ApplicationListener<ApplicationReadyEvent> {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     @Scheduled(cron = "0 0 2 * * *")
     fun syncKodeverk() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/kodeverk/KodeverkClient.kt
@@ -1,12 +1,11 @@
 package no.nav.familie.ef.sak.felles.kodeverk
 
 import no.nav.familie.ef.sak.infrastruktur.config.IntegrasjonerConfig
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.kodeverk.InntektKodeverkDto
 import no.nav.familie.kontrakter.felles.kodeverk.KodeverkDto
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestOperations
@@ -18,7 +17,7 @@ class KodeverkClient(
     private val integrasjonerConfig: IntegrasjonerConfig,
 ) : AbstractPingableRestClient(restOperations, "kodeverk") {
     override val pingUri: URI = integrasjonerConfig.pingUri
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     fun hentKodeverkLandkoder(): KodeverkDto = getForEntity<Ressurs<KodeverkDto>>(integrasjonerConfig.kodeverkLandkoderUri).data!!
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/felles/util/Timer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/felles/util/Timer.kt
@@ -1,9 +1,10 @@
 package no.nav.familie.ef.sak.felles.util
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import org.slf4j.LoggerFactory
 
 object Timer {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun <T> loggTid(
         metadata: String = "",

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/FerdigstillOppgavetypePåBehandlingTask.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.objectMapper
@@ -8,7 +9,6 @@ import no.nav.familie.kontrakter.felles.oppgave.StatusEnum
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 
@@ -23,7 +23,7 @@ class FerdigstillOppgavetypePåBehandlingTask(
     private val oppgaveService: OppgaveService,
     private val oppgaveRepository: OppgaveRepository,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue(task.payload, ForvaltningFerdigstillRequest::class.java)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/GjennoprettOppgavePåBehandlingTask.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.OPPRETTET
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.SATT_PÅ_VENT
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus.UTREDES
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
@@ -21,7 +22,6 @@ import no.nav.familie.kontrakter.felles.oppgave.StatusEnum.FEILREGISTRERT
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.Properties
@@ -41,7 +41,7 @@ class GjennoprettOppgavePåBehandlingTask(
     private val oppgaveService: OppgaveService,
     private val oppgaveRepository: OppgaveRepository,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Gjenoppretter oppgave for behandling ${task.payload}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InfotrygdForvaltningController.kt
@@ -2,11 +2,10 @@ package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -18,7 +17,7 @@ class InfotrygdForvaltningController(
     private val infotrygdService: InfotrygdService,
     private val tilgangService: TilgangService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(this::class)
 
     @GetMapping("rapport")
     fun hentRapportÅpneSaker(): Ressurs<InfotrygdReplikaClient.ÅpnesakerRapport> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/IverksettProxyTaskForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/IverksettProxyTaskForvaltningController.kt
@@ -1,10 +1,10 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import io.swagger.v3.oas.annotations.Operation
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.PathVariable
@@ -24,7 +24,7 @@ class IverksettProxyTaskForvaltningController(
     @Qualifier("azure")
     private val restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "familie.ef.iverksett.forvaltning") {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping("kopier/taskid/{taskId}")
     @Operation(

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
@@ -2,13 +2,13 @@ package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingPayload
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingTask
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -24,7 +24,7 @@ class KonsistensavstemmingForvaltningController(
     private val tilgangService: TilgangService,
     private val iverksettClient: IverksettClient,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping
     fun kjørKonsistensavstemming() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/LoggOppgaveMetadataTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/LoggOppgaveMetadataTask.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.Properties
 import java.util.UUID
@@ -20,8 +20,7 @@ import java.util.UUID
 class LoggOppgaveMetadataTask(
     private val tilordnetRessursService: TilordnetRessursService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Henter oppgave for behandling ${task.payload}")
@@ -29,7 +28,7 @@ class LoggOppgaveMetadataTask(
 
         when (oppgave) {
             null -> logger.info("Fant ikke oppgave for behandling ${task.payload}")
-            else -> secureLogger.info("Oppgave hentet for behandling ${task.payload}: ${oppgave.toLogString()}")
+            else -> logger.info("Oppgave hentet for behandling ${task.payload}: ${oppgave.toLogString()}")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/LoggOppgaveMetadataTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/LoggOppgaveMetadataTask.kt
@@ -23,11 +23,11 @@ class LoggOppgaveMetadataTask(
     private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
-        logger.info("Henter oppgave for behandling ${task.payload}")
+        logger.vanligInfo("Henter oppgave for behandling ${task.payload}")
         val oppgave = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(UUID.fromString(task.payload))
 
         when (oppgave) {
-            null -> logger.info("Fant ikke oppgave for behandling ${task.payload}")
+            null -> logger.vanligInfo("Fant ikke oppgave for behandling ${task.payload}")
             else -> logger.info("Oppgave hentet for behandling ${task.payload}: ${oppgave.toLogString()}")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/ManuellGOmregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/ManuellGOmregningController.kt
@@ -7,12 +7,11 @@ import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -30,7 +29,7 @@ class ManuellGOmregningController(
     private val tilkjentYtelseService: TilkjentYtelseService,
     private val tilgangService: TilgangService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(this::class)
 
     @PostMapping(path = ["startjobb"])
     fun opprettGOmregningTasksForBehandlingerMedGammeltGBelop(): Ressurs<Int> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsController.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,7 +16,7 @@ class OppgaveOppryddingForvaltningsController(
     private val tilgangService: TilgangService,
     private val taskService: TaskService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping("start-opprydding")
     fun ryddOppgaver(

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
 import no.nav.familie.kontrakter.felles.Tema
@@ -10,7 +11,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.util.Properties
@@ -25,8 +25,7 @@ import java.util.Properties
 class OppgaveOppryddingForvaltningsTask(
     private val oppgaveService: OppgaveService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     final val mappenavnProd = "41 Revurdering"
     final val mappenavnDev = "41 - Revurdering"
@@ -58,12 +57,12 @@ class OppgaveOppryddingForvaltningsTask(
                 val oppgaveId = oppgave.id
                 if (oppgaveId == null) {
                     logger.error("Kan ikke ferdigstille oppgave - mangler ID")
-                    secureLogger.info("Kan ikke ferdigstille oppgave pga manglende ID: $oppgave")
+                    logger.info("Kan ikke ferdigstille oppgave pga manglende ID: $oppgave")
                 } else if (oppgave.oppgavetype != Oppgavetype.Fremlegg.value) {
                     logger.error("Kan ikke ferdigstille oppgave - feil type")
-                    secureLogger.info("Kan ikke ferdigstille oppgave pga feil oppgavetype: $oppgave")
+                    logger.info("Kan ikke ferdigstille oppgave pga feil oppgavetype: $oppgave")
                 } else {
-                    secureLogger.info("Ferdigstiller oppgave $oppgaveId")
+                    logger.info("Ferdigstiller oppgave $oppgaveId")
                     oppgaveService.ferdigstillOppgave(oppgaveId)
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsTask.kt
@@ -56,10 +56,10 @@ class OppgaveOppryddingForvaltningsTask(
             oppgaver.oppgaver.forEach { oppgave ->
                 val oppgaveId = oppgave.id
                 if (oppgaveId == null) {
-                    logger.error("Kan ikke ferdigstille oppgave - mangler ID")
+                    logger.vanligError("Kan ikke ferdigstille oppgave - mangler ID")
                     logger.info("Kan ikke ferdigstille oppgave pga manglende ID: $oppgave")
                 } else if (oppgave.oppgavetype != Oppgavetype.Fremlegg.value) {
-                    logger.error("Kan ikke ferdigstille oppgave - feil type")
+                    logger.vanligError("Kan ikke ferdigstille oppgave - feil type")
                     logger.info("Kan ikke ferdigstille oppgave pga feil oppgavetype: $oppgave")
                 } else {
                     logger.info("Ferdigstiller oppgave $oppgaveId")

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/PdlSjekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/PdlSjekkController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
@@ -11,7 +12,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -27,7 +27,7 @@ class PdlSjekkController(
     private val tilgangService: TilgangService,
     private val personopplysningerService: PersonopplysningerService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping
     fun sjekkIdenter(
@@ -42,12 +42,12 @@ class PdlSjekkController(
                     if (fagsaker.isNotEmpty()) {
                         fagsaker.forEach {
                             val behandlinger = fagsakService.fagsakTilDto(it).behandlinger
-                            secureLogger.info("Fagsak=${it.id} har ${behandlinger.size} behandlinger")
+                            logger.info("Fagsak=${it.id} har ${behandlinger.size} behandlinger")
                         }
                     }
                     fagsaker.isNotEmpty()
                 }.count { it }
-        secureLogger.info("$count personer funnet")
+        logger.info("$count personer funnet")
         return count
     }
 
@@ -70,12 +70,12 @@ class PdlSjekkController(
                 personIdent = ident,
             )
 
-        secureLogger.info("Søker har ${barn.size} barn og ${andreForeldre.size} andre foreldre")
+        logger.info("Søker har ${barn.size} barn og ${andreForeldre.size} andre foreldre")
 
         andreForeldre.forEach { (id, forelder) ->
-            secureLogger.info("Annen forelder: $id - ${forelder.navn}  ")
+            logger.info("Annen forelder: $id - ${forelder.navn}  ")
             forelder.folkeregisteridentifikator.forEach { pid ->
-                secureLogger.info("Annen forelder-ident status: ${pid.status}, historisk = ${pid.metadata.historisk}")
+                logger.info("Annen forelder-ident status: ${pid.status}, historisk = ${pid.metadata.historisk}")
             }
         }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktService.kt
@@ -1,13 +1,12 @@
 package no.nav.familie.ef.sak.forvaltning.aktivitetsplikt
 
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
 import no.nav.familie.kontrakter.felles.Tema
 import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveRequest
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -18,7 +17,7 @@ class AutomatiskBrevInnhentingAktivitetspliktService(
     private val taskService: TaskService,
     private val oppgaveService: OppgaveService,
 ) {
-    val logger: Logger = LoggerFactory.getLogger(javaClass)
+    val logger = Logg.getLogger(this::class)
 
     val oppgaveAktivitetspliktFrist = LocalDate.parse("2025-05-17")
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/SendAktivitetspliktBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/SendAktivitetspliktBrevTilIverksettTask.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil
@@ -22,8 +23,6 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.Year
 import java.util.Properties
@@ -45,7 +44,7 @@ class SendAktivitetspliktBrevTilIverksettTask(
     private val iverksettClient: IverksettClient,
     private val arbeidsfordelingService: ArbeidsfordelingService,
 ) : AsyncTaskStep {
-    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue<AutomatiskBrevAktivitetspliktPayload>(task.payload)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/StartUtsendingAvAktivitetspliktBrevTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/StartUtsendingAvAktivitetspliktBrevTask.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning.aktivitetsplikt
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
@@ -8,8 +9,6 @@ import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.PropertiesWrapper
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
@@ -25,7 +24,7 @@ import java.util.Properties
 class StartUtsendingAvAktivitetspliktBrevTask(
     private val automatiskBrevInnhentingAktivitetspliktService: AutomatiskBrevInnhentingAktivitetspliktService,
 ) : AsyncTaskStep {
-    val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val payload = objectMapper.readValue<PayLoad>(task.payload)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
@@ -59,7 +59,7 @@ class AndelshistorikkUttrekkController(
 
         val uttrekkResultat =
             "Uttrekk unntatt aktivitet: mangler tilsyn. Total: ${alleSomManglerTilsynForÅr.size}. Snitt mnd: $snittAntMnd, Snitt beløp pr mnd: $snittBeløp "
-        logger.info(uttrekkResultat)
+        logger.vanligInfo(uttrekkResultat)
         return ResponseEntity.ok(uttrekkResultat)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ef.sak.forvaltning.uttrekk
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
@@ -24,8 +24,7 @@ class AndelshistorikkUttrekkController(
     val vedtakHistorikkService: VedtakHistorikkService,
     private val tilgangService: TilgangService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @GetMapping("/manglertilsyn")
     fun hentDataManglerTilsyn2022(): ResponseEntity<String> {
@@ -50,7 +49,7 @@ class AndelshistorikkUttrekkController(
                             it.beløpForManglendeTilsynSomErAvsluttet(),
                             it.tidligsteFom(),
                         )
-                    secureLogger.info("Snittutregning-manglertilsyn: $resultatPerFagsak ")
+                    logger.info("Snittutregning-manglertilsyn: $resultatPerFagsak ")
                     resultatPerFagsak
                 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdService.kt
@@ -2,9 +2,9 @@ package no.nav.familie.ef.sak.infotrygd
 
 import no.nav.familie.ef.sak.infotrygd.InfotrygdUtils.KLAGETYPER
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdEndringKode
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
@@ -22,6 +22,8 @@ class InfotrygdService(
     private val infotrygdReplikaClient: InfotrygdReplikaClient,
     private val personService: PersonService,
 ) {
+    private val logger = Logg.getLogger(this::class)
+
     /**
      * Forslag på sjekk om en person eksisterer i infotrygd
      */
@@ -78,7 +80,7 @@ class InfotrygdService(
     private fun hentSammenslåttePerioderFraReplika(personIdent: String): InfotrygdPeriodeResponse {
         val personIdenter = hentPersonIdenter(personIdent)
         feilHvis(personIdenter.isEmpty()) {
-            secureLogger.warn("Finner ikke $personIdent i pdl, kan følgelig ikke hente perioder fra replika")
+            logger.warn("Finner ikke $personIdent i pdl, kan følgelig ikke hente perioder fra replika")
             "Det finnes ingen identer i pdl for oppslaget"
         }
         return hentSammenslåttePerioderFraReplika(personIdenter)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/ApplicationConfig.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.infrastruktur.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext.harRolle
 import no.nav.familie.http.client.RetryOAuth2HttpClient
 import no.nav.familie.http.config.RestTemplateAzure
@@ -16,7 +17,6 @@ import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenRespons
 import no.nav.security.token.support.client.spring.oauth2.EnableOAuth2Client
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -47,7 +47,7 @@ import java.time.temporal.ChronoUnit
 @EnableOAuth2Client(cacheEnabled = true)
 @EnableScheduling
 class ApplicationConfig {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     @Bean
     fun kotlinModule(): KotlinModule = KotlinModule.Builder().build()

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
@@ -27,12 +27,12 @@ class ApiExceptionHandler(
         val mostSpecificCause = throwable.getMostSpecificCause()
         if (mostSpecificCause is SocketTimeoutException || mostSpecificCause is TimeoutException) {
             logger.warn("Timeout feil: ${mostSpecificCause.message}, $metodeSomFeiler ${rootCause(throwable)}", throwable)
-            logger.warn("Timeout feil: $metodeSomFeiler ${rootCause(throwable)} ")
+            logger.vanligWarn("Timeout feil: $metodeSomFeiler ${rootCause(throwable)} ")
             return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(lagTimeoutfeilRessurs())
         }
 
         logger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)}", throwable)
-        logger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)} ")
+        logger.vanligError("Uventet feil: $metodeSomFeiler ${rootCause(throwable)} ")
 
         return ResponseEntity
             .status(INTERNAL_SERVER_ERROR)
@@ -60,7 +60,7 @@ class ApiExceptionHandler(
     fun handleThrowable(feil: ApiFeil): ResponseEntity<Ressurs<Nothing>> {
         val metodeSomFeiler = finnMetodeSomFeiler(feil)
         logger.info("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.feil}", feil)
-        logger.info(
+        logger.vanligInfo(
             "En håndtert feil har oppstått(${feil.httpStatus}) metode=$metodeSomFeiler exception=${
                 rootCause(
                     feil,
@@ -79,7 +79,7 @@ class ApiExceptionHandler(
     fun handleThrowable(feil: Feil): ResponseEntity<Ressurs<Nothing>> {
         val metodeSomFeiler = finnMetodeSomFeiler(feil)
         logger.error("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.frontendFeilmelding}", feil)
-        logger.error(
+        logger.vanligError(
             "En håndtert feil har oppstått(${feil.httpStatus}) metode=$metodeSomFeiler exception=${
                 rootCause(
                     feil,
@@ -107,7 +107,7 @@ class ApiExceptionHandler(
     @ExceptionHandler(ManglerTilgang::class)
     fun handleThrowable(manglerTilgang: ManglerTilgang): ResponseEntity<Ressurs<Nothing>> {
         logger.warn("En håndtert tilgangsfeil har oppstått - ${manglerTilgang.melding}", manglerTilgang)
-        logger.warn("En håndtert tilgangsfeil har oppstått")
+        logger.vanligWarn("En håndtert tilgangsfeil har oppstått")
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)
             .body(
@@ -124,7 +124,7 @@ class ApiExceptionHandler(
     @ExceptionHandler(IntegrasjonException::class)
     fun handleThrowable(feil: IntegrasjonException): ResponseEntity<Ressurs<Nothing>> {
         logger.error("Feil mot integrasjonsclienten har oppstått: uri={} data={}", feil.uri, feil.data, feil)
-        logger.error("Feil mot integrasjonsclienten har oppstått exception=${rootCause(feil)}")
+        logger.vanligError("Feil mot integrasjonsclienten har oppstått exception=${rootCause(feil)}")
         return ResponseEntity
             .status(INTERNAL_SERVER_ERROR)
             .body(Ressurs.failure(frontendFeilmelding = feil.message))

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/exception/ApiExceptionHandler.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ef.sak.infrastruktur.exception
 
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.exceptions.JwtTokenMissingException
-import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
@@ -18,8 +18,7 @@ import java.util.concurrent.TimeoutException
 class ApiExceptionHandler(
     val featureToggleService: FeatureToggleService,
 ) {
-    private val logger = LoggerFactory.getLogger(ApiExceptionHandler::class.java)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(throwable: Throwable): ResponseEntity<Ressurs<Nothing>> {
@@ -27,12 +26,12 @@ class ApiExceptionHandler(
 
         val mostSpecificCause = throwable.getMostSpecificCause()
         if (mostSpecificCause is SocketTimeoutException || mostSpecificCause is TimeoutException) {
-            secureLogger.warn("Timeout feil: ${mostSpecificCause.message}, $metodeSomFeiler ${rootCause(throwable)}", throwable)
+            logger.warn("Timeout feil: ${mostSpecificCause.message}, $metodeSomFeiler ${rootCause(throwable)}", throwable)
             logger.warn("Timeout feil: $metodeSomFeiler ${rootCause(throwable)} ")
             return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(lagTimeoutfeilRessurs())
         }
 
-        secureLogger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)}", throwable)
+        logger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)}", throwable)
         logger.error("Uventet feil: $metodeSomFeiler ${rootCause(throwable)} ")
 
         return ResponseEntity
@@ -60,7 +59,7 @@ class ApiExceptionHandler(
     @ExceptionHandler(ApiFeil::class)
     fun handleThrowable(feil: ApiFeil): ResponseEntity<Ressurs<Nothing>> {
         val metodeSomFeiler = finnMetodeSomFeiler(feil)
-        secureLogger.info("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.feil}", feil)
+        logger.info("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.feil}", feil)
         logger.info(
             "En håndtert feil har oppstått(${feil.httpStatus}) metode=$metodeSomFeiler exception=${
                 rootCause(
@@ -79,7 +78,7 @@ class ApiExceptionHandler(
     @ExceptionHandler(Feil::class)
     fun handleThrowable(feil: Feil): ResponseEntity<Ressurs<Nothing>> {
         val metodeSomFeiler = finnMetodeSomFeiler(feil)
-        secureLogger.error("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.frontendFeilmelding}", feil)
+        logger.error("En håndtert feil har oppstått(${feil.httpStatus}): ${feil.frontendFeilmelding}", feil)
         logger.error(
             "En håndtert feil har oppstått(${feil.httpStatus}) metode=$metodeSomFeiler exception=${
                 rootCause(
@@ -107,7 +106,7 @@ class ApiExceptionHandler(
 
     @ExceptionHandler(ManglerTilgang::class)
     fun handleThrowable(manglerTilgang: ManglerTilgang): ResponseEntity<Ressurs<Nothing>> {
-        secureLogger.warn("En håndtert tilgangsfeil har oppstått - ${manglerTilgang.melding}", manglerTilgang)
+        logger.warn("En håndtert tilgangsfeil har oppstått - ${manglerTilgang.melding}", manglerTilgang)
         logger.warn("En håndtert tilgangsfeil har oppstått")
         return ResponseEntity
             .status(HttpStatus.FORBIDDEN)
@@ -124,7 +123,7 @@ class ApiExceptionHandler(
 
     @ExceptionHandler(IntegrasjonException::class)
     fun handleThrowable(feil: IntegrasjonException): ResponseEntity<Ressurs<Nothing>> {
-        secureLogger.error("Feil mot integrasjonsclienten har oppstått: uri={} data={}", feil.uri, feil.data, feil)
+        logger.error("Feil mot integrasjonsclienten har oppstått: uri={} data={}", feil.uri, feil.data, feil)
         logger.error("Feil mot integrasjonsclienten har oppstått exception=${rootCause(feil)}")
         return ResponseEntity
             .status(INTERNAL_SERVER_ERROR)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/logg/Logg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/logg/Logg.kt
@@ -1,0 +1,146 @@
+package no.nav.familie.ef.sak.infrastruktur.logg
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.MarkerFactory
+import kotlin.reflect.KClass
+
+class Logg(
+    private val logger: Logger,
+) {
+    private val teamLogsMarker = MarkerFactory.getMarker("TEAM_LOGS")
+
+    // Secure logging (Default)
+    fun info(msg: String) = logger.info(teamLogsMarker, msg)
+
+    fun info(
+        format: String,
+        arg: Any?,
+    ) = logger.info(teamLogsMarker, format, arg)
+
+    fun info(
+        format: String,
+        arg1: Any?,
+        arg2: Any?,
+    ) = logger.info(teamLogsMarker, format, arg1, arg2)
+
+    fun info(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.info(teamLogsMarker, format, *arguments)
+
+    fun info(
+        msg: String,
+        t: Throwable?,
+    ) = logger.info(teamLogsMarker, msg, t)
+
+    fun warn(msg: String) = logger.warn(teamLogsMarker, msg)
+
+    fun warn(
+        format: String,
+        arg: Any?,
+    ) = logger.warn(teamLogsMarker, format, arg)
+
+    fun warn(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.warn(teamLogsMarker, format, *arguments)
+
+    fun warn(
+        msg: String,
+        t: Throwable?,
+    ) = logger.warn(teamLogsMarker, msg, t)
+
+    fun error(msg: String) = logger.error(teamLogsMarker, msg)
+
+    fun error(
+        format: String,
+        arg: Any?,
+    ) = logger.error(teamLogsMarker, format, arg)
+
+    fun error(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.error(teamLogsMarker, format, *arguments)
+
+    fun error(
+        msg: String,
+        t: Throwable?,
+    ) = logger.error(teamLogsMarker, msg, t)
+
+    // Vanlig logging
+    fun vanligInfo(msg: String) = logger.info(msg)
+
+    fun vanligInfo(
+        format: String,
+        arg: Any?,
+    ) = logger.info(format, arg)
+
+    fun vanligInfo(
+        format: String,
+        arg1: Any?,
+        arg2: Any?,
+    ) = logger.info(format, arg1, arg2)
+
+    fun vanligInfo(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.info(format, *arguments)
+
+    fun vanligInfo(
+        msg: String,
+        t: Throwable?,
+    ) = logger.info(msg, t)
+
+    fun vanligWarn(msg: String) = logger.warn(msg)
+
+    fun vanligWarn(
+        format: String,
+        arg: Any?,
+    ) = logger.warn(format, arg)
+
+    fun vanligWarn(
+        format: String,
+        arg1: Any?,
+        arg2: Any?,
+    ) = logger.warn(format, arg1, arg2)
+
+    fun vanligWarn(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.warn(format, *arguments)
+
+    fun vanligWarn(
+        msg: String,
+        t: Throwable?,
+    ) = logger.warn(msg, t)
+
+    fun vanligError(msg: String) = logger.error(msg)
+
+    fun vanligError(
+        format: String,
+        arg: Any?,
+    ) = logger.error(format, arg)
+
+    fun vanligError(
+        format: String,
+        arg1: Any?,
+        arg2: Any?,
+    ) = logger.error(format, arg1, arg2)
+
+    fun vanligError(
+        format: String,
+        vararg arguments: Any?,
+    ) = logger.error(format, *arguments)
+
+    fun vanligError(
+        msg: String,
+        t: Throwable?,
+    ) = logger.error(msg, t)
+
+    companion object {
+        fun getLogger(clazz: KClass<*>): Logg = Logg(LoggerFactory.getLogger(clazz.java))
+
+        fun getLogger(name: String): Logg = Logg(LoggerFactory.getLogger(name))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/SikkerhetContext.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.infrastruktur.sikkerhet
 
 import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.sikkerhet.EksternBrukerUtils
 import no.nav.security.token.support.spring.SpringTokenValidationContextHolder
 import org.slf4j.LoggerFactory
@@ -12,7 +13,7 @@ object SikkerhetContext {
 
     val NAVIDENT_REGEX = """^[a-zA-Z]\d{6}$""".toRegex()
 
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun erMaskinTilMaskinToken(): Boolean {
         val claims = SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread")
@@ -34,7 +35,7 @@ object SikkerhetContext {
     private fun kallKommerFra(forventetApplikasjonsSuffix: String): Boolean {
         val claims = SpringTokenValidationContextHolder().getTokenValidationContext().getClaims("azuread")
         val applikasjonsnavn = claims.get("azp_name")?.toString() ?: "" // e.g. dev-gcp:some-team:application-name
-        secureLogger.info("Applikasjonsnavn: $applikasjonsnavn")
+        logger.info("Applikasjonsnavn: $applikasjonsnavn")
         return applikasjonsnavn.endsWith(forventetApplikasjonsSuffix)
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangInterceptor.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangInterceptor.kt
@@ -5,7 +5,7 @@ import jakarta.servlet.http.HttpServletResponse
 import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.exception.ManglerTilgang
-import org.slf4j.LoggerFactory
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.AsyncHandlerInterceptor
 
@@ -29,6 +29,6 @@ class TilgangInterceptor(
         }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(this::class.java)
+        private val logger = Logg.getLogger(this::class)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/TilgangService.kt
@@ -14,13 +14,13 @@ import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
 import no.nav.familie.ef.sak.infrastruktur.exception.ManglerTilgang
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext.hentGrupperFraToken
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerIntegrasjonerClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Adressebeskyttelse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.AdressebeskyttelseGradering.FORTROLIG
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.AdressebeskyttelseGradering.STRENGT_FORTROLIG
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import java.util.UUID
@@ -35,6 +35,8 @@ class TilgangService(
     private val cacheManager: CacheManager,
     private val auditLogger: AuditLogger,
 ) {
+    private val logger = Logg.getLogger(this::class)
+
     /**
      * Kun ved tilgangskontroll for enskild person, ellers bruk [validerTilgangTilPersonMedBarn]
      */
@@ -45,7 +47,7 @@ class TilgangService(
         val tilgang = personopplysningerIntegrasjonerClient.sjekkTilgangTilPerson(personIdent)
         auditLogger.log(Sporingsdata(event, personIdent, tilgang))
         if (!tilgang.harTilgang) {
-            secureLogger.warn(
+            logger.warn(
                 "Saksbehandler ${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} " +
                     "har ikke tilgang til $personIdent",
             )
@@ -65,7 +67,7 @@ class TilgangService(
         val tilgang = harTilgangTilPersonMedRelasjoner(personIdent)
         auditLogger.log(Sporingsdata(event, personIdent, tilgang))
         if (!tilgang.harTilgang) {
-            secureLogger.warn(
+            logger.warn(
                 "Saksbehandler ${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} " +
                     "har ikke tilgang til $personIdent eller dets barn",
             )

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveforbarn/BarnFyllerÅrOppfølgingsoppgaveService.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveforbarn
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.Oppgave
 import no.nav.familie.ef.sak.oppgave.OppgaveRepository
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMedFødselsdatoDto
@@ -11,7 +12,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Familierelasjon
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.relational.core.conversion.DbActionExecutionException
 import org.springframework.stereotype.Service
@@ -26,8 +26,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
     private val personService: PersonService,
     private val grunnlagsdataService: GrunnlagsdataService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun opprettTasksForAlleBarnSomHarFyltÅr(dryRun: Boolean = false) {
@@ -45,7 +44,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
             opprettOppgaveTasksForBarn(behandlingMedBarnIAktivitetspliktigAlder)
         } else {
             behandlingMedBarnIAktivitetspliktigAlder.forEach {
-                secureLogger.info(
+                logger.info(
                     "Ville opprettet oppgave for barn med fødselsnummer: " +
                         "${it.fødselsnummer} med alder ${it.aktivitetspliktigAlder}",
                 )
@@ -111,7 +110,7 @@ class BarnFyllerÅrOppfølgingsoppgaveService(
     ): LocalDate? {
         val grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn.firstOrNull { it.personIdent == barn.fødselsnummerBarn }
         if (grunnlagsdataBarn == null) {
-            secureLogger.warn("Fant ikke barn i grunnlagsdata for behandling ${barn.behandlingId} og fødselsnummer ${barn.fødselsnummerBarn}")
+            logger.warn("Fant ikke barn i grunnlagsdata for behandling ${barn.behandlingId} og fødselsnummer ${barn.fødselsnummerBarn}")
             return null
         }
         return grunnlagsdataBarn.fødsel.first().fødselsdato

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnService.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveterminbarn
 
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonForelderBarn
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForBarn
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -19,7 +19,7 @@ class ForberedOppgaverTerminbarnService(
     private val terminbarnRepository: TerminbarnRepository,
     private val taskService: TaskService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun forberedOppgaverForUfødteTerminbarn() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/ForberedOppgaverTerminbarnTask.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveterminbarn
 
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -20,7 +20,7 @@ class ForberedOppgaverTerminbarnTask(
     val forberedOppgaverTerminbarnService: ForberedOppgaverTerminbarnService,
     val featureToggleService: FeatureToggleService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Starter forbereding av oppgaver for ufødte terminbarn")

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/OpprettOppgaverTerminbarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/oppgaveterminbarn/OpprettOppgaverTerminbarnService.kt
@@ -1,16 +1,16 @@
 package no.nav.familie.ef.sak.iverksett.oppgaveterminbarn
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.ef.iverksett.OppgaveForBarn
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class OpprettOppgaverTerminbarnService(
     private val oppgaveService: OppgaveService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun opprettOppgaveForTerminbarn(oppgaveForBarn: OppgaveForBarn) {
         val opprettetOppgaveId =

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringKlageService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringKlageService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.journalføring
 
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.JournalføringHelper.validerGyldigAvsender
 import no.nav.familie.ef.sak.journalføring.dto.JournalføringRequestV2
@@ -11,7 +12,6 @@ import no.nav.familie.ef.sak.klage.dto.OpprettKlageDto
 import no.nav.familie.ef.sak.oppgave.OppgaveService
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.klage.Klagebehandlingsårsak
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,7 +22,7 @@ class JournalføringKlageService(
     private val journalpostService: JournalpostService,
     private val klageService: KlageService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun fullførJournalpostV2(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.sak.behandlingsflyt.task.OpprettOppgaveForOpprettetBeha
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.JournalføringHelper.utledNyAvsender
 import no.nav.familie.ef.sak.journalføring.JournalføringHelper.validerGyldigAvsender
@@ -35,7 +36,6 @@ import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -53,7 +53,7 @@ class JournalføringService(
     private val journalpostService: JournalpostService,
     private val infotrygdPeriodeValideringService: InfotrygdPeriodeValideringService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun fullførJournalpostV2(

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostClient.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.http.client.AbstractPingableRestClient
 import no.nav.familie.http.client.RessursException
@@ -38,6 +39,8 @@ class JournalpostClient(
     integrasjonerConfig: IntegrasjonerConfig,
     private val featureToggleService: FeatureToggleService,
 ) : AbstractPingableRestClient(restOperations, "journalpost") {
+    private val logger = Logg.getLogger(this::class)
+
     override val pingUri: URI = integrasjonerConfig.pingUri
     private val journalpostURI: URI = integrasjonerConfig.journalPostUri
     private val dokarkivUri: URI = integrasjonerConfig.dokarkivUri
@@ -176,7 +179,7 @@ class JournalpostClient(
             }
 
         if (ressurs.status != Ressurs.Status.SUKSESS) {
-            secureLogger.error(" Feil ved oppdatering av journalpost=$journalpostId - mottok: $ressurs")
+            logger.error(" Feil ved oppdatering av journalpost=$journalpostId - mottok: $ressurs")
             error("Feil ved oppdatering av journalpost=$journalpostId")
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.sak.journalføring
 
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.ef.sak.journalføring.dto.OppdaterJournalpostMedDokumenterRequest
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.logger
 import no.nav.familie.ef.sak.vedlegg.VedleggRequest
 import no.nav.familie.kontrakter.ef.sak.DokumentBrevkode
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
@@ -23,14 +23,13 @@ import no.nav.familie.kontrakter.felles.journalpost.JournalposterForBrukerReques
 import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.journalpost.LogiskVedlegg
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class JournalpostService(
     private val journalpostClient: JournalpostClient,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun hentJournalpost(journalpostId: String): Journalpost = journalpostClient.hentJournalpost(journalpostId)
 
@@ -237,7 +236,7 @@ class JournalpostService(
         try {
             journalpostClient.oppdaterJournalpost(request, journalpostId, saksbehandler)
         } catch (e: Exception) {
-            secureLogger.error("Kunne ikke oppdatere journalpost med id=$journalpostId")
+            logger.error("Kunne ikke oppdatere journalpost med id=$journalpostId")
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/metrics/MålerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/metrics/MålerService.kt
@@ -3,9 +3,9 @@ package no.nav.familie.ef.sak.metrics
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.MultiGauge
 import io.micrometer.core.instrument.Tags
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.metrics.domain.MålerRepository
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import java.time.YearMonth
@@ -23,7 +23,7 @@ class MålerService(
     private val antallMigreringerGauge = Metrics.gauge("AntallMigreringer", AtomicInteger()) ?: error("Forventer not null")
     private val antallSanksjonerGauge = Metrics.gauge("AntallSanksjoner", AtomicInteger()) ?: error("Forventer not null")
 
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     @Scheduled(initialDelay = 60 * 1000L, fixedDelay = OPPDATERINGSFREKVENS)
     fun antallMigreringer() {

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/AktiverMikrofrontendNyttFødselsnummerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/AktiverMikrofrontendNyttFødselsnummerTask.kt
@@ -2,10 +2,10 @@ package no.nav.familie.ef.sak.minside
 
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.util.UUID
 
@@ -18,7 +18,7 @@ class AktiverMikrofrontendNyttFødselsnummerTask(
     val minSideKafkaProducerService: MinSideKafkaProducerService,
     val fagsakPersonService: FagsakPersonService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Starter task for aktivering av bruker med nytt fødselsnummer for mikrofrontend")

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/AktiverMikrofrontendTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/AktiverMikrofrontendTask.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ef.sak.minside
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
@@ -21,7 +21,7 @@ class AktiverMikrofrontendTask(
     val minSideKafkaProducerService: MinSideKafkaProducerService,
     val fagsakPersonService: FagsakPersonService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Starter task for aktivering av bruker for mikrofrontend")

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendScheduler.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendScheduler.kt
@@ -1,9 +1,9 @@
 package no.nav.familie.ef.sak.minside
 
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.leader.LeaderClient
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -13,7 +13,7 @@ class DeaktiverMikrofrontendScheduler(
     val taskService: TaskService,
     val fagsakPersonService: FagsakPersonService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Scheduled(cron = "\${DEAKTIVER_MIKROFRONTEND_CRON_EXPRESSION}")
     @Transactional

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/DeaktiverMikrofrontendTask.kt
@@ -2,11 +2,11 @@ package no.nav.familie.ef.sak.minside
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.Properties
@@ -21,7 +21,7 @@ class DeaktiverMikrofrontendTask(
     val minSideKafkaProducerService: MinSideKafkaProducerService,
     val fagsakPersonService: FagsakPersonService,
 ) : AsyncTaskStep {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         logger.info("Starter task for deaktivering av bruker for mikrofrontend")

--- a/src/main/kotlin/no/nav/familie/ef/sak/minside/MinSideKafkaProducerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/minside/MinSideKafkaProducerService.kt
@@ -1,11 +1,10 @@
 package no.nav.familie.ef.sak.minside
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.log.IdUtils
 import no.nav.familie.log.mdc.MDCConstants
 import no.nav.tms.microfrontend.MicrofrontendMessageBuilder
 import no.nav.tms.microfrontend.Sensitivitet
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.kafka.core.KafkaTemplate
@@ -17,7 +16,7 @@ class MinSideKafkaProducerService(
 ) {
     @Value("\${MIN_SIDE_TOPIC}")
     lateinit var topic: String
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     fun aktiver(personIdent: String) {
         val melding =

--- a/src/main/kotlin/no/nav/familie/ef/sak/næringsinntektskontroll/NæringsinntektDataForBeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/næringsinntektskontroll/NæringsinntektDataForBeregningService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.næringsinntektskontroll
 import no.nav.familie.ef.sak.amelding.InntektService
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.sigrun.SigrunService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelse
@@ -10,7 +11,6 @@ import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.UUID
@@ -23,7 +23,7 @@ class NæringsinntektDataForBeregningService(
     val inntektService: InntektService,
     val sigrunService: SigrunService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun hentNæringsinntektDataForBeregning(
         oppgave: Oppgave,
@@ -46,9 +46,9 @@ class NæringsinntektDataForBeregningService(
                 fjoråretsPersonInntekt = inntektService.hentÅrsinntekt(personIdent, årstallIFjor),
                 forventetInntektIFjor = forventetInntektSnittIFjor(tilkjentYtelse, årstallIFjor),
             )
-        secureLogger.info("Næringsinntektsdata for beregning: $næringsinntektDataForBeregning")
-        secureLogger.info("${næringsinntektDataForBeregning.antallMånederMedVedtakForÅr(årstallIFjor)} måneder med vedtak for fagsakId: ${fagsakOvergangsstønad.id} eksternFagsakId: ${fagsakOvergangsstønad.eksternId}")
-        secureLogger.info("Forrige års inntekt for person uten ytelse fra offentlig: ${næringsinntektDataForBeregning.fjoråretsPersonInntekt} - næringsinntekt: ${næringsinntektDataForBeregning.fjoråretsNæringsinntekt} (Fagsak: ${fagsakOvergangsstønad.id})")
+        logger.info("Næringsinntektsdata for beregning: $næringsinntektDataForBeregning")
+        logger.info("${næringsinntektDataForBeregning.antallMånederMedVedtakForÅr(årstallIFjor)} måneder med vedtak for fagsakId: ${fagsakOvergangsstønad.id} eksternFagsakId: ${fagsakOvergangsstønad.eksternId}")
+        logger.info("Forrige års inntekt for person uten ytelse fra offentlig: ${næringsinntektDataForBeregning.fjoråretsPersonInntekt} - næringsinntekt: ${næringsinntektDataForBeregning.fjoråretsNæringsinntekt} (Fagsak: ${fagsakOvergangsstønad.id})")
         return næringsinntektDataForBeregning
     }
 
@@ -64,7 +64,7 @@ class NæringsinntektDataForBeregningService(
     ): Int {
         val inntekt = sigrunService.hentInntektForAlleÅrMedInntekt(fagsakPersonId).filter { it.inntektsår == årstallIFjor }
         val næringsinntekt = inntekt.sumOf { it.næring } + inntekt.sumOf { it.svalbard?.næring ?: 0 }
-        secureLogger.info("Inntekt for person $inntekt - næringsinntekt er beregnet til: $næringsinntekt")
+        logger.info("Inntekt for person $inntekt - næringsinntekt er beregnet til: $næringsinntekt")
         return næringsinntekt
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.oppgave
 
 import no.nav.familie.ef.sak.felles.util.FnrUtil.validerOptionalIdent
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
@@ -19,7 +20,6 @@ import no.nav.familie.kontrakter.felles.oppgave.FinnOppgaveResponseDto
 import no.nav.familie.kontrakter.felles.oppgave.MappeDto
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
@@ -44,8 +44,7 @@ class OppgaveController(
     private val tilordnetRessursService: TilordnetRessursService,
     private val oppfølgingsoppgaveService: OppfølgingsoppgaveService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping(
         path = ["/soek"],
@@ -68,7 +67,7 @@ class OppgaveController(
                         .ident
                 }
 
-        secureLogger.info("AktoerId: $aktørId, Ident: ${finnOppgaveRequest.ident}")
+        logger.info("AktoerId: $aktørId, Ident: ${finnOppgaveRequest.ident}")
         val oppgaveRepons = oppgaveService.hentOppgaver(finnOppgaveRequest.tilFinnOppgaveRequest(aktørId))
         return Ressurs.success(oppgaveRepons.tilDto())
     }
@@ -86,7 +85,7 @@ class OppgaveController(
         @PathVariable behandlingId: UUID,
     ): Ressurs<OppgaveResponseDto> {
         val oppgaveIder = oppfølgingsoppgaveService.hentOppgaverForFerdigstillingEllerNull(behandlingId)?.fremleggsoppgaveIderSomSkalFerdigstilles
-        secureLogger.info("Oppgave ider for behandlingId: $behandlingId, oppgaveIder: $oppgaveIder")
+        logger.info("Oppgave ider for behandlingId: $behandlingId, oppgaveIder: $oppgaveIder")
         val oppgaver = oppgaveService.hentOppgaverMedIder(oppgaveIder)
         val antallTreffTotalt = oppgaver.size.toLong()
         val oppgaveResponse = FinnOppgaveResponseDto(antallTreffTotalt, oppgaver)

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -146,7 +146,7 @@ class OppgaveController(
         val oppgave = tilordnetRessursService.hentIkkeFerdigstiltOppgaveForBehandling(behandlingId)
         val saksbehandlerIdentIOppgaveSystemet = oppgave?.tilordnetRessurs
         if (oppgave != null && saksbehandlerIdentIOppgaveSystemet != saksbehandlerIdent) {
-            logger.info(
+            logger.vanligInfo(
                 "(Eier av behandling/oppgave) " +
                     "Saksbehandler $saksbehandlerIdent er inne i behandling=$behandlingId " +
                     "mens oppgaven=${oppgave.id} er tilordnet $saksbehandlerIdentIOppgaveSystemet " +

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -6,11 +6,11 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.ENHET_NR_NAY
 import no.nav.familie.ef.sak.oppgave.OppgaveUtil.lagOpprettOppgavebeskrivelse
 import no.nav.familie.ef.sak.oppgave.dto.UtdanningOppgaveDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.felles.Behandlingstema
 import no.nav.familie.kontrakter.felles.Tema
@@ -31,7 +31,6 @@ import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.InnhentDokumentasjon
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype.VurderHenvendelse
 import no.nav.familie.kontrakter.felles.oppgave.OpprettOppgaveRequest
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
-import org.slf4j.LoggerFactory
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
@@ -50,7 +49,7 @@ class OppgaveService(
     private val behandlingRepository: BehandlingRepository,
     private val personService: PersonService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun opprettOppgave(
         behandlingId: UUID,
@@ -321,7 +320,7 @@ class OppgaveService(
                     .ident
             }
 
-        secureLogger.info("hent flere oppgaver -  aktørId: $aktørId")
+        logger.info("hent flere oppgaver -  aktørId: $aktørId")
 
         val oppgaverForAutomatiskFerdigstilling =
             OppgaverForAutomatiskFerdigstilling.values().flatMap { type ->

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveService.kt
@@ -170,9 +170,9 @@ class OppgaveService(
                     }?.id
                     ?.toLong()
             mappeIdForGodkjenneVedtak?.let {
-                logger.info("Legger oppgave i Godkjenne vedtak-mappe")
+                logger.vanligInfo("Legger oppgave i Godkjenne vedtak-mappe")
             } ?: run {
-                logger.error("Fant ikke mappe for godkjenne vedtak: 70 Godkjenne vedtak for enhetsnummer=$enhetsnummer")
+                logger.vanligError("Fant ikke mappe for godkjenne vedtak: 70 Godkjenne vedtak for enhetsnummer=$enhetsnummer")
             }
             return mappeIdForGodkjenneVedtak
         }
@@ -269,7 +269,7 @@ class OppgaveService(
             ferdigstillOppgave(oppgave.gsakOppgaveId)
         } catch (e: RessursException) {
             if (ignorerFeilregistrert && e.ressurs.melding.contains("Oppgave har status feilregistrert")) {
-                logger.warn("Ignorerer ferdigstill av oppgave=${oppgave.gsakOppgaveId} som har status feilregistrert")
+                logger.vanligWarn("Ignorerer ferdigstill av oppgave=${oppgave.gsakOppgaveId} som har status feilregistrert")
             } else {
                 throw e
             }
@@ -384,14 +384,14 @@ class OppgaveService(
 
     fun finnMapper(enhet: String): List<MappeDto> =
         cacheManager.getValue("oppgave-mappe", enhet) {
-            logger.info("Henter mapper på nytt")
+            logger.vanligInfo("Henter mapper på nytt")
             val mappeRespons =
                 oppgaveClient.finnMapper(
                     enhetsnummer = enhet,
                     limit = 1000,
                 )
             if (mappeRespons.antallTreffTotalt > mappeRespons.mapper.size) {
-                logger.error(
+                logger.vanligError(
                     "Det finnes flere mapper (${mappeRespons.antallTreffTotalt}) " +
                         "enn vi har hentet ut (${mappeRespons.mapper.size}). Sjekk limit. ",
                 )
@@ -465,7 +465,7 @@ class OppgaveService(
                     ),
             )
 
-        logger.info("Hentet oppgaver:  ${behandleSakOppgaver.antallTreffTotalt}, ${behandleUnderkjent.antallTreffTotalt}, ${godkjenne.antallTreffTotalt}")
+        logger.vanligInfo("Hentet oppgaver:  ${behandleSakOppgaver.antallTreffTotalt}, ${behandleUnderkjent.antallTreffTotalt}, ${godkjenne.antallTreffTotalt}")
 
         feilHvis(behandleSakOppgaver.antallTreffTotalt >= limit) { "For mange behandleSakOppgaver - limit truffet: + $limit " }
         feilHvis(behandleUnderkjent.antallTreffTotalt >= limit) { "For mange behandleUnderkjent - limit truffet: + $limit " }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveUtil.kt
@@ -1,14 +1,14 @@
 package no.nav.familie.ef.sak.oppgave
 
 import no.nav.familie.ef.sak.felles.util.dagensDatoMedTidNorskFormat
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.kontrakter.felles.oppgave.IdentGruppe
 import no.nav.familie.kontrakter.felles.oppgave.Oppgave
-import org.slf4j.LoggerFactory
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 
 object OppgaveUtil {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     val ENHET_NR_NAY = "4489"
     val ENHET_NR_EGEN_ANSATT = "4483"

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlClient.kt
@@ -142,7 +142,7 @@ class PdlClient(
         val pdlIdenter = feilsjekkOgReturnerData(ident, pdlResponse) { it.hentIdenter }
 
         if (pdlIdenter.identer.isEmpty()) {
-            secureLogger.error("Finner ikke personidenter for personIdent i PDL $ident ")
+            logger.error("Finner ikke personidenter for personIdent i PDL $ident ")
         }
         return pdlIdenter
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PdlUtil.kt
@@ -2,15 +2,13 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.infrastruktur.exception.PdlNotFoundException
 import no.nav.familie.ef.sak.infrastruktur.exception.PdlRequestException
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlBolkResponse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdent
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlIdentBolkResponse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlResponse
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
-val secureLogger: Logger = LoggerFactory.getLogger("secureLogger")
-val logger: Logger = LoggerFactory.getLogger(PdlClient::class.java)
+val logger = Logg.getLogger(PdlClient::class)
 
 inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
     ident: String?,
@@ -21,17 +19,17 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
         if (pdlResponse.errors?.any { it.extensions?.notFound() == true } == true) {
             throw PdlNotFoundException()
         }
-        secureLogger.error("Feil ved henting av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
+        logger.error("Feil ved henting av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
     }
     if (pdlResponse.harAdvarsel()) {
         logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
-        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
     }
     val data = dataMapper.invoke(pdlResponse.data)
     if (data == null) {
         val errorMelding = if (ident != null) "Feil ved oppslag på ident $ident. " else "Feil ved oppslag på person."
-        secureLogger.error(
+        logger.error(
             errorMelding +
                 "PDL rapporterte ingen feil men returnerte tomt datafelt",
         )
@@ -42,7 +40,7 @@ inline fun <reified DATA : Any, reified T : Any> feilsjekkOgReturnerData(
 
 inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkResponse<T>): Map<String, T> {
     if (pdlResponse.data == null) {
-        secureLogger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
+        logger.error("Data fra pdl er null ved bolkoppslag av ${T::class} fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Data er null fra PDL -  ${T::class}. Se secure logg for detaljer.")
     }
 
@@ -51,19 +49,19 @@ inline fun <reified T : Any> feilsjekkOgReturnerData(pdlResponse: PdlBolkRespons
             .filter { it.code != "ok" }
             .associate { it.ident to it.code }
     if (feil.isNotEmpty()) {
-        secureLogger.error("Feil ved henting av ${T::class} fra PDL: $feil")
+        logger.error("Feil ved henting av ${T::class} fra PDL: $feil")
         throw PdlRequestException("Feil ved henting av ${T::class} fra PDL. Se secure logg for detaljer.")
     }
     if (pdlResponse.harAdvarsel()) {
         logger.warn("Advarsel ved henting av ${T::class} fra PDL. Se securelogs for detaljer.")
-        secureLogger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
+        logger.warn("Advarsel ved henting av ${T::class} fra PDL: ${pdlResponse.extensions?.warnings}")
     }
     return pdlResponse.data.personBolk.associateBy({ it.ident }, { it.person!! })
 }
 
 fun feilmeldOgReturnerData(pdlResponse: PdlIdentBolkResponse): Map<String, PdlIdent> {
     if (pdlResponse.data == null) {
-        secureLogger.error("Data fra pdl er null ved bolkoppslag av identer fra PDL: ${pdlResponse.errorMessages()}")
+        logger.error("Data fra pdl er null ved bolkoppslag av identer fra PDL: ${pdlResponse.errorMessages()}")
         throw PdlRequestException("Data er null fra PDL -  ${PdlIdentBolkResponse::class}. Se secure logg for detaljer.")
     }
 
@@ -74,7 +72,7 @@ fun feilmeldOgReturnerData(pdlResponse: PdlIdentBolkResponse): Map<String, PdlId
     if (feil.isNotEmpty()) {
         // Logg feil og gå vider. Ved feil returneres nåværende ident.
         logger.error("Feil ved henting av ${PdlIdentBolkResponse::class}. Nåværende ident returnert.")
-        secureLogger.error("Feil ved henting av ${PdlIdentBolkResponse::class} fra PDL: $feil. Nåværende ident returnert.")
+        logger.error("Feil ved henting av ${PdlIdentBolkResponse::class} fra PDL: $feil. Nåværende ident returnert.")
     }
     return pdlResponse.data.hentIdenterBolk.associateBy({ it.ident }, { it.gjeldende() })
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerService.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.infrastruktur.config.getValue
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.egenansatt.EgenAnsattClient
@@ -13,7 +14,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
 import no.nav.familie.kontrakter.felles.personopplysning.ADRESSEBESKYTTELSEGRADERING
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.Cacheable
@@ -32,7 +32,7 @@ class PersonopplysningerService(
     @Qualifier("shortCache")
     private val cacheManager: CacheManager,
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     fun hentPersonopplysningerForBehandling(behandlingId: UUID): PersonopplysningerDto {
         val personIdent = behandlingService.hentAktivIdent(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/endringer/EndringerIPersonOpplysningerService.kt
@@ -5,11 +5,11 @@ import no.nav.familie.ef.sak.behandling.Saksbehandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.felles.util.harGåttAntallTimer
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataMedMetadata
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 import java.util.UUID
@@ -20,7 +20,7 @@ class EndringerIPersonOpplysningerService(
     private val grunnlagsdataService: GrunnlagsdataService,
     private val personopplysningerService: PersonopplysningerService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun hentEndringerPersonopplysninger(behandlingId: UUID): EndringerIPersonopplysningerDto {
         val behandling = behandlingService.hentSaksbehandling(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt
 
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.logger
 import no.nav.familie.http.client.AbstractPingableRestClient
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
@@ -40,7 +40,7 @@ class HistoriskPensjonClient(
             } catch (e: Exception) {
                 val skalLoggeSisteForsøk = teller == (antallForsøk - 1)
                 if (skalLoggeSisteForsøk) {
-                    logger.error("Kunne ikke kalle historisk pensjon for uthenting")
+                    logger.vanligError("Kunne ikke kalle historisk pensjon for uthenting")
                     logger.error("Kunne ikke kalle historisk pensjon for uthenting", e)
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pensjon/HistoriskPensjonClient.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.http.client.AbstractRestClient
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -15,7 +15,7 @@ class HistoriskPensjonClient(
     private val historiskPensjonUri: URI,
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "pensjon") {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     private fun lagHarPensjonUri() =
         UriComponentsBuilder
@@ -41,7 +41,7 @@ class HistoriskPensjonClient(
                 val skalLoggeSisteForsøk = teller == (antallForsøk - 1)
                 if (skalLoggeSisteForsøk) {
                     logger.error("Kunne ikke kalle historisk pensjon for uthenting")
-                    secureLogger.error("Kunne ikke kalle historisk pensjon for uthenting", e)
+                    logger.error("Kunne ikke kalle historisk pensjon for uthenting", e)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.opplysninger.søknad
 
 import no.nav.familie.ef.sak.felles.domain.Sporbar
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søknad
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadMapper
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadType
@@ -14,7 +15,6 @@ import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -27,7 +27,7 @@ class SøknadService(
     private val søknadSkolepengerRepository: SøknadSkolepengerRepository,
     private val søknadBarnetilsynRepository: SøknadBarnetilsynRepository,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     fun hentSøknadsgrunnlag(behandlingId: UUID): Søknadsverdier? {
         val søknad = hentSøknad(behandlingId) ?: return null

--- a/src/main/kotlin/no/nav/familie/ef/sak/saksbehandler/SaksbehandlerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/saksbehandler/SaksbehandlerController.kt
@@ -1,11 +1,11 @@
 package no.nav.familie.ef.sak.saksbehandler
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.OppgaveClient
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.saksbehandler.Saksbehandler
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 class SaksbehandlerController(
     private val oppgaveClient: OppgaveClient,
 ) {
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val logger = Logg.getLogger(this::class)
 
     @GetMapping("/saksbehandler-informasjon")
     fun hentSaksbehandlerInformasjon(): Ressurs<Saksbehandler> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.sigrun.ekstern
 
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.http.client.AbstractRestClient
 import no.nav.familie.kontrakter.felles.PersonIdent
 import org.springframework.beans.factory.annotation.Qualifier
@@ -14,6 +15,8 @@ class SigrunClient(
     @Value("\${FAMILIE_EF_PROXY_URL}") private val uri: URI,
     @Qualifier("azure") restOperations: RestOperations,
 ) : AbstractRestClient(restOperations, "sigrun") {
+    private val logger = Logg.getLogger(this::class)
+
     fun hentPensjonsgivendeInntekt(
         fødselsnummer: String,
         inntektsår: Int,
@@ -27,7 +30,7 @@ class SigrunClient(
                 .toUri()
 
         val response = postForEntity<PensjonsgivendeInntektResponse>(uri, PersonIdent(fødselsnummer))
-        secureLogger.info("Pensjonsgivende inntekt for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
+        logger.info("Pensjonsgivende inntekt for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }
 
@@ -44,7 +47,7 @@ class SigrunClient(
                 .toUri()
 
         val response = postForEntity<SummertSkattegrunnlag>(uri, PersonIdent(fødselsnummer))
-        secureLogger.info("Summert skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
+        logger.info("Summert skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }
 
@@ -61,7 +64,7 @@ class SigrunClient(
                 .toUri()
 
         val response = postForEntity<List<BeregnetSkatt>>(uri, PersonIdent(fødselsnummer))
-        secureLogger.info("Beregnet skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
+        logger.info("Beregnet skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -59,7 +59,7 @@ class SimuleringService(
         feilHvis(saksbehandling.status.behandlingErLåstForVidereRedigering()) {
             "Kan ikke slette simulering for behandling=$behandlingId då den er låst"
         }
-        logger.info("Sletter simulering for behandling=$behandlingId")
+        logger.vanligInfo("Sletter simulering for behandling=$behandlingId")
         simuleringsresultatRepository.deleteById(behandlingId)
         tilbakekrevingOppryddingService.slettTilbakekrevingsvalg(behandlingId)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/simulering/SimuleringService.kt
@@ -5,11 +5,11 @@ import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingOppryddingService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
@@ -18,7 +18,6 @@ import no.nav.familie.http.client.RessursException
 import no.nav.familie.kontrakter.ef.iverksett.SimuleringDto
 import no.nav.familie.kontrakter.felles.simulering.BeriketSimuleringsresultat
 import no.nav.familie.kontrakter.felles.simulering.Simuleringsoppsummering
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -34,7 +33,7 @@ class SimuleringService(
     private val tilordnetRessursService: TilordnetRessursService,
     private val tilbakekrevingOppryddingService: TilbakekrevingOppryddingService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun simuler(saksbehandling: Saksbehandling): Simuleringsoppsummering {
@@ -89,7 +88,7 @@ class SimuleringService(
         val nySimuleringoppsummering = simulerMedTilkjentYtelse(saksbehandling).oppsummering
         val harUlikFeilutbetaling = lagretSimuleringsoppsummering.feilutbetaling != nySimuleringoppsummering.feilutbetaling
         if (harUlikFeilutbetaling) {
-            secureLogger.warn(
+            logger.warn(
                 "Behandling med ulikt simuleringsresultat i beslutter-steget. BehandlingId: ${saksbehandling.id} \n" +
                     "lagretSimuleringsoppsummering: $lagretSimuleringsoppsummering \n" +
                     "nySimuleringoppsummering: $nySimuleringoppsummering",

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -237,10 +237,10 @@ class VedtakController(
         @RequestBody
         personIdenter: List<String>,
     ): Ressurs<List<ForventetInntektForPersonIdent>> {
-        logger.info("hentPersonerMedAktivStonadOgForventetInntekt start")
+        logger.vanligInfo("hentPersonerMedAktivStonadOgForventetInntekt start")
         val personIdentToBehandlingIds =
             behandlingRepository.finnSisteIverksatteBehandlingerForPersonIdenter(personIdenter).toMap()
-        logger.info("hentPersonerMedAktivStonadOgForventetInntekt hentet behandlinger")
+        logger.vanligInfo("hentPersonerMedAktivStonadOgForventetInntekt hentet behandlinger")
 
         val personIdentMedForventetInntektList = mutableListOf<PersonIdentMedForventetInntekt>()
         val behandlingIdToForventetInntektMap =
@@ -257,7 +257,7 @@ class VedtakController(
             }
         }
 
-        logger.info("hentPersonerMedAktivStonadOgForventetInntekt done")
+        logger.vanligInfo("hentPersonerMedAktivStonadOgForventetInntekt done")
         return Ressurs.success(
             personIdentMedForventetInntektList.map {
                 ForventetInntektForPersonIdent(

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -11,9 +11,9 @@ import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.vedtak.dto.Avslå
 import no.nav.familie.ef.sak.vedtak.dto.BeslutteVedtakDto
 import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseOvergangsstønad
@@ -25,7 +25,6 @@ import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -63,7 +62,7 @@ class VedtakController(
     private val tilordnetRessursService: TilordnetRessursService,
     private val environment: org.springframework.core.env.Environment,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     @PostMapping("/{behandlingId}/send-til-beslutter")
     fun sendTilBeslutter(
@@ -250,9 +249,9 @@ class VedtakController(
         for (personIdent in personIdentToBehandlingIds.keys) {
             val behandlingId = personIdentToBehandlingIds[personIdent]
             val forventetInntektForBehandling = behandlingIdToForventetInntektMap[behandlingId]
-            secureLogger.info("PersonIdent: $personIdent ForventetInntektForBehandling: $forventetInntektForBehandling")
+            logger.info("PersonIdent: $personIdent ForventetInntektForBehandling: $forventetInntektForBehandling")
             if (forventetInntektForBehandling == null) {
-                secureLogger.warn("Fant ikke behandling $behandlingId knyttet til ident $personIdent - får ikke vurdert inntekt")
+                logger.warn("Fant ikke behandling $behandlingId knyttet til ident $personIdent - får ikke vurdert inntekt")
             } else {
                 personIdentMedForventetInntektList.add(PersonIdentMedForventetInntekt(personIdent, forventetInntektForBehandling))
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/historikk/VedtakHistorikkBeregner.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.beregning.Inntekt
 import no.nav.familie.ef.sak.beregning.barnetilsyn.BeløpsperiodeBarnetilsynDto
 import no.nav.familie.ef.sak.felles.util.YEAR_MONTH_MAX
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.tilkjentytelse.tilBeløpsperiodeBarnetilsyn
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetstypeBarnetilsyn
@@ -17,7 +18,6 @@ import no.nav.familie.ef.sak.vedtak.dto.Sanksjonsårsak
 import no.nav.familie.ef.sak.vedtak.dto.VedtaksperiodeDto
 import no.nav.familie.ef.sak.vilkår.regler.SvarId
 import no.nav.familie.kontrakter.felles.Månedsperiode
-import org.slf4j.LoggerFactory
 import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.YearMonth
@@ -118,7 +118,7 @@ data class VedtakshistorikkperiodeBarnetilsyn(
 }
 
 object VedtakHistorikkBeregner {
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     /**
      * Lager totalbilde av vedtak per behandling

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/OpprettUttrekkArbeidssøkerTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/OpprettUttrekkArbeidssøkerTask.kt
@@ -3,11 +3,11 @@ package no.nav.familie.ef.sak.vedtak.uttrekk
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.DatoFormat.DATE_FORMAT_ISO_YEAR_MONTH
 import no.nav.familie.ef.sak.felles.util.EnvUtil
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.prosessering.AsyncTaskStep
 import no.nav.familie.prosessering.TaskStepBeskrivelse
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 
@@ -26,8 +26,7 @@ class OpprettUttrekkArbeidssøkerTask(
     private val fagsakService: FagsakService,
     private val taskService: TaskService,
 ) : AsyncTaskStep {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun doTask(task: Task) {
         val årMåned = YearMonth.parse(task.payload)
@@ -53,7 +52,7 @@ class OpprettUttrekkArbeidssøkerTask(
             } catch (ex: Exception) {
                 val errorMelding = "Sjekk av utrekkArbeidssøker feiler fagsak=${it.fagsakId} behandling=${it.behandlingId}"
                 logger.warn(errorMelding)
-                secureLogger.warn("$errorMelding - ${ex.message}", ex)
+                logger.warn("$errorMelding - ${ex.message}", ex)
                 ++feilede
             }
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/uttrekk/UttrekkArbeidssøkerService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.vedtak.uttrekk
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.arbeidssøker.ArbeidssøkerClient
@@ -9,7 +10,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Adressebeskytte
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonKort
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
@@ -32,6 +32,8 @@ class UttrekkArbeidssøkerService(
     private val arbeidssøkerClient: ArbeidssøkerClient,
     private val vurderingService: VurderingService,
 ) {
+    private val logger = Logg.getLogger(this::class)
+
     fun forrigeMåned(): () -> YearMonth = { YearMonth.now().minusMonths(1) }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -42,7 +44,7 @@ class UttrekkArbeidssøkerService(
         personIdent: String,
     ) {
         val registrertSomArbeidssøker = erRegistrertSomArbeidssøker(personIdent, årMåned)
-        secureLogger.info("Registrert som arbeidssøker: $registrertSomArbeidssøker - fagsakId: $fagsakId")
+        logger.info("Registrert som arbeidssøker: $registrertSomArbeidssøker - fagsakId: $fagsakId")
         uttrekkArbeidssøkerRepository.insert(
             UttrekkArbeidssøkere(
                 fagsakId = fagsakId,
@@ -141,7 +143,7 @@ class UttrekkArbeidssøkerService(
                 .hentPerioder(
                     personIdent,
                 )
-        secureLogger.info("Fant perioder for arbeidssøker med ident $personIdent med perioder: $perioder")
+        logger.info("Fant perioder for arbeidssøker med ident $personIdent med perioder: $perioder")
         return perioder.any { it.startet.tidspunkt.toLocalDate() <= sisteIMåneden && (it.avsluttet == null || it.avsluttet.tidspunkt.toLocalDate() >= sisteIMåneden) }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.vilkår
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.vilkår.dto.EnkeltVilkårForGjenbrukRequest
 import no.nav.familie.ef.sak.vilkår.dto.GjenbruktVilkårResponseDto
@@ -14,7 +15,6 @@ import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregler
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -35,7 +35,7 @@ class VurderingController(
     private val tilgangService: TilgangService,
     private val gjenbrukVilkårService: GjenbrukVilkårService,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @GetMapping("regler")
     fun hentRegler(): Ressurs<Vilkårsregler> = Ressurs.success(Vilkårsregler.ALLE_VILKÅRSREGLER)
@@ -50,7 +50,7 @@ class VurderingController(
             return Ressurs.success(vurderingStegService.oppdaterVilkår(vilkårsvurdering))
         } catch (e: Exception) {
             val delvilkårJson = objectMapper.writeValueAsString(vilkårsvurdering.delvilkårsvurderinger)
-            secureLogger.warn(
+            logger.warn(
                 "id=${vilkårsvurdering.id}" +
                     " behandlingId=${vilkårsvurdering.behandlingId}" +
                     " svar=$delvilkårJson",

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataEndring
@@ -25,7 +26,6 @@ import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår
 import no.nav.familie.ef.sak.vilkår.regler.evalutation.OppdaterVilkår.opprettNyeVilkårsvurderinger
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -43,8 +43,7 @@ class VurderingService(
     private val tilordnetRessursService: TilordnetRessursService,
     private val samværsavtaleService: SamværsavtaleService,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     @Transactional
     fun hentEllerOpprettVurderinger(behandlingId: UUID): VilkårDto {
@@ -60,7 +59,7 @@ class VurderingService(
         if (behandling.harStatusOpprettet) {
             val endredeGrunnlagsdata = finnEndringerIGrunnlagsdata(behandlingId)
             if (endredeGrunnlagsdata.isNotEmpty()) {
-                secureLogger.info("Grunnlagsdata som har endret seg: $endredeGrunnlagsdata")
+                logger.info("Grunnlagsdata som har endret seg: $endredeGrunnlagsdata")
                 logger.info("Grunnlagsdata har endret seg siden sist. Sletter gamle vilkår og grunnlagsdata og legger inn nye.")
                 grunnlagsdataService.oppdaterOgHentNyGrunnlagsdata(behandlingId)
                 vilkårsvurderingRepository.deleteByBehandlingId(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/gjenbruk/GjenbrukVilkårService.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.fagsak.domain.Fagsak
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
@@ -21,7 +22,6 @@ import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
 import no.nav.familie.ef.sak.vilkår.Vilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårsvurderingRepository
 import no.nav.familie.ef.sak.vilkår.dto.GjenbruktVilkårResponse
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -37,7 +37,7 @@ class GjenbrukVilkårService(
     private val samværsavtaleService: SamværsavtaleService,
     private val behandlingStegOppdaterer: BehandlingStegOppdaterer,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+    private val logger = Logg.getLogger(this::class)
 
     fun finnBehandlingerForGjenbruk(behandlingId: UUID): List<BehandlingDto> {
         val fagsak: Fagsak = fagsakService.hentFagsakForBehandling(behandlingId)
@@ -64,7 +64,7 @@ class GjenbrukVilkårService(
                 behandlingSomSkalOppdateresId,
                 behandlingForGjenbrukId,
             )
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} gjenbruker vurderinger fra behandling $behandlingForGjenbrukId " +
                 "for å oppdatere vurderinger på inngangsvilkår for behandling $behandlingSomSkalOppdateresId",
         )
@@ -112,7 +112,7 @@ class GjenbrukVilkårService(
         behandlingForGjenbrukId: UUID,
         vilkårsvurderingSomSkalOppdateres: Vilkårsvurdering,
     ): Vilkårsvurdering {
-        secureLogger.info(
+        logger.info(
             "${SikkerhetContext.hentSaksbehandlerEllerSystembruker()} gjenbruker enkel vurdering fra behandling $behandlingForGjenbrukId " +
                 "for å oppdatere vurderinger på inngangsvilkår for behandling $behandlingSomSkalOppdateresId",
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/NyttBarnSammePartnerRegel.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.vilkår.regler.vilkår
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import no.nav.familie.ef.sak.behandling.domain.Behandling
+import no.nav.familie.ef.sak.infrastruktur.logg.Logg
 import no.nav.familie.ef.sak.vilkår.Delvilkårsvurdering
 import no.nav.familie.ef.sak.vilkår.VilkårType
 import no.nav.familie.ef.sak.vilkår.Vilkårsresultat
@@ -16,7 +17,6 @@ import no.nav.familie.ef.sak.vilkår.regler.Vilkårsregel
 import no.nav.familie.ef.sak.vilkår.regler.jaNeiSvarRegel
 import no.nav.familie.ef.sak.vilkår.regler.regelIder
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
-import org.slf4j.LoggerFactory
 import java.util.UUID
 
 class NyttBarnSammePartnerRegel :
@@ -26,7 +26,7 @@ class NyttBarnSammePartnerRegel :
         hovedregler = regelIder(HAR_FÅTT_ELLER_VENTER_NYTT_BARN_MED_SAMME_PARTNER),
     ) {
     @JsonIgnore
-    private val logger = LoggerFactory.getLogger(javaClass)
+    private val logger = Logg.getLogger(this::class)
 
     override fun initiereDelvilkårsvurdering(
         metadata: HovedregelMetadata,

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,62 +2,11 @@
 <configuration>
     <property name="ROOT_LOG_LEVEL" value="INFO"/>
 
-    <!-- Logger for sensitive data with TEAM_LOGS marker -->
-    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>50MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-    </appender>
     <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-            <customFields>{"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${HOSTNAME}","nais_container_name":"${NAIS_APP_NAME}"}</customFields>
-            <includeContext>false</includeContext>
-        </encoder>
-    </appender>
-
-    <!-- Appender for secure logs with marker filter -->
-    <appender name="secureLog-marker" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/secure-logs/secure.log</file>
         <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
             <evaluator>
-                <matcher>
-                    <Name>TEAM_LOGS</Name>
-                    <Value>TEAM_LOGS</Value>
-                </matcher>
-                <expression>marker != null &amp;&amp; marker.contains("TEAM_LOGS")</expression>
-            </evaluator>
-            <OnMismatch>DENY</OnMismatch>
-            <OnMatch>ACCEPT</OnMatch>
-        </filter>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>1</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>50MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-    </appender>
-
-    <!-- Appender for team logs with marker filter -->
-    <appender name="team-logs-marker" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
-        <destination>team-logs.nais-system:5170</destination>
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <matcher>
-                    <Name>TEAM_LOGS</Name>
-                    <Value>TEAM_LOGS</Value>
-                </matcher>
-                <expression>marker != null &amp;&amp; marker.contains("TEAM_LOGS")</expression>
+                <expression>return marker != null &amp;&amp; marker.contains("TEAM_LOGS");</expression>
             </evaluator>
             <OnMismatch>DENY</OnMismatch>
             <OnMatch>ACCEPT</OnMatch>
@@ -85,17 +34,13 @@
         <appender-ref ref="auditLogger" />
     </logger>
 
-    <!-- Spesiell håndtering av loggeren no.nav.log.LogFilter for å forhindre logging av isAlive-sjekker o.l. -->
     <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 
     <root level="${ROOT_LOG_LEVEL:-INFO}">
-        <!-- nais+local -->
         <appender-ref ref="stdout_json"/>
-        <appender-ref ref="secureLog-marker"/>
-        <appender-ref ref="team-logs-marker"/>
-        <!-- <appender-ref ref="Sentry" /> -->
+        <appender-ref ref="team-logs"/>
     </root>
 
     <logger name="no.nav" level="WARN"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,13 +4,6 @@
 
     <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
-        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-            <evaluator>
-                <expression>return marker != null &amp;&amp; marker.contains("TEAM_LOGS");</expression>
-            </evaluator>
-            <OnMismatch>DENY</OnMismatch>
-            <OnMatch>ACCEPT</OnMatch>
-        </filter>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>{"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${HOSTNAME}","nais_container_name":"${NAIS_APP_NAME}"}</customFields>
             <includeContext>false</includeContext>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
     <property name="ROOT_LOG_LEVEL" value="INFO"/>
 
-    <!-- Logger for sensitive data -->
+    <!-- Logger for sensitive data with TEAM_LOGS marker -->
     <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/secure-logs/secure.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
@@ -23,10 +23,50 @@
         </encoder>
     </appender>
 
-    <logger name="secureLogger" level="INFO" additivity="false">
-        <appender-ref ref="secureLog"/>
-        <appender-ref ref="team-logs"/>
-    </logger>
+    <!-- Appender for secure logs with marker filter -->
+    <appender name="secureLog-marker" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <matcher>
+                    <Name>TEAM_LOGS</Name>
+                    <Value>TEAM_LOGS</Value>
+                </matcher>
+                <expression>marker != null &amp;&amp; marker.contains("TEAM_LOGS")</expression>
+            </evaluator>
+            <OnMismatch>DENY</OnMismatch>
+            <OnMatch>ACCEPT</OnMatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+
+    <!-- Appender for team logs with marker filter -->
+    <appender name="team-logs-marker" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>team-logs.nais-system:5170</destination>
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator>
+                <matcher>
+                    <Name>TEAM_LOGS</Name>
+                    <Value>TEAM_LOGS</Value>
+                </matcher>
+                <expression>marker != null &amp;&amp; marker.contains("TEAM_LOGS")</expression>
+            </evaluator>
+            <OnMismatch>DENY</OnMismatch>
+            <OnMatch>ACCEPT</OnMatch>
+        </filter>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${HOSTNAME}","nais_container_name":"${NAIS_APP_NAME}"}</customFields>
+            <includeContext>false</includeContext>
+        </encoder>
+    </appender>
 
     <appender name="auditLogger" class="com.papertrailapp.logback.Syslog4jAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
@@ -53,6 +93,8 @@
     <root level="${ROOT_LOG_LEVEL:-INFO}">
         <!-- nais+local -->
         <appender-ref ref="stdout_json"/>
+        <appender-ref ref="secureLog-marker"/>
+        <appender-ref ref="team-logs-marker"/>
         <!-- <appender-ref ref="Sentry" /> -->
     </root>
 


### PR DESCRIPTION
# Migrere fra SecureLogs til Team Logs med generell logger

### Hvorfor er denne endringen nødvendig? ✨ 

NAIS ønsker at vi tar i bruk Team Logs fremover, der de velger å slutte støtte for SecureLogs. Derfor ønsker vi å migrere over til Team Logs med en generell logger. Denne generelle loggeren har som hensikt å heller logg ting trygt og for mye i sikre logger. Det kan derfor introdusere nye innslag i sikrelogger fremover, som må korrigeres. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-26894).

### Verdt å nevne

Har testet ved å: 

* gå gjennom endringene og prøvd å matche logg innslag med det som var før, mot det som blir.
* deployet til pre-prod og sett etter logger i Google Cloud Log Explorer, samt open Nav logs.

Loggene ser ut til å dukke opp både sikkeret og usikkert.

<img width="2184" height="1174" alt="image" src="https://github.com/user-attachments/assets/c93970c8-f7b0-4647-9321-1c1aa84303f1" />