### PR TITLE
Forbedre byggetid med forbedret caching

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -18,7 +18,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Kjør ktlint
         env:
           GITHUB_USERNAME: x-access-token
@@ -38,13 +43,27 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/testcontainers-images
+          key: docker-testcontainers-${{ runner.os }}-${{ hashFiles('**/DbContainerInitializer.kt') }}
+      - name: Load cached testcontainer images
+        run: |
+          if [ -f ~/.cache/testcontainers-images/images.tar ]; then
+            docker load -i ~/.cache/testcontainers-images/images.tar
+          fi
       - name: Bygg (dependabot)
         if: github.actor == 'dependabot[bot]'
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml -Dsurefire.forkCount=2
       - name: Bygg og SonarCloud
         if: github.actor != 'dependabot[bot]'
         env:
@@ -52,4 +71,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_PROJECTKEY: ${{ secrets.SONAR_PROJECTKEY }}
           SONAR_LOGIN: ${{ secrets.SONAR_LOGIN }}
-        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn verify --settings .m2/maven-settings.xml --file pom.xml -Dsurefire.forkCount=2
+      - name: Save testcontainer images to cache
+        if: always()
+        run: |
+          mkdir -p ~/.cache/testcontainers-images
+          docker save testcontainers/ryuk:0.14.0 postgres:17.6 \
+            -o ~/.cache/testcontainers-images/images.tar 2>/dev/null || true

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - uses: actions/cache@v4
+      - uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Bygg med Maven
         env:
           GITHUB_USERNAME: x-access-token
@@ -58,6 +63,26 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/testcontainers-images
+          key: docker-testcontainers-${{ runner.os }}-${{ hashFiles('**/DbContainerInitializer.kt') }}
+      - name: Load cached testcontainer images
+        run: |
+          if [ -f ~/.cache/testcontainers-images/images.tar ]; then
+            docker load -i ~/.cache/testcontainers-images/images.tar
+          fi
       - name: Run Maven tests
-        run: mvn -B --no-transfer-progress test -DskipCompile --settings .m2/maven-settings.xml
+        run: mvn -B --no-transfer-progress test -DskipCompile --settings .m2/maven-settings.xml -Dsurefire.forkCount=2
+      - name: Save testcontainer images to cache
+        if: always()
+        run: |
+          mkdir -p ~/.cache/testcontainers-images
+          docker save testcontainers/ryuk:0.14.0 postgres:17.6 \
+            -o ~/.cache/testcontainers-images/images.tar 2>/dev/null || true

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,12 +25,33 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-          cache: 'maven'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Cache testcontainer images
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/testcontainers-images
+          key: docker-testcontainers-${{ runner.os }}-${{ hashFiles('**/DbContainerInitializer.kt') }}
+      - name: Load cached testcontainer images
+        run: |
+          if [ -f ~/.cache/testcontainers-images/images.tar ]; then
+            docker load -i ~/.cache/testcontainers-images/images.tar
+          fi
       - name: Bygg med Maven
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml
+        run: mvn -B --no-transfer-progress package --settings .m2/maven-settings.xml --file pom.xml -Dsurefire.forkCount=2
+      - name: Save testcontainer images to cache
+        if: always()
+        run: |
+          mkdir -p ~/.cache/testcontainers-images
+          docker save testcontainers/ryuk:0.14.0 postgres:17.6 \
+            -o ~/.cache/testcontainers-images/images.tar 2>/dev/null || true
       - uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b # ratchet:nais/docker-build-push@v0
         id: docker-push
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <revision>1.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
+        <surefire.forkCount>2</surefire.forkCount>
         <java.version>21</java.version>
         <kotlin.version>2.2.21</kotlin.version>
         <springdoc.version>3.0.1</springdoc.version>
@@ -355,7 +356,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.5</version>
+                <configuration>
+                    <forkCount>${surefire.forkCount}</forkCount>
+                    <reuseForks>true</reuseForks>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -22,8 +22,8 @@ import no.nav.familie.ef.sak.fagsak.domain.FagsakPerson
 import no.nav.familie.ef.sak.felles.util.TokenUtil
 import no.nav.familie.ef.sak.infrastruktur.config.JsonMapperProvider.jsonMapper
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
-import no.nav.familie.ef.sak.iverksett.oppgaveterminbarn.TerminbarnOppgave
 import no.nav.familie.ef.sak.infrastruktur.config.WireMockServerInitializer
