### PR TITLE
OS regelverksendring tidligere vedtakshistorikk

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadController.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.ef.sak.ekstern.soknad
+
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.sikkerhet.EksternBrukerUtils
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(
+    path = ["/api/ekstern/soknad"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+)
+@ProtectedWithClaims(issuer = EksternBrukerUtils.ISSUER_TOKENX, claimMap = ["acr=Level4"])
+class EksternSøknadController(
+    private val eksternSøknadService: EksternSøknadService,
+) {
+    @GetMapping("har-tidligere-innvilget-vedtak")
+    fun harTidligereInnvilgetVedtak(): Ressurs<TidligereVedtakStatus> {
+        feilHvisIkke(SikkerhetContext.kallKommerFraFamilieEfSøknadApi(), HttpStatus.UNAUTHORIZED) {
+            "Kallet utføres ikke av en autorisert klient"
+        }
+        return Ressurs.success(eksternSøknadService.harTidligereInnvilgetVedtak(EksternBrukerUtils.hentFnrFraToken()))
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -1,11 +1,10 @@
 package no.nav.familie.ef.sak.ekstern.soknad
 
-import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.fagsak.FagsakService
 import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
-import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -13,8 +12,7 @@ import org.springframework.stereotype.Service
 @Service
 class EksternSøknadService(
     private val fagsakService: FagsakService,
-    private val behandlingService: BehandlingService,
-    private val tilkjentYtelseService: TilkjentYtelseService,
+    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val personService: PersonService,
     private val infotrygdService: InfotrygdService,
 ) {
@@ -28,10 +26,8 @@ class EksternSøknadService(
                 StønadType.values().any { stønadstype ->
                     fagsakService
                         .finnFagsak(personIdenter, stønadstype)
-                        ?.let { behandlingService.finnSisteIverksatteBehandling(it.id) }
-                        ?.let { tilkjentYtelseService.hentForBehandling(it.id) }
-                        ?.andelerTilkjentYtelse
-                        ?.isNotEmpty() == true
+                        ?.let { tilkjentYtelseRepository.finnAlleIverksatteForFagsak(it.id) }
+                        ?.any { it.andelerTilkjentYtelse.isNotEmpty() } == true
                 }
 
             val harInnvilgetIInfotrygd = infotrygdService.eksisterer(personIdent)

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -1,0 +1,48 @@
+package no.nav.familie.ef.sak.ekstern.soknad
+
+import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class EksternSøknadService(
+    private val fagsakService: FagsakService,
+    private val behandlingService: BehandlingService,
+    private val tilkjentYtelseService: TilkjentYtelseService,
+    private val personService: PersonService,
+    private val infotrygdService: InfotrygdService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus =
+        try {
+            val personIdenter = personService.hentPersonIdenter(personIdent).identer()
+
+            val harInnvilgetIEfSak =
+                StønadType.values().any { stønadstype ->
+                    fagsakService
+                        .finnFagsak(personIdenter, stønadstype)
+                        ?.let { behandlingService.finnSisteIverksatteBehandling(it.id) }
+                        ?.let { tilkjentYtelseService.hentForBehandling(it.id) }
+                        ?.andelerTilkjentYtelse
+                        ?.isNotEmpty() == true
+                }
+
+            val harInnvilgetIInfotrygd = infotrygdService.eksisterer(personIdent)
+
+            if (harInnvilgetIEfSak || harInnvilgetIInfotrygd) {
+                TidligereVedtakStatus.JA
+            } else {
+                TidligereVedtakStatus.NEI
+            }
+        } catch (e: Exception) {
+            logger.warn("Feil ved sjekk av tidligere innvilget vedtak", e)
+            TidligereVedtakStatus.VET_IKKE
+        }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/TidligereVedtakStatus.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/TidligereVedtakStatus.kt
@@ -1,0 +1,7 @@
+package no.nav.familie.ef.sak.ekstern.soknad
+
+enum class TidligereVedtakStatus {
+    JA,
+    NEI,
+    VET_IKKE,
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/WebConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/WebConfig.kt
@@ -22,6 +22,7 @@ class WebConfig(
             "/v3/api-docs",
             "/api/ekstern/perioder/full-overgangsstonad", // håndteres i controllern
             "/api/ekstern/minside/stonadsperioder", // urelevant å sjekke roller for tokenx/kall fra min-side
+            "/api/ekstern/soknad/har-tidligere-innvilget-vedtak",
         )
 
     override fun addInterceptors(registry: InterceptorRegistry) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -1,0 +1,134 @@
+package no.nav.familie.ef.sak.ekstern.soknad
+
+import io.mockk.every
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
+import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
+import no.nav.familie.ef.sak.felles.domain.SporbarUtils
+import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
+import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
+import no.nav.familie.ef.sak.repository.behandling
+import no.nav.familie.ef.sak.repository.fagsak
+import no.nav.familie.ef.sak.repository.fagsakpersoner
+import no.nav.familie.ef.sak.repository.innvilgetOgFerdigstilt
+import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
+import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelseType
+import no.nav.familie.ef.sak.økonomi.DataGenerator
+import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
+import no.nav.familie.kontrakter.ef.infotrygd.Vedtakstreff
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.ef.StønadType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import java.time.LocalDate
+
+class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
+    private val personident = "12345678901"
+    private val fagsakOvergangsstønad =
+        fagsak(stønadstype = StønadType.OVERGANGSSTØNAD, identer = fagsakpersoner(setOf(personident)))
+
+    @Autowired
+    private lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
+
+    @Autowired
+    private lateinit var behandlingRepository: BehandlingRepository
+
+    @Autowired
+    private lateinit var infotrygdReplikaClient: InfotrygdReplikaClient
+
+    @BeforeEach
+    fun setUp() {
+        headers.setBearerAuth(søkerToken(personident))
+        InfotrygdReplikaMock.resetMock(infotrygdReplikaClient)
+        every { infotrygdReplikaClient.hentInslagHosInfotrygd(any()) } returns
+            InfotrygdFinnesResponse(vedtak = emptyList(), saker = emptyList())
+    }
+
+    @Test
+    fun `skal returnere JA for innvilget vedtak med beløp 0`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
+        val andelMedNullBeløp =
+            lagAndelTilkjentYtelse(
+                beløp = 0,
+                fraOgMed = LocalDate.of(2023, 1, 1),
+                tilOgMed = LocalDate.of(2023, 12, 31),
+                kildeBehandlingId = behandling.id,
+            )
+        tilkjentYtelseRepository.insert(
+            DataGenerator.tilfeldigTilkjentYtelse(behandling).copy(andelerTilkjentYtelse = listOf(andelMedNullBeløp)),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal returnere JA for opphørt sak som tidligere hadde andeler`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+
+        val førsteBehandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
+        val andelMedBeløp =
+            lagAndelTilkjentYtelse(
+                beløp = 5000,
+                fraOgMed = LocalDate.of(2023, 1, 1),
+                tilOgMed = LocalDate.of(2023, 6, 30),
+                kildeBehandlingId = førsteBehandling.id,
+            )
+        tilkjentYtelseRepository.insert(
+            DataGenerator.tilfeldigTilkjentYtelse(førsteBehandling).copy(andelerTilkjentYtelse = listOf(andelMedBeløp)),
+        )
+
+        val opphørtBehandling =
+            behandlingRepository.insert(
+                behandling(fagsakOvergangsstønad).copy(
+                    resultat = BehandlingResultat.OPPHØRT,
+                    status = BehandlingStatus.FERDIGSTILT,
+                    vedtakstidspunkt = SporbarUtils.now(),
+                ),
+            )
+        tilkjentYtelseRepository.insert(
+            DataGenerator.tilfeldigTilkjentYtelse(opphørtBehandling).copy(
+                andelerTilkjentYtelse = emptyList(),
+                type = TilkjentYtelseType.OPPHØR,
+                startdato = LocalDate.of(2023, 1, 1),
+            ),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal returnere JA når person kun finnes i Infotrygd`() {
+        every { infotrygdReplikaClient.hentInslagHosInfotrygd(any()) } returns
+            InfotrygdFinnesResponse(
+                vedtak = listOf(Vedtakstreff(personident, StønadType.OVERGANGSSTØNAD, false)),
+                saker = emptyList(),
+            )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    private fun hentHarTidligereInnvilgetVedtak() =
+        testRestTemplate.exchange<Ressurs<TidligereVedtakStatus>>(
+            localhost("/api/ekstern/soknad/har-tidligere-innvilget-vedtak"),
+            HttpMethod.GET,
+            HttpEntity<Ressurs<TidligereVedtakStatus>>(headers),
+        )
+}


### PR DESCRIPTION
Tilbyr nytt endepunkt for å sjekke om en person har fått noe fra EF før. Dette endepunktet skal brukes i søknad for å bestemme om gammel eller ny søknad med regelendring 2026 skal brukes.

- Bruker enum TidligereVedtakStatus i stedet for boolean, for en slags etterlevelse.

[favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28467)