### PR TITLE
Legger inn grunnbeløpet som gjelder fra 1. mai 2026.

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/beregning/Beregning.kt
@@ -72,7 +72,13 @@ object Grunnbeløpsperioder {
     val grunnbeløpsperioder: List<Grunnbeløp> =
         listOf(
             Grunnbeløp(
-                periode = Månedsperiode(YearMonth.parse("2025-05"), YearMonth.from(LocalDate.MAX)),
+                periode = Månedsperiode(YearMonth.parse("2026-05"), YearMonth.from(LocalDate.MAX)),
+                grunnbeløp = 136_549.toBigDecimal(),
+                perMnd = 11_379.toBigDecimal(),
+                gjennomsnittPerÅr = 134_419.toBigDecimal(),
+            ),
+            Grunnbeløp(
+                periode = Månedsperiode("2025-05" to "2026-04"),
                 grunnbeløp = 130_160.toBigDecimal(),
                 perMnd = 10_847.toBigDecimal(),
                 gjennomsnittPerÅr = 128_116.toBigDecimal(),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger inn ny G slik at alle nye beregninger/behandlinger blir med ny G. Behandlinger som allerede er iverksatt vil fortsatt ha gammel g, helt til vi kjører selve g-omregningen på tirsdag.

Når du gjør review av denne er det viktig at du sjekker følgende:
 - Det skal ikke automatisk g-omregnes enda, sjekk at g-omregning scheduler ikke kjører før på tirsdag.
 - Sjekk at featuretoggles for g-omregning er skrudd av for prod (for å være på den sikre siden)
 - Sjekk at tallene stemmer

Gjerne ta en stikkprøve fra en av testpersonene herfra som har kjørt g-omregning: https://dolly.ekstern.dev.nav.no/gruppe/11103