### PR TITLE
Noterer i G-Omregning readme-filen at man burde skalere opp apper før selve g-omregningen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
@@ -81,6 +81,7 @@ Når G-omregningen er ferdigkjørt er det viktig å gå igjennom denne listen fo
     * De i denne listen som har samordning skal overleveres til coachene.
     * Hvis G-omregning skjer etter 1. juni: Rekjør denne tasken når G-omregningen er ferdigkjørt
     * Kan bruke `finnFerdigstilteFagsakerMedUtdatertGBelop` og sjekke `samordningsfradrag > 0` samt `beløp > 0` for å finne liste for oversendelse til coacher
+    * Søk på `x_tags: G-omregning - Manuell` for å finne saker med fremtidig samordningsfradrag, som ikke kommer med i SQL over. (Samme som sanksjon).
 
 * **Sanksjon**
     * For de tilfellene med sanksjonsperioder vil G-omregningstaskene logge `Fagsak med id ... har sanksjon og må manuelt behandles` med `x_tags: G-omregning - Manuell`. Disse må sendes over til coachene.

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
@@ -12,7 +12,7 @@ valg vi har tatt og hva vi jobber med å endre før neste g-omregning.
 2. Legg inn ny G i no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 3. Nye behandlinger vil nå bruke ny G
 4. Kjør gjerne en test med 1 fagsak (se ManuellGOmregningController under) før man setter på scheduler?
-5. Skalér opp til 4 podder for familie-ef-sak, familie-ef-iverksett og familie-ks-sak før selve g-omregningen kjøres
+5. Skalér opp til 4 podder for familie-ef-sak, familie-ef-iverksett og familie-ks-sak før selve g-omregningen kjøres. Si ifra til BAKS-teamet før oppskalering av ks-sak.
 6. Se ["etterarbeid under"](#etterarbeid)
 
 G-omregning starter vanligvis med at en scheduler finner kandidater for g-omregning (sql) 

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/grunnbelop/dok/G-omregning-README.md
@@ -12,7 +12,8 @@ valg vi har tatt og hva vi jobber med å endre før neste g-omregning.
 2. Legg inn ny G i no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 3. Nye behandlinger vil nå bruke ny G
 4. Kjør gjerne en test med 1 fagsak (se ManuellGOmregningController under) før man setter på scheduler?
-5. Se ["etterarbeid under"](#etterarbeid)
+5. Skalér opp til 4 podder for familie-ef-sak, familie-ef-iverksett og familie-ks-sak før selve g-omregningen kjøres
+6. Se ["etterarbeid under"](#etterarbeid)
 
 G-omregning starter vanligvis med at en scheduler finner kandidater for g-omregning (sql) 
 `no.nav.familie.ef.sak.behandling.grunnbelop.GOmregningTaskServiceScheduler`


### PR DESCRIPTION
Noterer at ef-sak, iverksett og ks-sak burde skaleres opp til 4 podder på forhånd, da dette vil effektivisere prosessen betraktelig. Det vil også gjøre at det ikke blir mange feil/timeouts.