### PR TITLE
Feature toggle legge til foreldreansvar barn barnetilsyn

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -4,17 +4,23 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
+import no.nav.familie.ef.sak.journalføring.dto.Fosterbarn
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
 import no.nav.familie.ef.sak.opplysninger.mapper.MatchetBehandlingBarn
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.BarnMedIdent
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.visningsnavn
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -22,6 +28,8 @@ class BarnService(
     private val barnRepository: BarnRepository,
     private val søknadService: SøknadService,
     private val behandlingService: BehandlingService,
+    private val featureToggleService: FeatureToggleService,
+    private val personService: PersonService,
 ) {
     /**
      * Barn som blir lagrede er:
@@ -39,12 +47,13 @@ class BarnService(
         stønadstype: StønadType,
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType = UstrukturertDokumentasjonType.IKKE_VALGT,
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
+        fosterbarn: List<Fosterbarn> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
     ) {
         val barnPåBehandlingen: List<BehandlingBarn> =
             when (stønadstype) {
                 StønadType.BARNETILSYN -> {
-                    barnForBarnetilsyn(barnSomSkalFødes, behandlingId, grunnlagsdataBarn)
+                    barnForBarnetilsyn(fosterbarn, behandlingId, grunnlagsdataBarn)
                 }
 
                 StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER -> {
@@ -65,22 +74,40 @@ class BarnService(
      * Barnetilsyn bruker barn fra registeret, og kobler det til søknadsbarn hvis det finnes i søknaden
      */
     private fun barnForBarnetilsyn(
-        barnSomSkalFødes: List<BarnSomSkalFødes>,
+        fosterbarn: List<Fosterbarn>,
         behandlingId: UUID,
         grunnlagsdataBarn: List<BarnMedIdent>,
     ): List<BehandlingBarn> {
-        feilHvis(barnSomSkalFødes.isNotEmpty()) {
-            "Kan ikke håndtere barnSomSkalFødes i barnetilsyn"
-        }
         val barnFraSøknad = hentSøknadsbarnForBehandling(behandlingId).associate { it.fødselsnummer to it.id }
-        return grunnlagsdataBarn.map { barn ->
-            BehandlingBarn(
-                behandlingId = behandlingId,
-                søknadBarnId = barnFraSøknad[barn.personIdent],
-                personIdent = barn.personIdent,
-                navn = barn.navn.visningsnavn(),
-            )
+        val registerbarn =
+            grunnlagsdataBarn.map { barn ->
+                BehandlingBarn(
+                    behandlingId = behandlingId,
+                    søknadBarnId = barnFraSøknad[barn.personIdent],
+                    personIdent = barn.personIdent,
+                    navn = barn.navn.visningsnavn(),
+                )
+            }
+        if (!featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN)) {
+            return registerbarn
         }
+        val fosterBarnPdlMap =
+            if (fosterbarn.isNotEmpty()) {
+                personService.hentPersonForelderBarnRelasjon(fosterbarn.map { it.fødselsnummer })
+            } else {
+                emptyMap()
+            }
+        val fosterBarnSomBehandlingBarn =
+            fosterbarn.map { barn ->
+                val pdlBarn = fosterBarnPdlMap[barn.fødselsnummer]
+                BehandlingBarn(
+                    behandlingId = behandlingId,
+                    personIdent = barn.fødselsnummer,
+                    navn = pdlBarn?.navn?.gjeldende()?.visningsnavn(),
+                    fødselTermindato = pdlBarn?.fødselsdato?.firstOrNull()?.fødselsdato,
+                )
+            }
+        return registerbarn + fosterBarnSomBehandlingBarn
     }
 
     private fun kobleBarnForOvergangsstønadOgSkolepenger(

--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.Foreldreansvarsbarn
+import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
@@ -46,13 +46,13 @@ class BarnService(
         stønadstype: StønadType,
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType = UstrukturertDokumentasjonType.IKKE_VALGT,
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
-        foreldreansvarsbarn: List<Foreldreansvarsbarn> = emptyList(),
+        foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
     ) {
         val barnPåBehandlingen: List<BehandlingBarn> =
             when (stønadstype) {
                 StønadType.BARNETILSYN -> {
-                    barnForBarnetilsyn(foreldreansvarsbarn, behandlingId, grunnlagsdataBarn)
+                    barnForBarnetilsyn(foreldreansvarBarn, behandlingId, grunnlagsdataBarn)
                 }
 
                 StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER -> {
@@ -73,7 +73,7 @@ class BarnService(
      * Barnetilsyn bruker barn fra registeret, og kobler det til søknadsbarn hvis det finnes i søknaden
      */
     private fun barnForBarnetilsyn(
-        foreldreansvarsbarn: List<Foreldreansvarsbarn>,
+        foreldreansvarBarn: List<ForeldreansvarBarn>,
         behandlingId: UUID,
         grunnlagsdataBarn: List<BarnMedIdent>,
     ): List<BehandlingBarn> {
@@ -90,15 +90,15 @@ class BarnService(
         if (!featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN)) {
             return registerbarn
         }
-        val foreldreansvarsbarnPdlMap =
-            if (foreldreansvarsbarn.isNotEmpty()) {
-                personService.hentPersonForelderBarnRelasjon(foreldreansvarsbarn.map { it.fødselsnummer })
+        val foreldreansvarBarnPdlMap =
+            if (foreldreansvarBarn.isNotEmpty()) {
+                personService.hentPersonForelderBarnRelasjon(foreldreansvarBarn.map { it.fødselsnummer })
             } else {
                 emptyMap()
             }
-        val foreldreansvarsbarnSomBehandlingBarn =
-            foreldreansvarsbarn.map { barn ->
-                val pdlBarn = foreldreansvarsbarnPdlMap[barn.fødselsnummer]
+        val foreldreansvarBarnSomBehandlingBarn =
+            foreldreansvarBarn.map { barn ->
+                val pdlBarn = foreldreansvarBarnPdlMap[barn.fødselsnummer]
                 BehandlingBarn(
                     behandlingId = behandlingId,
                     personIdent = barn.fødselsnummer,
@@ -106,7 +106,7 @@ class BarnService(
                     fødselTermindato = pdlBarn?.fødselsdato?.firstOrNull()?.fødselsdato,
                 )
             }
-        return registerbarn + foreldreansvarsbarnSomBehandlingBarn
+        return registerbarn + foreldreansvarBarnSomBehandlingBarn
     }
 
     private fun kobleBarnForOvergangsstønadOgSkolepenger(

--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
+import no.nav.familie.ef.sak.journalføring.dto.Foreldreansvarsbarn
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
@@ -46,13 +46,13 @@ class BarnService(
         stønadstype: StønadType,
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType = UstrukturertDokumentasjonType.IKKE_VALGT,
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
-        foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
+        foreldreansvarsbarn: List<Foreldreansvarsbarn> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
     ) {
         val barnPåBehandlingen: List<BehandlingBarn> =
             when (stønadstype) {
                 StønadType.BARNETILSYN -> {
-                    barnForBarnetilsyn(foreldreansvarBarn, behandlingId, grunnlagsdataBarn)
+                    barnForBarnetilsyn(foreldreansvarsbarn, behandlingId, grunnlagsdataBarn)
                 }
 
                 StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER -> {
@@ -73,7 +73,7 @@ class BarnService(
      * Barnetilsyn bruker barn fra registeret, og kobler det til søknadsbarn hvis det finnes i søknaden
      */
     private fun barnForBarnetilsyn(
-        foreldreansvarBarn: List<ForeldreansvarBarn>,
+        foreldreansvarsbarn: List<Foreldreansvarsbarn>,
         behandlingId: UUID,
         grunnlagsdataBarn: List<BarnMedIdent>,
     ): List<BehandlingBarn> {
@@ -90,15 +90,15 @@ class BarnService(
         if (!featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN)) {
             return registerbarn
         }
-        val foreldreansvarBarnPdlMap =
-            if (foreldreansvarBarn.isNotEmpty()) {
-                personService.hentPersonForelderBarnRelasjon(foreldreansvarBarn.map { it.fødselsnummer })
+        val foreldreansvarsbarnPdlMap =
+            if (foreldreansvarsbarn.isNotEmpty()) {
+                personService.hentPersonForelderBarnRelasjon(foreldreansvarsbarn.map { it.fødselsnummer })
             } else {
                 emptyMap()
             }
-        val foreldreansvarBarnSomBehandlingBarn =
-            foreldreansvarBarn.map { barn ->
-                val pdlBarn = foreldreansvarBarnPdlMap[barn.fødselsnummer]
+        val foreldreansvarsbarnSomBehandlingBarn =
+            foreldreansvarsbarn.map { barn ->
+                val pdlBarn = foreldreansvarsbarnPdlMap[barn.fødselsnummer]
                 BehandlingBarn(
                     behandlingId = behandlingId,
                     personIdent = barn.fødselsnummer,
@@ -106,7 +106,7 @@ class BarnService(
                     fødselTermindato = pdlBarn?.fødselsdato?.firstOrNull()?.fødselsdato,
                 )
             }
-        return registerbarn + foreldreansvarBarnSomBehandlingBarn
+        return registerbarn + foreldreansvarsbarnSomBehandlingBarn
     }
 
     private fun kobleBarnForOvergangsstønadOgSkolepenger(

--- a/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/barn/BarnService.kt
@@ -7,7 +7,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.Fosterbarn
+import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.mapper.BarnMatcher
@@ -20,7 +20,6 @@ import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.findAllByIdOrThrow
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -47,13 +46,13 @@ class BarnService(
         stønadstype: StønadType,
         ustrukturertDokumentasjonType: UstrukturertDokumentasjonType = UstrukturertDokumentasjonType.IKKE_VALGT,
         barnSomSkalFødes: List<BarnSomSkalFødes> = emptyList(),
-        fosterbarn: List<Fosterbarn> = emptyList(),
+        foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
         vilkårsbehandleNyeBarn: VilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
     ) {
         val barnPåBehandlingen: List<BehandlingBarn> =
             when (stønadstype) {
                 StønadType.BARNETILSYN -> {
-                    barnForBarnetilsyn(fosterbarn, behandlingId, grunnlagsdataBarn)
+                    barnForBarnetilsyn(foreldreansvarBarn, behandlingId, grunnlagsdataBarn)
                 }
 
                 StønadType.OVERGANGSSTØNAD, StønadType.SKOLEPENGER -> {
@@ -74,7 +73,7 @@ class BarnService(
      * Barnetilsyn bruker barn fra registeret, og kobler det til søknadsbarn hvis det finnes i søknaden
      */
     private fun barnForBarnetilsyn(
-        fosterbarn: List<Fosterbarn>,
+        foreldreansvarBarn: List<ForeldreansvarBarn>,
         behandlingId: UUID,
         grunnlagsdataBarn: List<BarnMedIdent>,
     ): List<BehandlingBarn> {
@@ -88,18 +87,18 @@ class BarnService(
                     navn = barn.navn.visningsnavn(),
                 )
             }
-        if (!featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN)) {
+        if (!featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN)) {
             return registerbarn
         }
-        val fosterBarnPdlMap =
-            if (fosterbarn.isNotEmpty()) {
-                personService.hentPersonForelderBarnRelasjon(fosterbarn.map { it.fødselsnummer })
+        val foreldreansvarBarnPdlMap =
+            if (foreldreansvarBarn.isNotEmpty()) {
+                personService.hentPersonForelderBarnRelasjon(foreldreansvarBarn.map { it.fødselsnummer })
             } else {
                 emptyMap()
             }
-        val fosterBarnSomBehandlingBarn =
-            fosterbarn.map { barn ->
-                val pdlBarn = fosterBarnPdlMap[barn.fødselsnummer]
+        val foreldreansvarBarnSomBehandlingBarn =
+            foreldreansvarBarn.map { barn ->
+                val pdlBarn = foreldreansvarBarnPdlMap[barn.fødselsnummer]
                 BehandlingBarn(
                     behandlingId = behandlingId,
                     personIdent = barn.fødselsnummer,
@@ -107,7 +106,7 @@ class BarnService(
                     fødselTermindato = pdlBarn?.fødselsdato?.firstOrNull()?.fødselsdato,
                 )
             }
-        return registerbarn + fosterBarnSomBehandlingBarn
+        return registerbarn + foreldreansvarBarnSomBehandlingBarn
     }
 
     private fun kobleBarnForOvergangsstønadOgSkolepenger(

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
@@ -80,7 +80,7 @@ class FørstegangsbehandlingService(
             stønadstype = fagsak.stønadstype,
             ustrukturertDokumentasjonType = UstrukturertDokumentasjonType.PAPIRSØKNAD,
             barnSomSkalFødes = førstegangsBehandlingRequest.barn,
-            foreldreansvarsbarn = førstegangsBehandlingRequest.foreldreansvarsbarn,
+            foreldreansvarBarn = førstegangsBehandlingRequest.foreldreansvarBarn,
             grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn,
             vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
@@ -80,7 +80,7 @@ class FørstegangsbehandlingService(
             stønadstype = fagsak.stønadstype,
             ustrukturertDokumentasjonType = UstrukturertDokumentasjonType.PAPIRSØKNAD,
             barnSomSkalFødes = førstegangsBehandlingRequest.barn,
-            foreldreansvarBarn = førstegangsBehandlingRequest.foreldreansvarBarn,
+            foreldreansvarsbarn = førstegangsBehandlingRequest.foreldreansvarsbarn,
             grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn,
             vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
@@ -80,7 +80,7 @@ class FørstegangsbehandlingService(
             stønadstype = fagsak.stønadstype,
             ustrukturertDokumentasjonType = UstrukturertDokumentasjonType.PAPIRSØKNAD,
             barnSomSkalFødes = førstegangsBehandlingRequest.barn,
-            foreldreansvarBarn = førstegangsBehandlingRequest.fosterbarn,
+            foreldreansvarBarn = førstegangsBehandlingRequest.foreldreansvarBarn,
             grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn,
             vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
@@ -80,6 +80,7 @@ class FørstegangsbehandlingService(
             stønadstype = fagsak.stønadstype,
             ustrukturertDokumentasjonType = UstrukturertDokumentasjonType.PAPIRSØKNAD,
             barnSomSkalFødes = førstegangsBehandlingRequest.barn,
+            fosterbarn = førstegangsBehandlingRequest.fosterbarn,
             grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn,
             vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingService.kt
@@ -80,7 +80,7 @@ class FørstegangsbehandlingService(
             stønadstype = fagsak.stønadstype,
             ustrukturertDokumentasjonType = UstrukturertDokumentasjonType.PAPIRSØKNAD,
             barnSomSkalFødes = førstegangsBehandlingRequest.barn,
-            fosterbarn = førstegangsBehandlingRequest.fosterbarn,
+            foreldreansvarBarn = førstegangsBehandlingRequest.fosterbarn,
             grunnlagsdataBarn = grunnlagsdata.grunnlagsdata.barn,
             vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.VILKÅRSBEHANDLE,
         )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
@@ -9,5 +9,5 @@ data class FørstegangsbehandlingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val barn: List<BarnSomSkalFødes> = emptyList(),
-    val fosterbarn: List<ForeldreansvarBarn> = emptyList(),
+    val foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.behandling.dto
 
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
+import no.nav.familie.ef.sak.journalføring.dto.Foreldreansvarsbarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import java.time.LocalDate
 
@@ -9,5 +9,5 @@ data class FørstegangsbehandlingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val barn: List<BarnSomSkalFødes> = emptyList(),
-    val foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
+    val foreldreansvarsbarn: List<Foreldreansvarsbarn> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.behandling.dto
 
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.Fosterbarn
+import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import java.time.LocalDate
 
@@ -9,5 +9,5 @@ data class FørstegangsbehandlingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val barn: List<BarnSomSkalFødes> = emptyList(),
-    val fosterbarn: List<Fosterbarn> = emptyList(),
+    val fosterbarn: List<ForeldreansvarBarn> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.behandling.dto
 
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
+import no.nav.familie.ef.sak.journalføring.dto.Fosterbarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import java.time.LocalDate
 
@@ -8,4 +9,5 @@ data class FørstegangsbehandlingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val barn: List<BarnSomSkalFødes> = emptyList(),
+    val fosterbarn: List<Fosterbarn> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/FørstegangsbehandlingDto.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ef.sak.behandling.dto
 
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
-import no.nav.familie.ef.sak.journalføring.dto.Foreldreansvarsbarn
+import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import java.time.LocalDate
 
@@ -9,5 +9,5 @@ data class FørstegangsbehandlingDto(
     val behandlingsårsak: BehandlingÅrsak,
     val kravMottatt: LocalDate,
     val barn: List<BarnSomSkalFødes> = emptyList(),
-    val foreldreansvarsbarn: List<Foreldreansvarsbarn> = emptyList(),
+    val foreldreansvarBarn: List<ForeldreansvarBarn> = emptyList(),
 )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -28,6 +28,7 @@ class FeatureToggleController(
             Toggle.FRONTEND_VIS_BEREGNINGSSKJEMA,
             Toggle.VIS_ANDRE_YTELSER,
             Toggle.MIGRERING_BARNETILSYN,
+            Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleController.kt
@@ -28,7 +28,7 @@ class FeatureToggleController(
             Toggle.FRONTEND_VIS_BEREGNINGSSKJEMA,
             Toggle.VIS_ANDRE_YTELSER,
             Toggle.MIGRERING_BARNETILSYN,
-            Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN
+            Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN,
         )
 
     @GetMapping

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -17,7 +17,7 @@ enum class Toggle(
     FRONTEND_KOPIER_KNAPP_ERROR_ALERT("familie.ef.sak.frontend-alert-error-med-copy-button", "Release"),
     FRONTEND_VIS_BEREGNINGSSKJEMA("familie.ef.sak.frontend-vis-beregningsskjema", "Release"),
     VIS_ANDRE_YTELSER("familie.ef.sak.vis-andre-ytelser", "Release"),
-    MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN("familie.ef.sak.muliget-legg-til-fosterbarn-barnetilsyn", "Release"),
+    MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN("familie.ef.sak.muliget-legg-til-foreldreansvarsbarn-barnetilsyn", "Release"),
 
     // Operational
     G_BEREGNING("familie.ef.sak.g-beregning", "Operational"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/featuretoggle/FeatureToggleService.kt
@@ -17,6 +17,7 @@ enum class Toggle(
     FRONTEND_KOPIER_KNAPP_ERROR_ALERT("familie.ef.sak.frontend-alert-error-med-copy-button", "Release"),
     FRONTEND_VIS_BEREGNINGSSKJEMA("familie.ef.sak.frontend-vis-beregningsskjema", "Release"),
     VIS_ANDRE_YTELSER("familie.ef.sak.vis-andre-ytelser", "Release"),
+    MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN("familie.ef.sak.muliget-legg-til-fosterbarn-barnetilsyn", "Release"),
 
     // Operational
     G_BEREGNING("familie.ef.sak.g-beregning", "Operational"),

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -69,7 +69,7 @@ data class BarnSomSkalFødes(
         )
 }
 
-data class ForeldreansvarBarn(
+data class Foreldreansvarsbarn(
     val fødselsnummer: String,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -69,7 +69,7 @@ data class BarnSomSkalFødes(
         )
 }
 
-data class Foreldreansvarsbarn(
+data class ForeldreansvarBarn(
     val fødselsnummer: String,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -69,6 +69,10 @@ data class BarnSomSkalFødes(
         )
 }
 
+data class Fosterbarn(
+    val fødselsnummer: String,
+)
+
 /**
  * [IKKE_VALGT] er indirekte det samme som digital søknad, der man ikke velger ustrukturert dokumentasjonstype
  */

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/dto/JournalføringRequest.kt
@@ -69,7 +69,7 @@ data class BarnSomSkalFødes(
         )
 }
 
-data class Fosterbarn(
+data class ForeldreansvarBarn(
     val fødselsnummer: String,
 )
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/mapper/BarnMedSamværMapper.kt
@@ -93,6 +93,7 @@ class BarnMedSamværMapper(
         return BarnMedSamværSøknadsgrunnlagDto(
             id = behandlingBarn.id,
             navn = behandlingBarn.navn,
+            fødselsnummer = behandlingBarn.personIdent,
             fødselTermindato = behandlingBarn.fødselTermindato,
             harSammeAdresse = søknadsbarn?.harSkalHaSammeAdresse,
             skalBoBorHosSøker = søknadsbarn?.skalBoHosSøker,

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/BarnMedSamværDto.kt
@@ -23,6 +23,7 @@ data class BarnMedSamværDto(
 data class BarnMedSamværSøknadsgrunnlagDto(
     val id: UUID,
     val navn: String?,
+    val fødselsnummer: String?,
     val fødselTermindato: LocalDate?,
     val harSammeAdresse: Boolean?,
     val skalBoBorHosSøker: String?,

--- a/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
+import no.nav.familie.ef.sak.journalføring.dto.ForeldreansvarBarn
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
@@ -307,6 +308,29 @@ internal class BarnServiceTest {
         assertThat(barnSlot.captured).hasSize(2)
         assertThat(barnSlot.captured[0].personIdent).isEqualTo(pdlTerminbarn.personIdent)
         assertThat(barnSlot.captured[1].personIdent).isEqualTo(barnOver18.personIdent)
+    }
+
+    @Test
+    internal fun `skal inkludere foreldreansvarsbarn når feature toggle er aktivert`() {
+        every { featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN) } returns true
+        val fødselsDato = LocalDate.now().minusYears(2)
+
+        val forelderAnsvarBarn = barnMedIdent(FnrGenerator.generer(fødselsDato), "J B")
+
+        every { personService.hentPersonForelderBarnRelasjon(any()) } returns mapOf()
+
+        barnService.opprettBarnPåBehandlingMedSøknadsdata(
+            behandlingId,
+            fagsakId,
+            emptyList(),
+            BARNETILSYN,
+            UstrukturertDokumentasjonType.IKKE_VALGT,
+            vilkårsbehandleNyeBarn = VilkårsbehandleNyeBarn.IKKE_VALGT,
+            foreldreansvarBarn = listOf(ForeldreansvarBarn(forelderAnsvarBarn.personIdent)),
+        )
+
+        assertThat(barnSlot.captured).hasSize(1)
+        assertThat(barnSlot.captured[0].personIdent).isEqualTo(forelderAnsvarBarn.personIdent)
     }
 
     @Nested

--- a/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
@@ -56,7 +56,7 @@ internal class BarnServiceTest {
         every { søknadService.hentSøknadsgrunnlag(behandlingId) } returns søknadMock
         every { søknadMock.barn } returns emptySet()
         every { barnRepository.insertAll(capture(barnSlot)) } answers { firstArg() }
-        every { featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN) } returns false
+        every { featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN) } returns false
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/barn/BarnServiceTest.kt
@@ -7,9 +7,12 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
 import no.nav.familie.ef.sak.journalføring.dto.UstrukturertDokumentasjonType
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadBarn
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Søknadsverdier
@@ -37,7 +40,9 @@ internal class BarnServiceTest {
     val barnRepository = mockk<BarnRepository>()
     val søknadService = mockk<SøknadService>()
     val behandlingService = mockk<BehandlingService>()
-    val barnService = BarnService(barnRepository, søknadService, behandlingService)
+    val featureToggleService = mockk<FeatureToggleService>()
+    val personService = mockk<PersonService>()
+    val barnService = BarnService(barnRepository, søknadService, behandlingService, featureToggleService, personService)
     val søknadMock = mockk<Søknadsverdier>()
     val fagsakId: UUID = UUID.randomUUID()
     val behandlingId: UUID = UUID.randomUUID()
@@ -51,6 +56,7 @@ internal class BarnServiceTest {
         every { søknadService.hentSøknadsgrunnlag(behandlingId) } returns søknadMock
         every { søknadMock.barn } returns emptySet()
         every { barnRepository.insertAll(capture(barnSlot)) } answers { firstArg() }
+        every { featureToggleService.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN) } returns false
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/cucumber/steps/StepDefinitions.kt
@@ -57,6 +57,7 @@ import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.Saksbeh
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.cucumber.domeneparser.sisteDagenIMånedenEllerDefault
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
@@ -126,7 +127,8 @@ class StepDefinitions {
     private val simuleringService = mockk<SimuleringService>(relaxed = true)
     private val tilbakekrevingService = mockk<TilbakekrevingService>(relaxed = true)
     private val barnRepository = mockk<BarnRepository>()
-    private val barnService = spyk(BarnService(barnRepository, mockk(), behandlingService))
+    private val personService = mockk<PersonService>()
+    private val barnService = spyk(BarnService(barnRepository, mockk(), behandlingService, featureToggleService, personService))
     private val fagsakService = mockFagsakService()
     private val validerOmregningService = mockk<ValiderOmregningService>(relaxed = true)
     private val oppfølgingsoppgaveService = mockk<OppfølgingsoppgaveService>(relaxed = true)

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -21,7 +21,7 @@ class FeatureToggleMock {
         every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
         every { mockk.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE) } returns false
         every { mockk.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns false
-        every { mockk.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN) } returns false
+        every { mockk.isEnabled(Toggle.MULIGHET_LEGG_TIL_FORELDREANSVARSBARN_BARNETILSYN) } returns false
         return mockk
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FeatureToggleMock.kt
@@ -21,6 +21,7 @@ class FeatureToggleMock {
         every { mockk.isEnabled(Toggle.SATSENDRING_BRUK_IKKE_VEDTATT_MAXSATS) } returns false
         every { mockk.isEnabled(Toggle.UTVIKLER_MED_VEILEDERRROLLE) } returns false
         every { mockk.isEnabled(Toggle.INNVILGE_KUN_OPPHØR_OG_SANKSJON) } returns false
+        every { mockk.isEnabled(Toggle.MULIGHET_LEGG_TIL_FOSTERBARN_BARNETILSYN) } returns false
         return mockk
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -185,7 +185,7 @@ internal class JournalføringServiceTest {
         every { fagsakService.fagsakMedOppdatertPersonIdent(any()) } returns fagsak
 
         justRun {
-            barnService.opprettBarnPåBehandlingMedSøknadsdata(any(), any(), any(), any(), any(), any(), any())
+            barnService.opprettBarnPåBehandlingMedSøknadsdata(any(), any(), any(), any(), any(), any(), any(), any())
         }
 
         every { behandlingService.hentBehandlinger(any<UUID>()) } returns emptyList()
@@ -595,7 +595,7 @@ internal class JournalføringServiceTest {
                 journalpost = ustrukturertJournalpost,
             )
             verifyOrder {
-                barnService.opprettBarnPåBehandlingMedSøknadsdata(any(), any(), any(), any(), any(), any(), any())
+                barnService.opprettBarnPåBehandlingMedSøknadsdata(any(), any(), any(), any(), any(), any(), any(), any())
                 vurderingService.kopierVurderingerOgSamværsavtalerTilNyBehandling(behandlingId, forrigeBehandlingId, any(), any())
                 behandlingService.oppdaterStatusPåBehandling(behandlingId, BehandlingStatus.UTREDES)
                 behandlingService.oppdaterStegPåBehandling(behandlingId, StegType.BEREGNE_YTELSE)

--- a/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/vilkår/regler/vilkår/VilkårGrunnlagTestUtil.kt
@@ -109,6 +109,7 @@ fun tomtSøknadsgrunnlag() =
         UUID.randomUUID(),
         fødselTermindato = null,
         navn = null,
+        fødselsnummer = null,
         harSammeAdresse = null,
         skalBoBorHosSøker = null,
         forelder = null,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Fjernet mulighet for å legge til terminbarn for barnetilsyn og lagt til mulighet for å legge til foreldreansvar barn bak featuretoggle. Legger også nå med fødselsnummer på søknadsgrunnlagDto fra behandlingBarn, dette for å løse visning i frontend for foreldreansvar barn.

[Frontend](https://github.com/navikt/familie-ef-sak-frontend/pull/3392)