### PR TITLE
Automatisk utsending av aktivitetsplikt brev: Skal manuelt håndtere brukere under 18 år

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/SendAktivitetspliktBrevTilIverksettTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/SendAktivitetspliktBrevTilIverksettTask.kt
@@ -25,6 +25,7 @@ import no.nav.familie.prosessering.domene.Task
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.Year
 import java.util.Properties
 
@@ -53,7 +54,7 @@ class SendAktivitetspliktBrevTilIverksettTask(
         val ident = OppgaveUtil.finnPersonidentForOppgave(oppgave) ?: throw Feil("Fant ikke ident for oppgave=${oppgave.id}")
         val fagsaker = fagsakService.finnFagsaker(setOf(ident))
 
-        validerHarIkkeVergemål(ident, oppgave)
+        validerHarIkkeVergemålOgErOver18År(ident, oppgave)
         validerHarFagsakOgBehandling(fagsaker, oppgave)
 
         val visningsnavn = personopplysningerService.hentGjeldeneNavn(listOf(ident)).getValue(ident)
@@ -76,14 +77,17 @@ class SendAktivitetspliktBrevTilIverksettTask(
         )
     }
 
-    private fun validerHarIkkeVergemål(
+    private fun validerHarIkkeVergemålOgErOver18År(
         ident: String,
-        opggave: Oppgave,
+        oppgave: Oppgave,
     ) {
         val personopplysninger = personopplysningerService.hentPersonopplysningerFraRegister(ident)
         val harVerge = personopplysninger.vergemål.isNotEmpty()
+        feilHvis(personopplysninger.fødselsdato == null || LocalDate.now().isBefore(personopplysninger.fødselsdato.plusYears(18))) {
+            "Kan ikke automatisk sende brev for oppgaveId=${oppgave.id}. Bruker er under 18 år eller fødselsdato er ukjent. Saken må følges opp manuelt."
+        }
         feilHvis(harVerge) {
-            "Kan ikke automatisk sende brev for oppgaveId=${opggave.id}. Brev om innhenting av aktivitetsplikt skal ikke sendes automatisk fordi bruker har vergemål. Saken må følges opp manuelt og tasken kan avvikshåndteres."
+            "Kan ikke automatisk sende brev for oppgaveId=${oppgave.id}. Brev om innhenting av aktivitetsplikt skal ikke sendes automatisk fordi bruker har vergemål. Saken må følges opp manuelt og tasken kan avvikshåndteres."
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -52,7 +52,7 @@ class PersonopplysningerMapper(
                 søker.folkeregisterpersonstatus
                     .gjeldende()
                     ?.let { Folkeregisterpersonstatus.fraPdl(it) },
-            fødselsdato = søker.fødsel.first()?.fødselsdato,
+            fødselsdato = søker.fødsel.first().fødselsdato,
             dødsdato = søker.dødsfall?.dødsdato,
             navn = NavnDto.fraNavn(søker.navn),
             kjønn = KjønnMapper.tilKjønn(søker.kjønn),

--- a/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AktivitetspliktBrevTaskTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AktivitetspliktBrevTaskTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
 import java.time.Year
 
 internal class AktivitetspliktBrevTaskTest {
@@ -45,6 +46,7 @@ internal class AktivitetspliktBrevTaskTest {
         every { personopplysningerService.hentPersonopplysningerFraRegister(any<String>()) } returns
             mockk {
                 every { vergemål } returns emptyList()
+                every { fødselsdato } returns LocalDate.now().minusYears(30)
             }
     }
 
@@ -97,11 +99,34 @@ internal class AktivitetspliktBrevTaskTest {
         every { personopplysningerService.hentPersonopplysningerFraRegister(any<String>()) } returns
             mockk {
                 every { vergemål } returns listOf(mockk())
+                every { fødselsdato } returns LocalDate.now().minusYears(30)
             }
 
         val task = SendAktivitetspliktBrevTilIverksettTask.opprettTask(oppgaveId, Year.of(2023))
 
         val feil = assertThrows<Feil> { aktivitetspliktBrevTask.doTask(task) }
         assertThat(feil.frontendFeilmelding?.contains("Kan ikke automatisk sende brev for oppgaveId=$oppgaveId. Brev om innhenting av aktivitetsplikt skal ikke sendes automatisk fordi bruker har vergemål. Saken må følges opp manuelt og tasken kan avvikshåndteres."))
+    }
+
+    @Test
+    internal fun `task skal feile dersom bruker er under 18 år`() {
+        val oppgaveId: Long = 123
+
+        every { oppgaveService.hentOppgave(oppgaveId) } returns
+            Oppgave(
+                id = oppgaveId,
+                identer = listOf(OppgaveIdentV2("11111111", IdentGruppe.FOLKEREGISTERIDENT)),
+            )
+        every { fagsakService.finnFagsaker(any()) } returns listOf(fagsak())
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any<String>()) } returns
+            mockk {
+                every { vergemål } returns emptyList()
+                every { fødselsdato } returns LocalDate.now().minusYears(17)
+            }
+
+        val task = SendAktivitetspliktBrevTilIverksettTask.opprettTask(oppgaveId, Year.of(2026))
+
+        val feil = assertThrows<Feil> { aktivitetspliktBrevTask.doTask(task) }
+        assertThat(feil.message).contains("under 18")
     }
 }


### PR DESCRIPTION
Dette skal håndteres på samme måte som voksne med verge, for at brev skal sendes riktig. 
Løser dette ved å legge til validering på fødselsdato. Dersom fødselsdato ikke finnes feiler også tasken, men det anses som greit da det i følge dokumentasjonen er god datakvalitet på dette.

https://pdl-docs.ansatt.nav.no/ekstern/index.html#_f%C3%B8dselsdato