### PR TITLE
Skal ikke sende vedlegg om rettigheter på OS regelendring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-validation-spring.version>6.0.6</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>4.0_20260605100546_f529556</kontrakter.version>
+        <kontrakter.version>4.0_20260608075026_1c29629</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20260323170751_4c02e3c</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.34.3</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <token-validation-spring.version>6.0.6</token-validation-spring.version>
 
         <start-class>no.nav.familie.ef.sak.ApplicationKt</start-class>
-        <kontrakter.version>4.0_20260427083013_f53660d</kontrakter.version>
+        <kontrakter.version>4.0_20260605100546_f529556</kontrakter.version>
         <mikrofrontend.builder.version>20230704114948-74aa2e9</mikrofrontend.builder.version>
         <eksterne.kontrakter.bisys.version>2.0_20260323170751_4c02e3c</eksterne.kontrakter.bisys.version>
         <cucumber.version>7.34.3</cucumber.version>

--- a/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/iverksett/IverksettingDtoMapper.kt
@@ -287,6 +287,7 @@ class IverksettingDtoMapper(
             kravMottatt = saksbehandling.kravMottatt,
             årsakRevurdering = mapÅrsakRevurdering(saksbehandling),
             kategori = saksbehandling.kategori,
+            erRegelendring2026 = saksbehandling.erRegelendring2026,
         )
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I dag sender vi et vedlegg sammen med vedtaksbrev om innvilgelse og revurdering (ikke opphør og avslag). Vedlegget inneholder rettigheter og plikter bruker har. Ifølge den nye brevstandarden skal plikter som bruker har stå i selve vedtaksbrevet.

Sender med verdi til ef-iverksett - tilhørende PR: https://github.com/navikt/familie-ef-iverksett/pull/1174

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29243)