### PR TITLE
FeatureToggle innvilge kun opphør og sanksjons vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -403,8 +403,12 @@ class BeregnYtelseSteg(
 
         val andelerTilkjentYtelse: List<AndelTilkjentYtelse> =
             lagBeløpsperioderForInnvilgelseOvergangsstønad(vedtak, saksbehandling)
-        brukerfeilHvis(andelerTilkjentYtelse.isEmpty()) { "Innvilget vedtak må ha minimum en beløpsperiode" }
 
+        if (featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON)) {
+            logger.warn("NB! Krever ikke beløpsperiode for innvilgelse grunnet toggle innvilge kun opphør og sanksjon")
+        } else {
+            brukerfeilHvis(andelerTilkjentYtelse.isEmpty()) { "Innvilget vedtak må ha minimum en beløpsperiode" }
+        }
         val (nyeAndeler, startdato) =
             when (saksbehandling.type) {
                 FØRSTEGANGSBEHANDLING -> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -14,6 +14,8 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.min
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
 import no.nav.familie.ef.sak.simulering.SimuleringService
 import no.nav.familie.ef.sak.tilbakekreving.TilbakekrevingService
@@ -64,6 +66,7 @@ class BeregnYtelseSteg(
     private val fagsakService: FagsakService,
     private val validerOmregningService: ValiderOmregningService,
     private val oppfølgingsoppgaveService: OppfølgingsoppgaveService,
+    private val featureToggleService: FeatureToggleService,
 ) : BehandlingSteg<VedtakDto> {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val midlertidigOpphørFeilmelding = "Kan ikke starte vedtaket med opphørsperiode for en førstegangsbehandling"
@@ -223,8 +226,17 @@ class BeregnYtelseSteg(
         if (data is InnvilgelseOvergangsstønad) {
             val harOpphørsperioder = data.perioder.any { it.periodeType == VedtaksperiodeType.MIDLERTIDIG_OPPHØR }
             val harInnvilgedePerioder = data.perioder.any { !it.erMidlertidigOpphørEllerSanksjon() }
-            brukerfeilHvis(harOpphørsperioder && !harInnvilgedePerioder) {
-                "Må ha innvilgelsesperioder i tillegg til opphørsperioder"
+
+            if (featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON)) {
+                val harKunOpphørsperioderOgSanksjon = data.perioder.all { it.erMidlertidigOpphørEllerSanksjon() }
+                logger.warn("NB! Validerer ikke perioder for innvilgelse grunnet toggle innvilge kun opphør og sanksjon")
+                brukerfeilHvis(!harKunOpphørsperioderOgSanksjon) {
+                    "Må kun ha opphørsperioder og sanksjon"
+                }
+            } else {
+                brukerfeilHvis(harOpphørsperioder && !harInnvilgedePerioder) {
+                    "Må ha innvilgelsesperioder i tillegg til opphørsperioder"
+                }
             }
             brukerfeilHvis(
                 !saksbehandling.erMigrering &&

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseSteg.kt
@@ -744,7 +744,11 @@ class BeregnYtelseSteg(
                 forrigeTilkjenteYtelse.andelerTilkjentYtelse,
                 listOf(vedtak.periode.tilPeriode()),
             )
-        brukerfeilHvis(andelerTilkjentYtelse.isEmpty()) { "Innvilget vedtak må ha minimum en beløpsperiode" }
+        if (featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON)) {
+            logger.warn("NB! Krever ikke beløpsperiode for sanksjonert revurdering grunnet toggle innvilge kun opphør og sanksjon")
+        } else {
+            brukerfeilHvis(andelerTilkjentYtelse.isEmpty()) { "Innvilget vedtak må ha minimum en beløpsperiode" }
+        }
         return andelerTilkjentYtelse
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/BeregningService.kt
@@ -1,12 +1,15 @@
 package no.nav.familie.ef.sak.beregning
 
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.tilkjentytelse.tilBeløpsperiode
 import no.nav.familie.ef.sak.vedtak.domain.Vedtak
 import no.nav.familie.kontrakter.felles.Månedsperiode
 import no.nav.familie.kontrakter.felles.erSammenhengende
 import no.nav.familie.kontrakter.felles.harOverlappende
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -15,7 +18,10 @@ import java.util.UUID
 @Service
 class BeregningService(
     val tilkjentYtelseService: TilkjentYtelseService,
+    val featureToggleService: FeatureToggleService,
 ) {
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
     fun beregnYtelse(
         vedtaksperioder: List<Månedsperiode>,
         inntektsperioder: List<Inntektsperiode>,
@@ -34,6 +40,10 @@ class BeregningService(
     }
 
     private fun validerVedtaksperioder(vedtaksperioder: List<Månedsperiode>) {
+        if (featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON)) {
+            secureLogger.warn("Validerer ikke inntektsperioder/vedtaksperioder fordi toggle innvilge kun opphør og sanksjon er på for saksbehandler")
+            return
+        }
         brukerfeilHvis(
             vedtaksperioder.harOverlappende(),
         ) { "Vedtaksperioder $vedtaksperioder overlapper" }
@@ -43,6 +53,10 @@ class BeregningService(
         inntektsperioder: List<Inntektsperiode>,
         vedtaksperioder: List<Månedsperiode>,
     ) {
+        if (featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON)) {
+            secureLogger.warn("Validerer ikke inntektsperioder/vedtaksperioder fordi toggle innvilge kun opphør og sanksjon er på for saksbehandler")
+            return
+        }
         brukerfeilHvis(inntektsperioder.isEmpty()) {
             "Inntektsperioder kan ikke være tom liste"
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -20,6 +20,7 @@ enum class Toggle(
 
     // Operational
     G_BEREGNING("familie.ef.sak.g-beregning", "Operational"),
+    INNVILGE_KUN_OPPHØR_OG_SANKSJON("familie.ef.sak.innvilge-kun-opphor-og-sanskjon", "Operational"),
     G_BEREGNING_SCHEDULER("familie.ef.sak.g-beregning-scheduler", "Operational"),
     SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS("familie.ef.sak.bruk-nye-maxsatser", "Operational"),
     FRONTEND_VIS_IKKE_PUBLISERTE_BREVMALER(

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -108,6 +108,7 @@ internal class BeregnYtelseStegTest {
             fagsakService,
             validerOmregningService,
             oppfølgingsoppgaveService,
+            featureToggleService,
         )
 
     private val slot = slot<TilkjentYtelse>()
@@ -116,6 +117,7 @@ internal class BeregnYtelseStegTest {
     internal fun setUp() {
         every { featureToggleService.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
         every { featureToggleService.isEnabled(any()) } returns true
+        every { featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns false
         every { fagsakService.fagsakMedOppdatertPersonIdent(any()) } returns fagsak(fagsakpersoner(setOf("123")))
         every { simuleringService.hentOgLagreSimuleringsresultat(any()) }
             .returns(

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/BeregnYtelseStegTest.kt
@@ -40,6 +40,7 @@ import no.nav.familie.ef.sak.vedtak.VedtakService
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetType
 import no.nav.familie.ef.sak.vedtak.domain.AktivitetstypeBarnetilsyn
 import no.nav.familie.ef.sak.vedtak.domain.PeriodetypeBarnetilsyn
+import no.nav.familie.ef.sak.vedtak.domain.Vedtaksperiode
 import no.nav.familie.ef.sak.vedtak.domain.VedtaksperiodeType
 import no.nav.familie.ef.sak.vedtak.dto.Avslå
 import no.nav.familie.ef.sak.vedtak.dto.InnvilgelseBarnetilsyn
@@ -2005,6 +2006,64 @@ internal class BeregnYtelseStegTest {
         assertThat(feil.feil).contains("Periodene må være sammenhengende")
     }
 
+    @Test
+    internal fun `Skal bare innvilge med vedtak med opphør og sanksjon hvis feature toggle er INNVILGE_KUN_OPPHØR_OG_SANKSJON er på`() {
+        every { featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns true
+        every { beregningService.beregnYtelse(any(), any()) } returns emptyList()
+        val opphørFom = YearMonth.of(2021, 1)
+        val opphørTom = opphørFom.plusMonths(1)
+        val sanskjonsMåned = YearMonth.of(2021, 3)
+
+        utførSteg(
+            BehandlingType.REVURDERING,
+            sanksjon(sanskjonsMåned),
+            forrigeBehandlingId = UUID.randomUUID(),
+        )
+
+        mockHistorikk(andelhistorikkSanksjon(sanskjonsMåned))
+
+        utførSteg(
+            BehandlingType.REVURDERING,
+            innvilget(
+                listOf(
+                    opphørsperiode(opphørFom, opphørTom),
+                    sanksjonsperiode(sanskjonsMåned),
+                ),
+                listOf(inntekt(sanskjonsMåned)),
+            ),
+            forrigeBehandlingId = UUID.randomUUID(),
+        )
+
+        val tilkjentYtelse = slot.captured
+        assertThat(tilkjentYtelse.andelerTilkjentYtelse).isEmpty()
+
+        verify(exactly = 2) {
+            tilkjentYtelseService.opprettTilkjentYtelse(any())
+        }
+    }
+
+    @Test
+    internal fun `Skal feile ved innvilgelse med vanlig hovedperiode når feature toggle INNVILGE_KUN_OPPHØR_OG_SANKSJON er på`() {
+        every { featureToggleService.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns true
+        every { beregningService.beregnYtelse(any(), any()) } returns emptyList()
+        val periodeFom = YearMonth.of(2021, 1)
+        val periodeTom = YearMonth.of(2021, 6)
+
+        val feil =
+            assertThrows<ApiFeil> {
+                utførSteg(
+                    BehandlingType.REVURDERING,
+                    innvilget(
+                        listOf(innvilgetPeriode(periodeFom, periodeTom)),
+                        listOf(inntekt(periodeFom)),
+                    ),
+                    forrigeBehandlingId = UUID.randomUUID(),
+                )
+            }
+
+        assertThat(feil.feil).contains("Må kun ha opphørsperioder og sanksjon")
+    }
+
     private fun mockHistorikk(vararg andelHistorikkDto: AndelHistorikkDto) {
         every {
             andelsHistorikkService.hentHistorikk(any(), any())
@@ -2194,6 +2253,17 @@ internal class BeregnYtelseStegTest {
         periode = Månedsperiode(opphørFom, opphørTom),
         aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
         periodeType = VedtaksperiodeType.MIDLERTIDIG_OPPHØR,
+    )
+
+    private fun sanksjonsperiode(
+        sanksjonFom: YearMonth,
+    ) = VedtaksperiodeDto(
+        årMånedFra = sanksjonFom,
+        årMånedTil = sanksjonFom,
+        periode = Månedsperiode(sanksjonFom, sanksjonFom),
+        aktivitet = AktivitetType.IKKE_AKTIVITETSPLIKT,
+        periodeType = VedtaksperiodeType.SANKSJON,
+        sanksjonsårsak = Sanksjonsårsak.SAGT_OPP_STILLING,
     )
 
     private fun innvilgetPeriode(

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningControllerUnitTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.beregning
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.repository.vedtaksperiodeDto
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.ef.sak.vedtak.VedtakService
@@ -25,11 +26,12 @@ import java.util.UUID
 
 internal class BeregningControllerUnitTest {
     val tilkjentytelseService = mockk<TilkjentYtelseService>()
+    val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
     val vedtakService = mockk<VedtakService>()
 
     val beregningController =
         BeregningController(
-            beregningService = BeregningService(tilkjentytelseService),
+            beregningService = BeregningService(tilkjentytelseService, featureToggleService),
             tilgangService = mockk(relaxed = true),
             vedtakService = vedtakService,
         )

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/BeregningServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.beregning
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.repository.inntektsperiode
 import no.nav.familie.ef.sak.repository.tilkjentYtelse
 import no.nav.familie.ef.sak.repository.vedtak
@@ -22,7 +23,8 @@ import java.util.UUID
 
 internal class BeregningServiceTest {
     private val tilkjentYtelseService = mockk<TilkjentYtelseService>()
-    private val beregningService = BeregningService(tilkjentYtelseService = tilkjentYtelseService)
+    private val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
+    private val beregningService = BeregningService(tilkjentYtelseService = tilkjentYtelseService, featureToggleService = featureToggleService)
 
     @Test
     internal fun `skal beregne full ytelse når det ikke foreligger inntekt`() {

--- a/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/beregning/ValiderOmregningServiceTest.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.beregning.BeregningService
 import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.beregning.ValiderOmregningService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext.SYSTEM_FORKORTELSE
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -36,7 +37,8 @@ class ValiderOmregningServiceTest {
     val vedtakService = mockk<VedtakService>()
     val tilkjentYtelseRepository = mockk<TilkjentYtelseRepository>()
     val tilkjentYtelseService = mockk<TilkjentYtelseService>()
-    val beregningService = BeregningService(tilkjentYtelseService)
+    val featureToggleService = mockk<FeatureToggleService>(relaxed = true)
+    val beregningService = BeregningService(tilkjentYtelseService, featureToggleService)
     val vedtakHistorikkService = mockk<VedtakHistorikkService>()
     val validerOmregningService =
         ValiderOmregningService(

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -116,7 +116,7 @@ class StepDefinitions {
     private val andelsHistorikkService = mockk<AndelsHistorikkService>(relaxed = true)
     private val vedtakService = mockk<VedtakService>(relaxed = true)
     private val featureToggleService = mockFeatureToggleService()
-    private val beregningService = BeregningService(tilkjentYtelseService)
+    private val beregningService = BeregningService(tilkjentYtelseService, featureToggleService)
     private val beregningBarnetilsynService = BeregningBarnetilsynService(featureToggleService)
     private val beregningSkolepengerService =
         BeregningSkolepengerService(
@@ -145,6 +145,7 @@ class StepDefinitions {
             fagsakService,
             validerOmregningService,
             oppfølgingsoppgaveService,
+            featureToggleService,
         )
 
     private val vedtakHistorikkService =

--- a/src/test/kotlin/no/nav/familie/ef/sak/felles/util/FeatureToggleTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/felles/util/FeatureToggleTestUtil.kt
@@ -9,5 +9,6 @@ fun mockFeatureToggleService(enabled: Boolean = true): FeatureToggleService {
     val mockk = mockk<FeatureToggleService>()
     every { mockk.isEnabled(any()) } returns enabled
     every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
+    every { mockk.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns false
     return mockk
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -20,6 +20,7 @@ class FeatureToggleMock {
         every { mockk.isEnabled(Toggle.TILLAT_MIGRERING_7_ÅR_TILBAKE) } returns false
         every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
         every { mockk.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE) } returns false
+        every { mockk.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns false
         return mockk
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Lagt til toggle for å gi muligheten for å innvilge et vedtak hvor det kun er opphør og sanksjon. Dette skal brukes for et enkelttilfelle hvor vi er intresert i å opphøre tildigere vedtak og samtidig ikke overskrive tidligere sanksjon. 

Featuretoggle skal kun brukes for den enkelte saksbehandler som skal håndtere den relevante saken.