### PR TITLE
Prodfeil: Fix map søker. Fødselsdato og fødested kan være null, og det må håndteres i koden

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -75,7 +75,7 @@ object GrunnlagsdataMapper {
         dødsfall = pdlSøker.dødsfall.gjeldende(),
         forelderBarnRelasjon = pdlSøker.forelderBarnRelasjon.mapForelderBarnRelasjon(),
         fullmakt = mapFullmakt(pdlSøker, andrePersoner),
-        fødsel = mapFødsel(pdlSøker.fødselsdato.first(), pdlSøker.fødested.first()),
+        fødsel = mapFødsel(pdlSøker.fødselsdato.firstOrNull(), pdlSøker.fødested.firstOrNull()),
         folkeregisterpersonstatus = pdlSøker.folkeregisterpersonstatus,
         innflyttingTilNorge = pdlSøker.innflyttingTilNorge,
         kjønn = pdlSøker.kjønn.firstOrNull()?.kjønn ?: KjønnType.UKJENT,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler får feil i prod ved journalføring, da listen med fødselsdato og fødested kan være tom i prod. Håndterer nå dette.

Har også opprettet et kort på at det kanskje kan være greit å gå gjennom .first() i ef-sak, da det kan se ut til at det har blitt brukt feil flere steder.
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28651