+import no.nav.familie.ef.sak.iverksett.oppgaveterminbarn.TerminbarnOppgave
 import no.nav.familie.ef.sak.oppfølgingsoppgave.domain.OppgaverForOpprettelse
 import no.nav.familie.ef.sak.oppgave.Oppgave
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -23,6 +23,7 @@ import no.nav.familie.ef.sak.felles.util.TokenUtil
 import no.nav.familie.ef.sak.infrastruktur.config.JsonMapperProvider.jsonMapper
 import no.nav.familie.ef.sak.infrastruktur.config.RolleConfig
 import no.nav.familie.ef.sak.iverksett.oppgaveterminbarn.TerminbarnOppgave
+import no.nav.familie.ef.sak.infrastruktur.config.WireMockServerInitializer
 import no.nav.familie.ef.sak.oppfølgingsoppgave.domain.OppgaverForOpprettelse
 import no.nav.familie.ef.sak.oppgave.Oppgave
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.Grunnlagsdata
@@ -63,7 +64,7 @@ import org.springframework.web.client.RestOperations
 import org.springframework.web.client.RestTemplate
 
 @ExtendWith(SpringExtension::class)
-@ContextConfiguration(initializers = [DbContainerInitializer::class])
+@ContextConfiguration(initializers = [DbContainerInitializer::class, WireMockServerInitializer::class])
 @SpringBootTest(classes = [ApplicationLocalSetup::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(
     "integrasjonstest",

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -14,8 +14,8 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.felles.integration.dto.Tilgang
-import no.nav.familie.ef.sak.journalføring.JournalføringTestUtil.avsenderMottaker
 import no.nav.familie.ef.sak.infrastruktur.config.WireMockServerInitializer
+import no.nav.familie.ef.sak.journalføring.JournalføringTestUtil.avsenderMottaker
 import no.nav.familie.kontrakter.ef.sak.DokumentBrevkode
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import no.nav.familie.kontrakter.felles.BrukerIdType

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -15,6 +15,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
 import no.nav.familie.ef.sak.arbeidsfordeling.Arbeidsfordelingsenhet
 import no.nav.familie.ef.sak.felles.integration.dto.Tilgang
 import no.nav.familie.ef.sak.journalføring.JournalføringTestUtil.avsenderMottaker
+import no.nav.familie.ef.sak.infrastruktur.config.WireMockServerInitializer
 import no.nav.familie.kontrakter.ef.sak.DokumentBrevkode
 import no.nav.familie.kontrakter.ef.søknad.Testsøknad
 import no.nav.familie.kontrakter.felles.BrukerIdType
@@ -141,14 +142,12 @@ class FamilieIntegrasjonerMock(
 
     @Bean("mock-integrasjoner")
     @Profile("mock-integrasjoner")
-    fun integrationMockServer(
-        @Value("\${FAMILIE_INTEGRASJONER_URL}") uri: URI,
-    ): WireMockServer {
-        val mockServer = WireMockServer(uri.port)
+    fun integrationMockServer(): WireMockServer {
+        val mockServer = WireMockServerInitializer.wireMockServer
         responses.forEach {
             mockServer.stubFor(it)
         }
-        mockServer.start()
+
         return mockServer
     }
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/WireMockServerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/WireMockServerInitializer.kt
@@ -1,0 +1,22 @@
+package no.nav.familie.ef.sak.infrastruktur.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.support.TestPropertySourceUtils
+
+class WireMockServerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+            applicationContext,
+            "FAMILIE_INTEGRASJONER_URL=http://localhost:${wireMockServer.port()}",
+        )
+    }
+
+    companion object {
+        val wireMockServer: WireMockServer by lazy {
+            WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort()).also { it.start() }
+        }
+    }
+}

--- a/src/test/resources/application-integrasjonstest.yaml
+++ b/src/test/resources/application-integrasjonstest.yaml
@@ -27,7 +27,6 @@ no.nav.security.jwt:
 unleash:
   enabled: false
 
-FAMILIE_INTEGRASJONER_URL: http://localhost:8385
 FAMILIE_BREV_API_URL: http://localhost:8001
 
 AZURE_APP_TENANT_ID: navq.onmicrosoft.com


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For å forbedre byggetiden i github actions, har følgende blitt gjort:

- Caching av dependencies med restore key. Resultatet av dette vil være at ikke alle dependencies lastes ned ved endring av pom, bare de som faktisk er endret vil bli lastet ned
- Caching av docker image
- Kjører tester parallelt i GHA. Testene kjøres fortsatt sekvensielt lokalt. Måtte endre wiremock config til å bruke dynamic ports for at dette skulle virke.