### PR TITLE
Tidligere vedtak skal sjekk PE PP

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -1,38 +1,24 @@
 package no.nav.familie.ef.sak.ekstern.soknad
 
-import no.nav.familie.ef.sak.fagsak.FagsakService
-import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.identer
-import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
-import no.nav.familie.kontrakter.felles.ef.StønadType
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
+import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class EksternSøknadService(
-    private val fagsakService: FagsakService,
-    private val tilkjentYtelseRepository: TilkjentYtelseRepository,
     private val personService: PersonService,
-    private val infotrygdService: InfotrygdService,
+    private val tidligereVedtaksperioderService: TidligereVedtaksperioderService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus =
         try {
-            val personIdenter = personService.hentPersonIdenter(personIdent).identer()
+            val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
+            val tidligereVedtaksperioder = tidligereVedtaksperioderService.hentTidligereVedtaksperioder(folkeregisteridentifikatorer)
 
-            val harInnvilgetIEfSak =
-                StønadType.values().any { stønadstype ->
-                    fagsakService
-                        .finnFagsak(personIdenter, stønadstype)
-                        ?.let { tilkjentYtelseRepository.finnAlleIverksatteForFagsak(it.id) }
-                        ?.any { it.andelerTilkjentYtelse.isNotEmpty() } == true
-                }
-
-            val harInnvilgetIInfotrygd = infotrygdService.eksisterer(personIdent)
-
-            if (harInnvilgetIEfSak || harInnvilgetIInfotrygd) {
+            if (tidligereVedtaksperioder.tilDto().harTidligereVedtaksperioder()) {
                 TidligereVedtakStatus.JA
             } else {
                 TidligereVedtakStatus.NEI

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.ekstern.soknad
 
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
+import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
 import no.nav.familie.ef.sak.vilkår.dto.tilDto
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -18,13 +19,20 @@ class EksternSøknadService(
             val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
             val tidligereVedtaksperioder = tidligereVedtaksperioderService.hentTidligereVedtaksperioder(folkeregisteridentifikatorer)
 
-            if (tidligereVedtaksperioder.tilDto().harTidligereVedtaksperioder()) {
-                TidligereVedtakStatus.JA
-            } else {
-                TidligereVedtakStatus.NEI
-            }
+            tidligereVedtaksperioder.tilDto().tilTidligereVedtakStatus()
         } catch (e: Exception) {
             logger.warn("Feil ved sjekk av tidligere innvilget vedtak", e)
             TidligereVedtakStatus.VET_IKKE
         }
+}
+
+private fun TidligereVedtaksperioderDto.tilTidligereVedtakStatus(): TidligereVedtakStatus {
+    val harFraInfotrygd = infotrygd?.harTidligereInnvilgetVedtak() ?: false
+    val harFraSak = sak?.harTidligereInnvilgetVedtak() ?: false
+
+    if (harFraInfotrygd || harFraSak) return TidligereVedtakStatus.JA
+    if (historiskPensjon == null) return TidligereVedtakStatus.VET_IKKE
+    if (historiskPensjon) return TidligereVedtakStatus.JA
+
+    return TidligereVedtakStatus.NEI
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/TidligereVedtaksperioderDto.kt
@@ -15,7 +15,10 @@ data class TidligereVedtaksperioderDto(
     val sak: TidligereInnvilgetVedtakDto?,
     val historiskPensjon: Boolean?,
 ) {
-    fun harTidligereVedtaksperioder() = infotrygd?.harTidligereInnvilgetVedtak() ?: false || sak?.harTidligereInnvilgetVedtak() ?: false || historiskPensjon ?: true
+    fun harTidligereVedtaksperioder() =
+        (infotrygd?.harTidligereInnvilgetVedtak() ?: false) ||
+            (sak?.harTidligereInnvilgetVedtak() ?: false) ||
+            (historiskPensjon ?: true)
 }
 
 data class TidligereInnvilgetVedtakDto(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Skal også ta hensyn til PE PP (Vedtakshistorikk før desember 2008) når vi sjekker om en person har tidligere vedtak som enslig forsørger.
- Fikser logikk i harTidligereVedtaksperioder || har presedens før ?: elvis