### PR TITLE
Legger til firstOrNull for foedsted og foedeland for mapBarn metode

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -33,7 +33,7 @@ object GrunnlagsdataMapper {
         pdlPersonForelderBarn: PdlPersonForelderBarn,
         personIdent: String,
     ) = BarnMedIdent(
-        fødsel = mapFødsel(pdlPersonForelderBarn.fødselsdato.first(), pdlPersonForelderBarn.fødested.first()),
+        fødsel = mapFødsel(pdlPersonForelderBarn.fødselsdato.firstOrNull(), pdlPersonForelderBarn.fødested.firstOrNull()),
         adressebeskyttelse = pdlPersonForelderBarn.adressebeskyttelse,
         navn = pdlPersonForelderBarn.navn.gjeldende(),
         bostedsadresse = pdlPersonForelderBarn.bostedsadresse,


### PR DESCRIPTION
# Legger til firstOrNull for foedsted og foedeland for mapBarn metode

### Hvorfor er denne endringen nødvendig? ✨ 

Det virker som vi ikke tåler tom liste for fødested og fødeland når vi mapper barn rett fra pdl. Denne PRen har som hensikt å prøve å fikse dette. Det kan skyldes mapping oppdatering fra SB. 

Dette så vi der denne metoden feilet når man gikk inn på en sak der en bruker hadde barn der disse verdiene manglet og tom liste ble returnerert. 

### Verdt å nevne

Har snakket med PDL og fått de til å sjekke om saken dette gjelder, der verdiene PDL sender ser normale ut og vi er problemet. 