### PR TITLE
Overgangsstønad søknad regelendring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <token-validation-spring.version>6.0.1</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>4.0_20260421110727_62291cc</kontrakter.version>
+        <kontrakter.version>4.0_20260427083013_f53660d</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20251111094125_cdf5bf2</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.31.0</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <token-validation-spring.version>6.0.1</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>4.0_20260316145734_3c2b7db</kontrakter.version>
+        <kontrakter.version>4.0_20260421110727_62291cc</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20251111094125_cdf5bf2</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.31.0</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.vilkår.gjenbruk.GjenbrukVilkårService
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
@@ -31,6 +32,7 @@ class BehandlingController(
     private val tilgangService: TilgangService,
     private val gjenbrukVilkårService: GjenbrukVilkårService,
     private val featureToggleService: FeatureToggleService,
+    private val søknadService: SøknadService,
 ) {
     @GetMapping("{behandlingId}")
     fun hentBehandling(
@@ -38,7 +40,8 @@ class BehandlingController(
     ): Ressurs<BehandlingDto> {
         val saksbehandling: Saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilPersonMedBarn(saksbehandling.ident, AuditLoggerEvent.ACCESS)
-        return Ressurs.success(saksbehandling.tilDto())
+        val erRegelendring2026 = søknadService.hentOvergangsstønad(behandlingId)?.erRegelendring2026 ?: false
+        return Ressurs.success(saksbehandling.tilDto(erRegelendring2026 = erRegelendring2026))
     }
 
     @GetMapping("gamle-behandlinger")

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/BehandlingDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/dto/BehandlingDto.kt
@@ -28,6 +28,7 @@ data class BehandlingDto(
     val stønadstype: StønadType,
     val vedtaksdato: LocalDateTime? = null,
     val henlagtÅrsak: HenlagtÅrsak? = null,
+    val erRegelendring2026: Boolean = false,
 )
 
 fun Behandling.tilDto(stønadstype: StønadType): BehandlingDto =
@@ -49,7 +50,7 @@ fun Behandling.tilDto(stønadstype: StønadType): BehandlingDto =
         vedtaksdato = this.vedtakstidspunkt,
     )
 
-fun Saksbehandling.tilDto(): BehandlingDto =
+fun Saksbehandling.tilDto(erRegelendring2026: Boolean = false): BehandlingDto =
     BehandlingDto(
         id = this.id,
         forrigeBehandlingId = this.forrigeBehandlingId,
@@ -66,4 +67,5 @@ fun Saksbehandling.tilDto(): BehandlingDto =
         henlagtÅrsak = this.henlagtÅrsak,
         stønadstype = stønadstype,
         vedtaksdato = this.vedtakstidspunkt,
+        erRegelendring2026 = erRegelendring2026,
     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/DatabaseConfiguration.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/DatabaseConfiguration.kt
@@ -10,6 +10,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdat
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Arbeidssituasjon
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Dokumentasjon
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.GjelderDeg
+import no.nav.familie.ef.sak.opplysninger.søknad.domain.StringListeWrapper
 import no.nav.familie.ef.sak.samværsavtale.domain.SamværsukeWrapper
 import no.nav.familie.ef.sak.vedtak.domain.BarnetilsynWrapper
 import no.nav.familie.ef.sak.vedtak.domain.InntektWrapper
@@ -131,6 +132,8 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
             SamværsukerTilPGobjectConverter(),
             GrunnlagsdataInntektTilPGobjectConverter(),
             PGobjectTilGrunnlagsdataInntekt(),
+            StringListeWrapperTilStringConverter(),
+            StringTilStringListeWrapperConverter(),
         )
 
     @ReadingConverter
@@ -418,5 +421,15 @@ class DatabaseConfiguration : AbstractJdbcConfiguration() {
                 type = "json"
                 value = jsonMapper.writeValueAsString(samværsuker.uker)
             }
+    }
+
+    @WritingConverter
+    class StringListeWrapperTilStringConverter : Converter<StringListeWrapper, String> {
+        override fun convert(wrapper: StringListeWrapper): String = wrapper.verdier.joinToString(";")
+    }
+
+    @ReadingConverter
+    class StringTilStringListeWrapperConverter : Converter<String, StringListeWrapper> {
+        override fun convert(verdi: String): StringListeWrapper = StringListeWrapper(verdi.split(";").filter { it.isNotEmpty() })
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -328,12 +328,14 @@ class JournalføringService(
     ) {
         when (fagsak.stønadstype) {
             StønadType.OVERGANGSSTØNAD -> {
-                val råJson = journalpostService.hentRåJsonSøknadFraJournalpostForOvergangsstønad(journalpost)
-                if (jsonMapper.readTree(råJson).path("erRegelendring2026").asBoolean(false)) {
-                    val søknad = jsonMapper.readValue(råJson, SøknadOvergangsstønadRegelendring2026::class.java)
-                    søknadService.lagreSøknadForOvergangsstønadRegelendring2026(søknad, behandlingId, fagsak.id, journalpost.journalpostId)
+                val jsonOs = journalpostService.hentOvergangssøknadJsonFraJournalpost(journalpost)
+                val erRegelendring2026 = jsonMapper.readTree(jsonOs).path("erRegelendring2026").asBoolean(false)
+
+                if (erRegelendring2026) {
+                    val søknad = jsonMapper.readValue(jsonOs, SøknadOvergangsstønadRegelendring2026::class.java)
+                    søknadService.lagreSøknadForOvergangsstønadRegelendring2026(søknad, behandlingId, journalpost.journalpostId)
                 } else {
-                    val søknad = jsonMapper.readValue(råJson, SøknadOvergangsstønad::class.java)
+                    val søknad = jsonMapper.readValue(jsonOs, SøknadOvergangsstønad::class.java)
                     søknadService.lagreSøknadForOvergangsstønad(søknad, behandlingId, fagsak.id, journalpost.journalpostId)
                 }
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringService.kt
@@ -29,9 +29,12 @@ import no.nav.familie.ef.sak.opplysninger.søknad.SøknadService
 import no.nav.familie.ef.sak.vilkår.VurderingService
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.ef.journalføring.AutomatiskJournalføringResponse
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.journalpost.Journalpost
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
+import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
@@ -325,8 +328,14 @@ class JournalføringService(
     ) {
         when (fagsak.stønadstype) {
             StønadType.OVERGANGSSTØNAD -> {
-                val søknad = journalpostService.hentSøknadFraJournalpostForOvergangsstønad(journalpost)
-                søknadService.lagreSøknadForOvergangsstønad(søknad, behandlingId, fagsak.id, journalpost.journalpostId)
+                val råJson = journalpostService.hentRåJsonSøknadFraJournalpostForOvergangsstønad(journalpost)
+                if (jsonMapper.readTree(råJson).path("erRegelendring2026").asBoolean(false)) {
+                    val søknad = jsonMapper.readValue(råJson, SøknadOvergangsstønadRegelendring2026::class.java)
+                    søknadService.lagreSøknadForOvergangsstønadRegelendring2026(søknad, behandlingId, fagsak.id, journalpost.journalpostId)
+                } else {
+                    val søknad = jsonMapper.readValue(råJson, SøknadOvergangsstønad::class.java)
+                    søknadService.lagreSøknadForOvergangsstønad(søknad, behandlingId, fagsak.id, journalpost.journalpostId)
+                }
             }
 
             StønadType.BARNETILSYN -> {

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
@@ -81,6 +81,11 @@ class JournalpostService(
         return journalpostClient.hentOvergangsstønadSøknad(journalpost.journalpostId, dokumentinfo.dokumentInfoId)
     }
 
+    fun hentRåJsonSøknadFraJournalpostForOvergangsstønad(journalpost: Journalpost): ByteArray {
+        val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(journalpost, DokumentBrevkode.OVERGANGSSTØNAD)
+        return journalpostClient.hentDokument(journalpost.journalpostId, dokumentinfo.dokumentInfoId, DokumentVariantformat.ORIGINAL)
+    }
+
     fun hentSøknadFraJournalpostForBarnetilsyn(journalpost: Journalpost): SøknadBarnetilsyn {
         val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(journalpost, DokumentBrevkode.BARNETILSYN)
         return journalpostClient.hentBarnetilsynSøknad(journalpost.journalpostId, dokumentinfo.dokumentInfoId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostService.kt
@@ -76,12 +76,7 @@ class JournalpostService(
         dokumentVariantformat: DokumentVariantformat = DokumentVariantformat.ARKIV,
     ): ByteArray = journalpostClient.hentDokument(journalpostId, dokumentInfoId, dokumentVariantformat)
 
-    fun hentSøknadFraJournalpostForOvergangsstønad(journalpost: Journalpost): SøknadOvergangsstønad {
-        val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(journalpost, DokumentBrevkode.OVERGANGSSTØNAD)
-        return journalpostClient.hentOvergangsstønadSøknad(journalpost.journalpostId, dokumentinfo.dokumentInfoId)
-    }
-
-    fun hentRåJsonSøknadFraJournalpostForOvergangsstønad(journalpost: Journalpost): ByteArray {
+    fun hentOvergangssøknadJsonFraJournalpost(journalpost: Journalpost): ByteArray {
         val dokumentinfo = JournalføringHelper.plukkUtOriginaldokument(journalpost, DokumentBrevkode.OVERGANGSSTØNAD)
         return journalpostClient.hentDokument(journalpost.journalpostId, dokumentinfo.dokumentInfoId, DokumentVariantformat.ORIGINAL)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
@@ -94,7 +94,6 @@ class SøknadService(
     fun lagreSøknadForOvergangsstønadRegelendring2026(
         søknad: SøknadOvergangsstønadRegelendring2026,
         behandlingId: UUID,
-        fagsakId: UUID,
         journalpostId: String,
     ) {
         val søknadsskjema = SøknadsskjemaMapper.tilDomene(søknad)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/SøknadService.kt
@@ -13,6 +13,7 @@ import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
 import no.nav.familie.ef.sak.repository.findByIdOrThrow
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -80,6 +81,18 @@ class SøknadService(
     @Transactional
     fun lagreSøknadForOvergangsstønad(
         søknad: SøknadOvergangsstønad,
+        behandlingId: UUID,
+        fagsakId: UUID,
+        journalpostId: String,
+    ) {
+        val søknadsskjema = SøknadsskjemaMapper.tilDomene(søknad)
+        søknadOvergangsstønadRepository.insert(søknadsskjema)
+        søknadRepository.insert(SøknadMapper.toDomain(journalpostId, søknadsskjema, behandlingId))
+    }
+
+    @Transactional
+    fun lagreSøknadForOvergangsstønadRegelendring2026(
+        søknad: SøknadOvergangsstønadRegelendring2026,
         behandlingId: UUID,
         fagsakId: UUID,
         journalpostId: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/StringListeWrapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/StringListeWrapper.kt
@@ -1,0 +1,5 @@
+package no.nav.familie.ef.sak.opplysninger.søknad.domain
+
+data class StringListeWrapper(
+    val verdier: List<String>,
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
@@ -45,8 +45,8 @@ data class SøknadsskjemaOvergangsstønad(
     val erRegelendring2026: Boolean = false,
     @Column("hva_situasjon")
     val hvaSituasjon: StringListeWrapper? = null,
-    @Column("har_inntekt")
-    val harInntekt: StringListeWrapper? = null,
+    @Column("inntekter")
+    val inntekter: StringListeWrapper? = null,
 ) : ISøknadsskjema
 
 data class Situasjon(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
@@ -43,8 +43,6 @@ data class SøknadsskjemaOvergangsstønad(
     val adresseopplysninger: Adresseopplysninger?,
     @Column("er_regelendring_2026")
     val erRegelendring2026: Boolean = false,
-    @Column("hva_situasjon")
-    val hvaSituasjon: StringListeWrapper? = null,
     @Column("inntekter")
     val inntekter: StringListeWrapper? = null,
 ) : ISøknadsskjema

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/SøknadsskjemaOvergangsstønad.kt
@@ -41,6 +41,12 @@ data class SøknadsskjemaOvergangsstønad(
     val søkerFraBestemtMåned: Boolean,
     @Embedded(onEmpty = Embedded.OnEmpty.USE_NULL, prefix = "adresseopplysninger_")
     val adresseopplysninger: Adresseopplysninger?,
+    @Column("er_regelendring_2026")
+    val erRegelendring2026: Boolean = false,
+    @Column("hva_situasjon")
+    val hvaSituasjon: StringListeWrapper? = null,
+    @Column("har_inntekt")
+    val harInntekt: StringListeWrapper? = null,
 ) : ISøknadsskjema
 
 data class Situasjon(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/Søknadsverdier.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/Søknadsverdier.kt
@@ -13,13 +13,14 @@ data class Søknadsverdier(
     val sivilstandsplaner: Sivilstandsplaner?,
     val bosituasjon: Bosituasjon,
     val sivilstand: Sivilstand,
-    val aktivitet: Aktivitet? = null, // Gjelder: OS og BT
-    val situasjon: Situasjon? = null, // Gjelder: OS
+    val aktivitet: Aktivitet? = null,
+    val situasjon: Situasjon? = null,
     val datoMottatt: LocalDateTime,
     val datoPåbegyntSøknad: LocalDate? = null,
     val søkerFra: YearMonth? = null,
     val adresseopplysninger: Adresseopplysninger?,
     val dokumentasjon: DokumentasjonFraSøknadDto,
+    val inntekter: List<String> = emptyList(),
 )
 
 data class DokumentasjonFraSøknadDto(
@@ -102,4 +103,5 @@ fun SøknadsskjemaOvergangsstønad.tilSøknadsverdier() =
         adresseopplysninger = this.adresseopplysninger,
         datoPåbegyntSøknad = this.datoPåbegyntSøknad,
         dokumentasjon = DokumentasjonMapper.tilDokumentasjonDto(this),
+        inntekter = this.inntekter?.verdier ?: emptyList(),
     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/AktivitetMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/AktivitetMapper.kt
@@ -26,6 +26,7 @@ object AktivitetMapper {
         situasjon: Situasjon?,
         søknadBarn: Set<SøknadBarn>,
         datoPåbegyntSøknad: LocalDate?,
+        inntekter: List<String> = emptyList(),
     ): AktivitetDto =
         AktivitetDto(
             arbeidssituasjon = aktivitet?.hvordanErArbeidssituasjonen?.verdier ?: emptyList(),
@@ -43,6 +44,7 @@ object AktivitetMapper {
             særligeTilsynsbehov = tilSærligeTilsynsbehovDto(søknadBarn),
             datoOppstartJobb = situasjon?.oppstartNyJobb,
             erIArbeid = aktivitet?.erIArbeid,
+            inntekter = inntekter,
         )
 
     private fun tilArbeidforholdDto(arbeidsgivere: Set<Arbeidsgiver>?): List<ArbeidsforholdSøknadDto> =

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -101,7 +101,6 @@ object SøknadsskjemaMapper {
             søkerFraBestemtMåned = kontraktsøknad.stønadsstart.verdi.søkerFraBestemtMåned.verdi,
             adresseopplysninger = tilDomene(kontraktsøknad.personalia, kontraktsøknad.adresseopplysninger),
             erRegelendring2026 = true,
-            hvaSituasjon = StringListeWrapper(kontraktsøknad.hvaSituasjon.svarId ?: emptyList()),
             inntekter = StringListeWrapper(kontraktsøknad.inntekter.svarId ?: emptyList()),
             aktivitet =
                 Aktivitet(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -101,16 +101,16 @@ object SøknadsskjemaMapper {
             søkerFraBestemtMåned = kontraktsøknad.stønadsstart.verdi.søkerFraBestemtMåned.verdi,
             adresseopplysninger = tilDomene(kontraktsøknad.personalia, kontraktsøknad.adresseopplysninger),
             erRegelendring2026 = true,
-            hvaSituasjon = StringListeWrapper(kontraktsøknad.hvaSituasjon.verdi),
-            harInntekt = StringListeWrapper(kontraktsøknad.harInntekt.verdi),
+            hvaSituasjon = StringListeWrapper(kontraktsøknad.hvaSituasjon.svarId ?: emptyList()),
+            harInntekt = StringListeWrapper(kontraktsøknad.harInntekt.svarId ?: emptyList()),
             aktivitet =
                 Aktivitet(
-                    hvordanErArbeidssituasjonen = Arbeidssituasjon(kontraktsøknad.harInntekt.verdi),
+                    hvordanErArbeidssituasjonen = Arbeidssituasjon(kontraktsøknad.harInntekt.svarId ?: emptyList()),
                     firmaer = tilFirmaer(kontraktsøknad.firmaer?.verdi),
                 ),
             situasjon =
                 Situasjon(
-                    gjelderDetteDeg = GjelderDeg(kontraktsøknad.hvaSituasjon.verdi),
+                    gjelderDetteDeg = GjelderDeg(kontraktsøknad.hvaSituasjon.svarId ?: emptyList()),
                     sagtOppEllerRedusertStilling = kontraktsøknad.sagtOppEllerRedusertStilling?.verdi,
                     oppsigelseReduksjonÅrsak = kontraktsøknad.begrunnelseSagtOppEllerRedusertStilling?.verdi,
                     oppsigelseReduksjonTidspunkt = kontraktsøknad.datoSagtOppEllerRedusertStilling?.verdi,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -21,6 +21,7 @@ import no.nav.familie.ef.sak.opplysninger.søknad.domain.Selvstendig
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Situasjon
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Sivilstand
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.Sivilstandsplaner
+import no.nav.familie.ef.sak.opplysninger.søknad.domain.StringListeWrapper
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadBarn
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadType
 import no.nav.familie.ef.sak.opplysninger.søknad.domain.SøknadsskjemaBarnetilsyn
@@ -57,6 +58,7 @@ import no.nav.familie.kontrakter.ef.søknad.Situasjon as KontraktSituasjon
 import no.nav.familie.kontrakter.ef.søknad.Sivilstandsplaner as KontraktSivilstandsplaner
 import no.nav.familie.kontrakter.ef.søknad.SøknadBarnetilsyn as KontraktSøknadBarnetilsyn
 import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønad as KontraktSøknadOvergangsstønad
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026 as KontraktSøknadOvergangsstønadRegelendring2026
 import no.nav.familie.kontrakter.ef.søknad.SøknadSkolepenger as KontraktSøknadSkolepenger
 import no.nav.familie.kontrakter.ef.søknad.TidligereUtdanning as KontraktTidligereUtdanning
 import no.nav.familie.kontrakter.ef.søknad.UnderUtdanning as KontraktUnderUtdanning
@@ -81,6 +83,38 @@ object SøknadsskjemaMapper {
             søkerFra = tilDomene(kontraktsøknad.stønadsstart.verdi),
             søkerFraBestemtMåned = kontraktsøknad.stønadsstart.verdi.søkerFraBestemtMåned.verdi,
             adresseopplysninger = tilDomene(kontraktsøknad.personalia, kontraktsøknad.adresseopplysninger),
+        )
+
+    fun tilDomene(kontraktsøknad: KontraktSøknadOvergangsstønadRegelendring2026): SøknadsskjemaOvergangsstønad =
+        SøknadsskjemaOvergangsstønad(
+            fødselsnummer = kontraktsøknad.personalia.verdi.fødselsnummer.verdi.verdi,
+            navn = kontraktsøknad.personalia.verdi.navn.verdi,
+            type = SøknadType.OVERGANGSSTØNAD,
+            datoMottatt = kontraktsøknad.innsendingsdetaljer.verdi.datoMottatt.verdi,
+            datoPåbegyntSøknad = kontraktsøknad.innsendingsdetaljer.verdi.datoPåbegyntSøknad,
+            sivilstand = tilDomene(kontraktsøknad.sivilstandsdetaljer.verdi),
+            medlemskap = tilDomene(kontraktsøknad.medlemskapsdetaljer.verdi),
+            bosituasjon = tilDomene(kontraktsøknad.bosituasjon.verdi),
+            sivilstandsplaner = tilDomene(kontraktsøknad.sivilstandsplaner?.verdi),
+            barn = tilDomene(kontraktsøknad.barn.verdi),
+            søkerFra = tilDomene(kontraktsøknad.stønadsstart.verdi),
+            søkerFraBestemtMåned = kontraktsøknad.stønadsstart.verdi.søkerFraBestemtMåned.verdi,
+            adresseopplysninger = tilDomene(kontraktsøknad.personalia, kontraktsøknad.adresseopplysninger),
+            erRegelendring2026 = true,
+            hvaSituasjon = StringListeWrapper(kontraktsøknad.hvaSituasjon.verdi),
+            harInntekt = StringListeWrapper(kontraktsøknad.harInntekt.verdi),
+            aktivitet =
+                Aktivitet(
+                    hvordanErArbeidssituasjonen = Arbeidssituasjon(kontraktsøknad.harInntekt.verdi),
+                    firmaer = tilFirmaer(kontraktsøknad.firmaer?.verdi),
+                ),
+            situasjon =
+                Situasjon(
+                    gjelderDetteDeg = GjelderDeg(kontraktsøknad.hvaSituasjon.verdi),
+                    sagtOppEllerRedusertStilling = kontraktsøknad.sagtOppEllerRedusertStilling?.verdi,
+                    oppsigelseReduksjonÅrsak = kontraktsøknad.begrunnelseSagtOppEllerRedusertStilling?.verdi,
+                    oppsigelseReduksjonTidspunkt = kontraktsøknad.datoSagtOppEllerRedusertStilling?.verdi,
+                ),
         )
 
     fun tilDomene(kontraktsøknad: KontraktSøknadBarnetilsyn): SøknadsskjemaBarnetilsyn =

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -110,7 +110,7 @@ object SøknadsskjemaMapper {
             situasjon =
                 Situasjon(
                     gjelderDetteDeg = GjelderDeg(kontraktsøknad.hvaSituasjon.svarId ?: emptyList()),
-                    sagtOppEllerRedusertStilling = kontraktsøknad.sagtOppEllerRedusertStilling?.verdi,
+                    sagtOppEllerRedusertStilling = kontraktsøknad.sagtOppEllerRedusertStilling?.svarId,
                     oppsigelseReduksjonÅrsak = kontraktsøknad.begrunnelseSagtOppEllerRedusertStilling?.verdi,
                     oppsigelseReduksjonTidspunkt = kontraktsøknad.datoSagtOppEllerRedusertStilling?.verdi,
                 ),

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/mapper/SøknadsskjemaMapper.kt
@@ -102,10 +102,10 @@ object SøknadsskjemaMapper {
             adresseopplysninger = tilDomene(kontraktsøknad.personalia, kontraktsøknad.adresseopplysninger),
             erRegelendring2026 = true,
             hvaSituasjon = StringListeWrapper(kontraktsøknad.hvaSituasjon.svarId ?: emptyList()),
-            harInntekt = StringListeWrapper(kontraktsøknad.harInntekt.svarId ?: emptyList()),
+            inntekter = StringListeWrapper(kontraktsøknad.inntekter.svarId ?: emptyList()),
             aktivitet =
                 Aktivitet(
-                    hvordanErArbeidssituasjonen = Arbeidssituasjon(kontraktsøknad.harInntekt.svarId ?: emptyList()),
+                    hvordanErArbeidssituasjonen = Arbeidssituasjon(kontraktsøknad.inntekter.svarId ?: emptyList()),
                     firmaer = tilFirmaer(kontraktsøknad.firmaer?.verdi),
                 ),
             situasjon =

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
@@ -52,7 +52,8 @@ class VilkårGrunnlagService(
                     aktivitet = it.aktivitet,
                     situasjon = it.situasjon,
                     søknadBarn = it.barn,
-                    it.datoPåbegyntSøknad,
+                    datoPåbegyntSøknad = it.datoPåbegyntSøknad,
+                    inntekter = it.inntekter,
                 )
             }
         val søknadsbarn = søknad?.barn ?: emptyList()

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/Overgangsstønad.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/Overgangsstønad.kt
@@ -23,6 +23,7 @@ data class AktivitetDto(
     val særligeTilsynsbehov: List<SærligeTilsynsbehovDto>,
     val datoOppstartJobb: LocalDate?,
     val erIArbeid: String?,
+    val inntekter: List<String> = emptyList(),
 )
 
 data class SagtOppEllerRedusertStillingDto(

--- a/src/main/resources/db/migration/V163__regelendring_2026_felter.sql
+++ b/src/main/resources/db/migration/V163__regelendring_2026_felter.sql
@@ -1,0 +1,4 @@
+ALTER TABLE soknadsskjema
+    ADD COLUMN er_regelendring_2026 BOOLEAN DEFAULT false,
+    ADD COLUMN hva_situasjon       VARCHAR,
+    ADD COLUMN har_inntekt         VARCHAR;

--- a/src/main/resources/db/migration/V164__rename_har_inntekt_til_inntekter.sql
+++ b/src/main/resources/db/migration/V164__rename_har_inntekt_til_inntekter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE soknadsskjema
+    RENAME COLUMN har_inntekt TO inntekter;

--- a/src/main/resources/db/migration/V165__drop_hva_situasjon.sql
+++ b/src/main/resources/db/migration/V165__drop_hva_situasjon.sql
@@ -1,0 +1,2 @@
+ALTER TABLE soknadsskjema
+    DROP COLUMN hva_situasjon;

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -853,7 +853,7 @@ internal class JournalføringServiceTest {
             bosituasjon = gammelSøknad.bosituasjon,
             barn = gammelSøknad.barn,
             hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("Jeg har barn under 14 måneder"), svarId = listOf("barnUnder14Måneder")),
-            harInntekt = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
+            inntekter = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
             firmaer =
                 Søknadsfelt(
                     "Firmaer",

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.felles.util.BrukerContextUtil
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.journalføring.dto.BarnSomSkalFødes
+import no.nav.familie.ef.sak.journalføring.dto.DokumentVariantformat
 import no.nav.familie.ef.sak.journalføring.dto.JournalføringRequestV2
 import no.nav.familie.ef.sak.journalføring.dto.JournalføringTilNyBehandlingRequest
 import no.nav.familie.ef.sak.journalføring.dto.Journalføringsaksjon
@@ -43,6 +44,9 @@ import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak.NYE_OPPLYSNINGER
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak.SØKNAD
 import no.nav.familie.kontrakter.ef.iverksett.BehandlingKategori
 import no.nav.familie.kontrakter.ef.sak.DokumentBrevkode
+import no.nav.familie.kontrakter.ef.søknad.Selvstendig
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
+import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import no.nav.familie.kontrakter.felles.Fagsystem
 import no.nav.familie.kontrakter.felles.dokarkiv.BulkOppdaterLogiskVedleggRequest
@@ -58,6 +62,7 @@ import no.nav.familie.kontrakter.felles.journalpost.Journalposttype
 import no.nav.familie.kontrakter.felles.journalpost.Journalstatus
 import no.nav.familie.kontrakter.felles.journalpost.LogiskVedlegg
 import no.nav.familie.kontrakter.felles.journalpost.RelevantDato
+import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.familie.kontrakter.felles.oppgave.OppgavePrioritet
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
@@ -70,6 +75,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 internal class JournalføringServiceTest {
@@ -210,6 +216,14 @@ internal class JournalføringServiceTest {
             søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any())
         } just Runs
 
+        every {
+            søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any())
+        } just Runs
+
+        every {
+            journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL)
+        } returns jsonMapper.writeValueAsBytes(Testsøknad.søknadOvergangsstønad)
+
         every { taskService.save(capture(slotOpprettedeTasks)) } answers { firstArg() }
 
         every { behandlingService.oppdaterStegPåBehandling(any(), any()) } returns behandling(id = behandlingId)
@@ -262,9 +276,6 @@ internal class JournalføringServiceTest {
                 stønadstype = StønadType.OVERGANGSSTØNAD,
             )
 
-        every {
-            journalpostClient.hentOvergangsstønadSøknad(any(), any())
-        } returns Testsøknad.søknadOvergangsstønad
         every { infotrygdPeriodeValideringService.validerKanOppretteBehandlingGittInfotrygdData(any()) } just Runs
         every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns null
 
@@ -292,6 +303,32 @@ internal class JournalføringServiceTest {
             assertThat(oppdatertDokument?.tittel).isEqualTo(nyTittel)
         }
         assertThat(slotOpprettedeTasks.map { it.type }).doesNotContain(OpprettOppgaveForOpprettetBehandlingTask.TYPE)
+        verify { journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL) }
+        verify(exactly = 0) { journalpostClient.hentOvergangsstønadSøknad(any(), any()) }
+        verify { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
+    }
+
+    @Test
+    internal fun `skal bruke regelendring2026-søknad ved deteksjon av ny versjon`() {
+        every { fagsakService.hentFagsak(fagsakId) } returns
+            fagsak(
+                id = fagsakId,
+                eksternId = fagsakEksternId,
+                stønadstype = StønadType.OVERGANGSSTØNAD,
+            )
+        every {
+            journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL)
+        } returns jsonMapper.writeValueAsBytes(lagTestRegelendring2026Søknad())
+        every { infotrygdPeriodeValideringService.validerKanOppretteBehandlingGittInfotrygdData(any()) } just Runs
+        every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns null
+
+        journalføringService.fullførJournalpostV2(
+            journalpost = journalpostDigitalSøknad,
+            journalføringRequest = lagRequest(årsak = Journalføringsårsak.DIGITAL_SØKNAD, aksjon = Journalføringsaksjon.OPPRETT_BEHANDLING),
+        )
+
+        verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
+        verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
     }
 
     @Test
@@ -326,9 +363,6 @@ internal class JournalføringServiceTest {
                 stønadstype = StønadType.OVERGANGSSTØNAD,
             )
         every { journalpostClient.hentJournalpost(journalpostId) } returns (journalpostDigitalSøknad.copy(journalstatus = Journalstatus.JOURNALFOERT))
-        every {
-            journalpostClient.hentOvergangsstønadSøknad(any(), any())
-        } returns Testsøknad.søknadOvergangsstønad
         every { infotrygdPeriodeValideringService.validerKanOppretteBehandlingGittInfotrygdData(any()) } just Runs
         every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns null
 
@@ -370,9 +404,6 @@ internal class JournalføringServiceTest {
     @Test
     internal fun `opprettBehandlingMedSøknadsdataFraEnFerdigstiltJournalpost skal kaste feil hvis finnes i infotrygd`() {
         every { journalpostClient.hentJournalpost(journalpostId) } returns (journalpostDigitalSøknad.copy(journalstatus = Journalstatus.JOURNALFOERT))
-        every {
-            journalpostClient.hentOvergangsstønadSøknad(any(), any())
-        } returns Testsøknad.søknadOvergangsstønad
 
         mockFeilerValideringAvInfotrygdperioder()
 
@@ -657,10 +688,6 @@ internal class JournalføringServiceTest {
 
         @Test
         internal fun `skal automatisk journalføre en ny digital søknad`() {
-            every {
-                journalpostClient.hentOvergangsstønadSøknad(any(), any())
-            } returns Testsøknad.søknadOvergangsstønad
-
             every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns null
             val journalførendeEnhet = "4489"
             val mappeId = 1234L
@@ -675,7 +702,10 @@ internal class JournalføringServiceTest {
                 )
             verify { journalpostClient.oppdaterJournalpost(any(), journalpostId, null) }
             verify { journalpostClient.ferdigstillJournalpost(journalpostId, journalførendeEnhet, null) }
+            verify { journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL) }
+            verify(exactly = 0) { journalpostClient.hentOvergangsstønadSøknad(any(), any()) }
             verify { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
+            verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
             verify {
                 behandlingService.opprettBehandling(
                     behandlingType = FØRSTEGANGSBEHANDLING,
@@ -699,6 +729,26 @@ internal class JournalføringServiceTest {
             assertThat(res.behandlingId).isEqualTo(behandlingId)
             assertThat(res.fagsakId).isEqualTo(fagsakId)
             assertThat(slotOpprettedeTasks.map { it.type }).containsExactly(OpprettOppgaveForOpprettetBehandlingTask.TYPE)
+        }
+
+        @Test
+        internal fun `skal bruke regelendring2026-søknad ved automatisk journalføring`() {
+            every {
+                journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL)
+            } returns jsonMapper.writeValueAsBytes(lagTestRegelendring2026Søknad())
+            every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns null
+
+            journalføringService.automatiskJournalfør(
+                fagsak,
+                journalpostDigitalSøknad,
+                "4489",
+                null,
+                FØRSTEGANGSBEHANDLING,
+                OppgavePrioritet.NORM,
+            )
+
+            verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
+            verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
         }
     }
 
@@ -791,5 +841,32 @@ internal class JournalføringServiceTest {
 
     private fun mockSisteIverksatteBehandlinger(sisteBehandling: Behandling?) {
         every { behandlingService.finnSisteIverksatteBehandlingMedEventuellAvslått(any()) } returns sisteBehandling
+    }
+
+    private fun lagTestRegelendring2026Søknad(): SøknadOvergangsstønadRegelendring2026 {
+        val gammelSøknad = Testsøknad.søknadOvergangsstønad
+        return SøknadOvergangsstønadRegelendring2026(
+            innsendingsdetaljer = gammelSøknad.innsendingsdetaljer,
+            personalia = gammelSøknad.personalia,
+            sivilstandsdetaljer = gammelSøknad.sivilstandsdetaljer,
+            medlemskapsdetaljer = gammelSøknad.medlemskapsdetaljer,
+            bosituasjon = gammelSøknad.bosituasjon,
+            barn = gammelSøknad.barn,
+            hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("barnUnder14Måneder")),
+            harInntekt = Søknadsfelt("Har du inntekt?", listOf("arbeidstaker")),
+            firmaer =
+                Søknadsfelt(
+                    "Firmaer",
+                    listOf(
+                        Selvstendig(
+                            firmanavn = Søknadsfelt("Firmanavn", "Firma AS"),
+                            organisasjonsnummer = Søknadsfelt("Orgnr", "123456789"),
+                            etableringsdato = Søknadsfelt("Etableringsdato", LocalDate.of(2020, 1, 1)),
+                            hvordanSerArbeidsukenUt = Søknadsfelt("Arbeidsuke", "8 timer daglig"),
+                        ),
+                    ),
+                ),
+            stønadsstart = gammelSøknad.stønadsstart,
+        )
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -217,7 +217,7 @@ internal class JournalføringServiceTest {
         } just Runs
 
         every {
-            søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any())
+            søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any())
         } just Runs
 
         every {
@@ -327,7 +327,7 @@ internal class JournalføringServiceTest {
             journalføringRequest = lagRequest(årsak = Journalføringsårsak.DIGITAL_SØKNAD, aksjon = Journalføringsaksjon.OPPRETT_BEHANDLING),
         )
 
-        verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
+        verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any()) }
         verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
     }
 
@@ -705,7 +705,7 @@ internal class JournalføringServiceTest {
             verify { journalpostClient.hentDokument(journalpostId, dokumentInfoIdMedJsonVerdi, DokumentVariantformat.ORIGINAL) }
             verify(exactly = 0) { journalpostClient.hentOvergangsstønadSøknad(any(), any()) }
             verify { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
-            verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
+            verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any()) }
             verify {
                 behandlingService.opprettBehandling(
                     behandlingType = FØRSTEGANGSBEHANDLING,
@@ -747,7 +747,7 @@ internal class JournalføringServiceTest {
                 OppgavePrioritet.NORM,
             )
 
-            verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any(), any()) }
+            verify { søknadService.lagreSøknadForOvergangsstønadRegelendring2026(any(), any(), any()) }
             verify(exactly = 0) { søknadService.lagreSøknadForOvergangsstønad(any(), any(), any(), any()) }
         }
     }

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalføringServiceTest.kt
@@ -852,8 +852,8 @@ internal class JournalføringServiceTest {
             medlemskapsdetaljer = gammelSøknad.medlemskapsdetaljer,
             bosituasjon = gammelSøknad.bosituasjon,
             barn = gammelSøknad.barn,
-            hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("barnUnder14Måneder")),
-            harInntekt = Søknadsfelt("Har du inntekt?", listOf("arbeidstaker")),
+            hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("Jeg har barn under 14 måneder"), svarId = listOf("barnUnder14Måneder")),
+            harInntekt = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
             firmaer =
                 Søknadsfelt(
                     "Firmaer",

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/AktivitetMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/AktivitetMapperTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 internal class AktivitetMapperTest {
     @Test
     internal fun `sjekker at mappet aktivitet har fått satt alle verdier`() {
-        val dto = AktivitetMapper.tilDto(aktivitet(), situasjon(), barn(), LocalDate.now())
+        val dto = AktivitetMapper.tilDto(aktivitet(), situasjon(), barn(), LocalDate.now(), inntekter = listOf("arbeidstaker"))
         sjekkAtAlleVerdierErSatt(dto)
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
@@ -238,7 +238,7 @@ internal class SøknadsskjemaMapperTest {
                 barn = gammelSøknad.barn,
                 hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("Jeg har barn under 14 måneder", "Barnet trenger særlig tilsyn"), svarId = listOf("barnUnder14Måneder", "barnSærligTilsyn")),
                 inntekter = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
-                sagtOppEllerRedusertStilling = Søknadsfelt("Sagt opp?", "sagtOpp"),
+                sagtOppEllerRedusertStilling = Søknadsfelt("Sagt opp?", "Dette er tekst", svarId = "sagtOpp"),
                 begrunnelseSagtOppEllerRedusertStilling = Søknadsfelt("Begrunnelse", "Reduksjon forklaring"),
                 firmaer =
                     Søknadsfelt(

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
@@ -209,7 +209,6 @@ internal class SøknadsskjemaMapperTest {
             val result = SøknadsskjemaMapper.tilDomene(søknad)
 
             assertThat(result.erRegelendring2026).isTrue()
-            assertThat(result.hvaSituasjon?.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
             assertThat(result.inntekter?.verdier).containsExactly("arbeidstaker")
             assertThat(result.aktivitet.hvordanErArbeidssituasjonen?.verdier).containsExactly("arbeidstaker")
             assertThat(result.situasjon.gjelderDetteDeg.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
@@ -225,7 +224,6 @@ internal class SøknadsskjemaMapperTest {
             val result = SøknadsskjemaMapper.tilDomene(søknad)
 
             assertThat(result.erRegelendring2026).isFalse()
-            assertThat(result.hvaSituasjon).isNull()
             assertThat(result.inntekter).isNull()
         }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
@@ -238,8 +238,8 @@ internal class SøknadsskjemaMapperTest {
                 medlemskapsdetaljer = gammelSøknad.medlemskapsdetaljer,
                 bosituasjon = gammelSøknad.bosituasjon,
                 barn = gammelSøknad.barn,
-                hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("barnUnder14Måneder", "barnSærligTilsyn")),
-                harInntekt = Søknadsfelt("Har du inntekt?", listOf("arbeidstaker")),
+                hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("Jeg har barn under 14 måneder", "Barnet trenger særlig tilsyn"), svarId = listOf("barnUnder14Måneder", "barnSærligTilsyn")),
+                harInntekt = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
                 sagtOppEllerRedusertStilling = Søknadsfelt("Sagt opp?", "sagtOpp"),
                 begrunnelseSagtOppEllerRedusertStilling = Søknadsfelt("Begrunnelse", "Reduksjon forklaring"),
                 firmaer =

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
@@ -210,7 +210,7 @@ internal class SøknadsskjemaMapperTest {
 
             assertThat(result.erRegelendring2026).isTrue()
             assertThat(result.hvaSituasjon?.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
-            assertThat(result.harInntekt?.verdier).containsExactly("arbeidstaker")
+            assertThat(result.inntekter?.verdier).containsExactly("arbeidstaker")
             assertThat(result.aktivitet.hvordanErArbeidssituasjonen?.verdier).containsExactly("arbeidstaker")
             assertThat(result.situasjon.gjelderDetteDeg.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
             assertThat(result.situasjon.sagtOppEllerRedusertStilling).isEqualTo("sagtOpp")
@@ -226,7 +226,7 @@ internal class SøknadsskjemaMapperTest {
 
             assertThat(result.erRegelendring2026).isFalse()
             assertThat(result.hvaSituasjon).isNull()
-            assertThat(result.harInntekt).isNull()
+            assertThat(result.inntekter).isNull()
         }
 
         private fun lagTestRegelendring2026Søknad(): SøknadOvergangsstønadRegelendring2026 {
@@ -239,7 +239,7 @@ internal class SøknadsskjemaMapperTest {
                 bosituasjon = gammelSøknad.bosituasjon,
                 barn = gammelSøknad.barn,
                 hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("Jeg har barn under 14 måneder", "Barnet trenger særlig tilsyn"), svarId = listOf("barnUnder14Måneder", "barnSærligTilsyn")),
-                harInntekt = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
+                inntekter = Søknadsfelt("Har du inntekt?", listOf("Arbeidstaker"), svarId = listOf("arbeidstaker")),
                 sagtOppEllerRedusertStilling = Søknadsfelt("Sagt opp?", "sagtOpp"),
                 begrunnelseSagtOppEllerRedusertStilling = Søknadsfelt("Begrunnelse", "Reduksjon forklaring"),
                 firmaer =

--- a/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/mapper/SøknadsskjemaMapperTest.kt
@@ -2,7 +2,9 @@ package no.nav.familie.ef.sak.mapper
 
 import no.nav.familie.ef.sak.opplysninger.søknad.mapper.SøknadsskjemaMapper
 import no.nav.familie.kontrakter.ef.søknad.Adresse
+import no.nav.familie.kontrakter.ef.søknad.Selvstendig
 import no.nav.familie.kontrakter.ef.søknad.Stønadsstart
+import no.nav.familie.kontrakter.ef.søknad.SøknadOvergangsstønadRegelendring2026
 import no.nav.familie.kontrakter.ef.søknad.Søknadsfelt
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import no.nav.familie.kontrakter.ef.søknad.TestsøknadBuilder
@@ -195,6 +197,71 @@ internal class SøknadsskjemaMapperTest {
                     .first()
                     .årsakUtenlandsopphold,
             ).isEqualTo("Ferie")
+        }
+    }
+
+    @Nested
+    inner class RegelendringMapping {
+        @Test
+        internal fun `skal mappe SøknadOvergangsstønadRegelendring2026 korrekt`() {
+            val søknad = lagTestRegelendring2026Søknad()
+
+            val result = SøknadsskjemaMapper.tilDomene(søknad)
+
+            assertThat(result.erRegelendring2026).isTrue()
+            assertThat(result.hvaSituasjon?.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
+            assertThat(result.harInntekt?.verdier).containsExactly("arbeidstaker")
+            assertThat(result.aktivitet.hvordanErArbeidssituasjonen?.verdier).containsExactly("arbeidstaker")
+            assertThat(result.situasjon.gjelderDetteDeg.verdier).containsExactlyInAnyOrder("barnUnder14Måneder", "barnSærligTilsyn")
+            assertThat(result.situasjon.sagtOppEllerRedusertStilling).isEqualTo("sagtOpp")
+            assertThat(result.situasjon.oppsigelseReduksjonÅrsak).isEqualTo("Reduksjon forklaring")
+            assertThat(result.aktivitet.firmaer).hasSize(2)
+        }
+
+        @Test
+        internal fun `skal sette erRegelendring2026 og ikke populere aktivitet og situasjon for gammel søknad`() {
+            val søknad = Testsøknad.søknadOvergangsstønad
+
+            val result = SøknadsskjemaMapper.tilDomene(søknad)
+
+            assertThat(result.erRegelendring2026).isFalse()
+            assertThat(result.hvaSituasjon).isNull()
+            assertThat(result.harInntekt).isNull()
+        }
+
+        private fun lagTestRegelendring2026Søknad(): SøknadOvergangsstønadRegelendring2026 {
+            val gammelSøknad = Testsøknad.søknadOvergangsstønad
+            return SøknadOvergangsstønadRegelendring2026(
+                innsendingsdetaljer = gammelSøknad.innsendingsdetaljer,
+                personalia = gammelSøknad.personalia,
+                sivilstandsdetaljer = gammelSøknad.sivilstandsdetaljer,
+                medlemskapsdetaljer = gammelSøknad.medlemskapsdetaljer,
+                bosituasjon = gammelSøknad.bosituasjon,
+                barn = gammelSøknad.barn,
+                hvaSituasjon = Søknadsfelt("Hva er situasjonen din?", listOf("barnUnder14Måneder", "barnSærligTilsyn")),
+                harInntekt = Søknadsfelt("Har du inntekt?", listOf("arbeidstaker")),
+                sagtOppEllerRedusertStilling = Søknadsfelt("Sagt opp?", "sagtOpp"),
+                begrunnelseSagtOppEllerRedusertStilling = Søknadsfelt("Begrunnelse", "Reduksjon forklaring"),
+                firmaer =
+                    Søknadsfelt(
+                        "Firmaer",
+                        listOf(
+                            Selvstendig(
+                                firmanavn = Søknadsfelt("Firmanavn", "Firma AS"),
+                                organisasjonsnummer = Søknadsfelt("Orgnr", "123456789"),
+                                etableringsdato = Søknadsfelt("Etableringsdato", LocalDate.of(2020, 1, 1)),
+                                hvordanSerArbeidsukenUt = Søknadsfelt("Arbeidsuke", "8 timer daglig"),
+                            ),
+                            Selvstendig(
+                                firmanavn = Søknadsfelt("Firmanavn", "Bivirksomhet ENK"),
+                                organisasjonsnummer = Søknadsfelt("Orgnr", "987654321"),
+                                etableringsdato = Søknadsfelt("Etableringsdato", LocalDate.of(2022, 6, 1)),
+                                hvordanSerArbeidsukenUt = Søknadsfelt("Arbeidsuke", "4 timer daglig"),
+                            ),
+                        ),
+                    ),
+                stønadsstart = gammelSøknad.stønadsstart,
+            )
         }
     }
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/metrics/MålerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/metrics/MålerRepositoryTest.kt
@@ -206,6 +206,7 @@ class MålerRepositoryTest : OppslagSpringRunnerTest() {
             status = BehandlingStatus.FERDIGSTILT,
             resultat = INNVILGET,
             opprettetTid = opprettetTid,
+            vedtakstidspunkt = opprettetTid,
         ),
     )
 


### PR DESCRIPTION
Disse endringene gjør at nye felter fra søknad på overgangsstønad med regelendringer blir lagret og lagt til i grunnlagsdata. Dette gjør at disse er tilgjengelig i en behandling.

- Populerer behandling med data fra ny versjon av overgangsstønad søknad
- Lagerer nye felter (er_regelendring_2026 og inntekter) i tabellen soknadsskjema
- Legger til nye felter på søknad i grunnlagsdata
- Lagt til flagget erRegelendring2026 på saksbehandling slik at det enkelt kan skilles på hvilken versjon av søknaden en behandling er søkt på

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28466)