### PR TITLE
Fiks: Riktig søknadsregel basert på regelendring 2026

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -209,40 +209,12 @@ interface BehandlingRepository :
     // language=PostgreSQL
     @Query(
         """
-        SELECT EXISTS (
-            SELECT 1
-            FROM gjeldende_iverksatte_behandlinger gib
-            JOIN behandling b ON b.id = gib.id
-            JOIN person_ident pi ON gib.fagsak_person_id = pi.fagsak_person_id
-            WHERE pi.ident IN (:identer)
-              AND gib.stonadstype = :stønadstype
-              AND gib.resultat = 'INNVILGET'
-              AND b.er_regelendring_2026 = false
-              AND EXISTS (
-                  SELECT 1 FROM andel_tilkjent_ytelse aty
-                  JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
-                  WHERE ty.behandling_id = gib.id
-                    AND aty.belop > 0
-                    AND aty.stonad_tom >= :iDag
-              )
-        )
-        """,
-    )
-    fun harGjeldendePeriodePåGammeltRegelverk(
-        identer: Set<String>,
-        stønadstype: StønadType,
-        iDag: LocalDate,
-    ): Boolean
-
-    // language=PostgreSQL
-    @Query(
-        """
         SELECT b.er_regelendring_2026
         FROM behandling b
         JOIN fagsak f ON f.id = b.fagsak_id
         JOIN person_ident pi ON f.fagsak_person_id = pi.fagsak_person_id
         WHERE pi.ident IN (:identer)
-          AND f.stonadstype = :stønadstype
+          AND f.stonadstype IN (:stønadstyper)
           AND b.status = 'FERDIGSTILT'
           AND b.resultat <> 'HENLAGT'
         ORDER BY b.vedtakstidspunkt DESC
@@ -251,7 +223,7 @@ interface BehandlingRepository :
     )
     fun erSisteFerdigstilteBehandlingPåNyttRegelverk(
         identer: Set<String>,
-        stønadstype: StønadType,
+        stønadstyper: Set<StønadType>,
     ): Boolean?
 
     // language=PostgreSQL

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -209,6 +209,34 @@ interface BehandlingRepository :
     // language=PostgreSQL
     @Query(
         """
+        SELECT EXISTS (
+            SELECT 1
+            FROM gjeldende_iverksatte_behandlinger gib
+            JOIN behandling b ON b.id = gib.id
+            JOIN person_ident pi ON gib.fagsak_person_id = pi.fagsak_person_id
+            WHERE pi.ident IN (:identer)
+              AND gib.stonadstype = :stønadstype
+              AND gib.resultat = 'INNVILGET'
+              AND b.er_regelendring_2026 = false
+              AND EXISTS (
+                  SELECT 1 FROM andel_tilkjent_ytelse aty
+                  JOIN tilkjent_ytelse ty ON aty.tilkjent_ytelse = ty.id
+                  WHERE ty.behandling_id = gib.id
+                    AND aty.belop > 0
+                    AND aty.stonad_tom >= :iDag
+              )
+        )
+        """,
+    )
+    fun harGjeldendePeriodePåGammeltRegelverk(
+        identer: Set<String>,
+        stønadstype: StønadType,
+        iDag: LocalDate,
+    ): Boolean
+
+    // language=PostgreSQL
+    @Query(
+        """
         SELECT b.*, f.stonadstype
         FROM behandling b
         JOIN fagsak f ON f.id = b.fagsak_id

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingRepository.kt
@@ -237,6 +237,26 @@ interface BehandlingRepository :
     // language=PostgreSQL
     @Query(
         """
+        SELECT b.er_regelendring_2026
+        FROM behandling b
+        JOIN fagsak f ON f.id = b.fagsak_id
+        JOIN person_ident pi ON f.fagsak_person_id = pi.fagsak_person_id
+        WHERE pi.ident IN (:identer)
+          AND f.stonadstype = :stønadstype
+          AND b.status = 'FERDIGSTILT'
+          AND b.resultat <> 'HENLAGT'
+        ORDER BY b.vedtakstidspunkt DESC
+        LIMIT 1
+        """,
+    )
+    fun erSisteFerdigstilteBehandlingPåNyttRegelverk(
+        identer: Set<String>,
+        stønadstype: StønadType,
+    ): Boolean?
+
+    // language=PostgreSQL
+    @Query(
+        """
         SELECT b.*, f.stonadstype
         FROM behandling b
         JOIN fagsak f ON f.id = b.fagsak_id

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -1,38 +1,61 @@
 package no.nav.familie.ef.sak.ekstern.soknad
 
+import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
-import no.nav.familie.ef.sak.vilkår.dto.TidligereVedtaksperioderDto
-import no.nav.familie.ef.sak.vilkår.dto.tilDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonService
+import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 
 @Service
 class EksternSøknadService(
     private val personService: PersonService,
-    private val tidligereVedtaksperioderService: TidligereVedtaksperioderService,
+    private val behandlingRepository: BehandlingRepository,
+    private val infotrygdService: InfotrygdService,
+    private val historiskPensjonService: HistoriskPensjonService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus =
-        try {
+    fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus {
+        return try {
             val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
-            val tidligereVedtaksperioder = tidligereVedtaksperioderService.hentTidligereVedtaksperioder(folkeregisteridentifikatorer)
+            if (folkeregisteridentifikatorer.isEmpty() || folkeregisteridentifikatorer.none { !it.metadata.historisk }) {
+                return TidligereVedtakStatus.NEI
+            }
 
-            tidligereVedtaksperioder.tilDto().tilTidligereVedtakStatus()
+            val aktivIdent = folkeregisteridentifikatorer.gjeldende().ident
+            val identer = folkeregisteridentifikatorer.map { it.ident }.toSet()
+
+            when {
+                harGjeldendePeriodePåGammeltRegelverkIEf(identer) -> TidligereVedtakStatus.JA
+                harTidligereOvergangsstønadIInfotrygd(identer) -> TidligereVedtakStatus.JA
+                else -> historiskPensjonStatus(aktivIdent, identer)
+            }
         } catch (e: Exception) {
             logger.warn("Feil ved sjekk av tidligere innvilget vedtak", e)
             TidligereVedtakStatus.VET_IKKE
         }
-}
+    }
 
-private fun TidligereVedtaksperioderDto.tilTidligereVedtakStatus(): TidligereVedtakStatus {
-    val harFraInfotrygd = infotrygd?.harTidligereInnvilgetVedtak() ?: false
-    val harFraSak = sak?.harTidligereInnvilgetVedtak() ?: false
+    private fun harGjeldendePeriodePåGammeltRegelverkIEf(identer: Set<String>): Boolean =
+        behandlingRepository.harGjeldendePeriodePåGammeltRegelverk(
+            identer = identer,
+            stønadstype = StønadType.OVERGANGSSTØNAD,
+            iDag = LocalDate.now(),
+        )
 
-    if (harFraInfotrygd || harFraSak) return TidligereVedtakStatus.JA
-    if (historiskPensjon == null) return TidligereVedtakStatus.VET_IKKE
-    if (historiskPensjon) return TidligereVedtakStatus.JA
+    private fun harTidligereOvergangsstønadIInfotrygd(identer: Set<String>): Boolean = infotrygdService.hentPerioderFraReplika(identer).overgangsstønad.isNotEmpty()
 
-    return TidligereVedtakStatus.NEI
+    private fun historiskPensjonStatus(
+        aktivIdent: String,
+        identer: Set<String>,
+    ): TidligereVedtakStatus =
+        when (historiskPensjonService.hentHistoriskPensjon(aktivIdent, identer).harPensjonsdata()) {
+            null -> TidligereVedtakStatus.VET_IKKE
+            true -> TidligereVedtakStatus.JA
+            false -> TidligereVedtakStatus.NEI
+        }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -22,7 +22,7 @@ class EksternSøknadService(
     fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus {
         return try {
             val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
-            if (folkeregisteridentifikatorer.isEmpty() || folkeregisteridentifikatorer.none { !it.metadata.historisk }) {
+            if (folkeregisteridentifikatorer.none { !it.metadata.historisk }) {
                 return TidligereVedtakStatus.NEI
             }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -23,7 +23,7 @@ class EksternSøknadService(
         return try {
             val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
             if (folkeregisteridentifikatorer.none { !it.metadata.historisk }) {
-                return TidligereVedtakStatus.NEI
+                return TidligereVedtakStatus.VET_IKKE
             }
 
             val aktivIdent = folkeregisteridentifikatorer.gjeldende().ident

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -8,7 +8,6 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPe
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.LocalDate
 
 @Service
 class EksternSøknadService(
@@ -29,11 +28,10 @@ class EksternSøknadService(
             val aktivIdent = folkeregisteridentifikatorer.gjeldende().ident
             val identer = folkeregisteridentifikatorer.map { it.ident }.toSet()
 
-            when {
-                sisteFerdigstilteBehandlingErPåNyttRegelverk(identer) -> TidligereVedtakStatus.NEI
-                harGjeldendePeriodePåGammeltRegelverkIEf(identer) -> TidligereVedtakStatus.JA
-                harTidligereOvergangsstønadIInfotrygd(identer) -> TidligereVedtakStatus.JA
-                else -> historiskPensjonStatus(aktivIdent, identer)
+            when (sisteFerdigstilteBehandlingErPåNyttRegelverk(identer)) {
+                true -> TidligereVedtakStatus.NEI
+                false -> TidligereVedtakStatus.JA
+                null -> statusFraEksternHistorikk(aktivIdent = aktivIdent, identer = identer)
             }
         } catch (e: Exception) {
             logger.warn("Feil ved sjekk av tidligere innvilget vedtak", e)
@@ -41,18 +39,20 @@ class EksternSøknadService(
         }
     }
 
-    private fun sisteFerdigstilteBehandlingErPåNyttRegelverk(identer: Set<String>): Boolean =
+    private fun sisteFerdigstilteBehandlingErPåNyttRegelverk(identer: Set<String>): Boolean? =
         behandlingRepository.erSisteFerdigstilteBehandlingPåNyttRegelverk(
             identer = identer,
-            stønadstype = StønadType.OVERGANGSSTØNAD,
-        ) == true
-
-    private fun harGjeldendePeriodePåGammeltRegelverkIEf(identer: Set<String>): Boolean =
-        behandlingRepository.harGjeldendePeriodePåGammeltRegelverk(
-            identer = identer,
-            stønadstype = StønadType.OVERGANGSSTØNAD,
-            iDag = LocalDate.now(),
+            stønadstyper = STØNADSTYPER_SOM_GIR_GAMMEL_ORDNING,
         )
+
+    private fun statusFraEksternHistorikk(
+        aktivIdent: String,
+        identer: Set<String>,
+    ): TidligereVedtakStatus =
+        when {
+            harTidligereOvergangsstønadIInfotrygd(identer) -> TidligereVedtakStatus.JA
+            else -> historiskPensjonStatus(aktivIdent = aktivIdent, identer = identer)
+        }
 
     private fun harTidligereOvergangsstønadIInfotrygd(identer: Set<String>): Boolean = infotrygdService.hentPerioderFraReplika(identer).overgangsstønad.isNotEmpty()
 
@@ -65,4 +65,9 @@ class EksternSøknadService(
             true -> TidligereVedtakStatus.JA
             false -> TidligereVedtakStatus.NEI
         }
+
+    companion object {
+        private val STØNADSTYPER_SOM_GIR_GAMMEL_ORDNING =
+            setOf(StønadType.OVERGANGSSTØNAD, StønadType.BARNETILSYN, StønadType.SKOLEPENGER)
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -30,6 +30,7 @@ class EksternSøknadService(
             val identer = folkeregisteridentifikatorer.map { it.ident }.toSet()
 
             when {
+                sisteFerdigstilteBehandlingErPåNyttRegelverk(identer) -> TidligereVedtakStatus.NEI
                 harGjeldendePeriodePåGammeltRegelverkIEf(identer) -> TidligereVedtakStatus.JA
                 harTidligereOvergangsstønadIInfotrygd(identer) -> TidligereVedtakStatus.JA
                 else -> historiskPensjonStatus(aktivIdent, identer)
@@ -39,6 +40,12 @@ class EksternSøknadService(
             TidligereVedtakStatus.VET_IKKE
         }
     }
+
+    private fun sisteFerdigstilteBehandlingErPåNyttRegelverk(identer: Set<String>): Boolean =
+        behandlingRepository.erSisteFerdigstilteBehandlingPåNyttRegelverk(
+            identer = identer,
+            stønadstype = StønadType.OVERGANGSSTØNAD,
+        ) == true
 
     private fun harGjeldendePeriodePåGammeltRegelverkIEf(identer: Set<String>): Boolean =
         behandlingRepository.harGjeldendePeriodePåGammeltRegelverk(

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadService.kt
@@ -3,7 +3,7 @@ package no.nav.familie.ef.sak.ekstern.soknad
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
 import no.nav.familie.ef.sak.infotrygd.InfotrygdService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
-import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldendeEllerNull
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonService
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.slf4j.LoggerFactory
@@ -18,52 +18,44 @@ class EksternSøknadService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus {
-        return try {
+    fun harTidligereInnvilgetVedtak(personIdent: String): TidligereVedtakStatus =
+        try {
             val folkeregisteridentifikatorer = personService.hentSøker(personIdent).folkeregisteridentifikator
-            if (folkeregisteridentifikatorer.none { !it.metadata.historisk }) {
-                return TidligereVedtakStatus.VET_IKKE
-            }
+            val aktivIdent = folkeregisteridentifikatorer.gjeldendeEllerNull()?.ident
 
-            val aktivIdent = folkeregisteridentifikatorer.gjeldende().ident
-            val identer = folkeregisteridentifikatorer.map { it.ident }.toSet()
+            if (aktivIdent == null) {
+                TidligereVedtakStatus.VET_IKKE
+            } else {
+                val identer = folkeregisteridentifikatorer.map { it.ident }.toSet()
 
-            when (sisteFerdigstilteBehandlingErPåNyttRegelverk(identer)) {
-                true -> TidligereVedtakStatus.NEI
-                false -> TidligereVedtakStatus.JA
-                null -> statusFraEksternHistorikk(aktivIdent = aktivIdent, identer = identer)
+                statusFraSisteBehandling(identer)
+                    ?: statusFraInfotrygd(identer)
+                    ?: statusFraHistoriskPensjon(aktivIdent = aktivIdent, identer = identer)
             }
         } catch (e: Exception) {
             logger.warn("Feil ved sjekk av tidligere innvilget vedtak", e)
             TidligereVedtakStatus.VET_IKKE
         }
-    }
 
-    private fun sisteFerdigstilteBehandlingErPåNyttRegelverk(identer: Set<String>): Boolean? =
-        behandlingRepository.erSisteFerdigstilteBehandlingPåNyttRegelverk(
-            identer = identer,
-            stønadstyper = STØNADSTYPER_SOM_GIR_GAMMEL_ORDNING,
-        )
-
-    private fun statusFraEksternHistorikk(
-        aktivIdent: String,
-        identer: Set<String>,
-    ): TidligereVedtakStatus =
-        when {
-            harTidligereOvergangsstønadIInfotrygd(identer) -> TidligereVedtakStatus.JA
-            else -> historiskPensjonStatus(aktivIdent = aktivIdent, identer = identer)
+    private fun statusFraSisteBehandling(identer: Set<String>): TidligereVedtakStatus? =
+        when (behandlingRepository.erSisteFerdigstilteBehandlingPåNyttRegelverk(identer, STØNADSTYPER_SOM_GIR_GAMMEL_ORDNING)) {
+            true -> TidligereVedtakStatus.NEI
+            false -> TidligereVedtakStatus.JA
+            null -> null
         }
 
-    private fun harTidligereOvergangsstønadIInfotrygd(identer: Set<String>): Boolean = infotrygdService.hentPerioderFraReplika(identer).overgangsstønad.isNotEmpty()
+    private fun statusFraInfotrygd(identer: Set<String>): TidligereVedtakStatus? =
+        TidligereVedtakStatus.JA
+            .takeIf { infotrygdService.hentPerioderFraReplika(identer).overgangsstønad.isNotEmpty() }
 
-    private fun historiskPensjonStatus(
+    private fun statusFraHistoriskPensjon(
         aktivIdent: String,
         identer: Set<String>,
     ): TidligereVedtakStatus =
         when (historiskPensjonService.hentHistoriskPensjon(aktivIdent, identer).harPensjonsdata()) {
-            null -> TidligereVedtakStatus.VET_IKKE
             true -> TidligereVedtakStatus.JA
             false -> TidligereVedtakStatus.NEI
+            null -> TidligereVedtakStatus.VET_IKKE
         }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonUtil.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/pdl/PdlPersonUtil.kt
@@ -37,7 +37,9 @@ fun List<FolkeregisteridentifikatorFraSøk>.gjeldende(): Folkeregisteridentifika
         .distinct()
         .single() // Distinkt luker vekk feilen med at samme person kan ha flere identiske identer som begge er i bruk
 
-fun List<Folkeregisteridentifikator>.gjeldende(): Folkeregisteridentifikator = this.single { it.status == FolkeregisteridentifikatorStatus.I_BRUK && !it.metadata.historisk }
+fun List<Folkeregisteridentifikator>.gjeldende(): Folkeregisteridentifikator = gjeldendeEllerNull() ?: error("Forventet nøyaktig én gjeldende folkeregisteridentifikator")
+
+fun List<Folkeregisteridentifikator>.gjeldendeEllerNull(): Folkeregisteridentifikator? = this.singleOrNull { it.status == FolkeregisteridentifikatorStatus.I_BRUK && !it.metadata.historisk }
 
 fun List<SivilstandMedNavn>.gjeldende(): SivilstandMedNavn = this.find { !it.metadata.historisk } ?: this.first()
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -11,6 +11,10 @@ import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.no.nav.familie.ef.sak.infotrygd.InfotrygdPeriodeTestUtil.lagInfotrygdPeriode
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.PdlClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Folkeregisteridentifikator
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.FolkeregisteridentifikatorStatus
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Metadata
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonClient
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonStatus
@@ -54,6 +58,9 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     private lateinit var historiskPensjonClient: HistoriskPensjonClient
 
     @Autowired
+    private lateinit var pdlClient: PdlClient
+
+    @Autowired
     @Qualifier("longCache")
     private lateinit var longCache: CacheManager
 
@@ -65,6 +72,7 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
             InfotrygdPeriodeResponse(overgangsstønad = emptyList(), barnetilsyn = emptyList(), skolepenger = emptyList())
         every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
             HistoriskPensjonDto(HistoriskPensjonStatus.HAR_IKKE_HISTORIKK, "")
+        every { pdlClient.hentSøker(any()) } returns PdlClientConfig.opprettPdlSøker()
         longCache.cacheNames.mapNotNull { longCache.getCache(it) }.forEach { it.clear() }
     }
 
@@ -254,6 +262,23 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     fun `skal returnere VET_IKKE når historisk pensjon er ukjent og ingen treff ellers`() {
         every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
             HistoriskPensjonDto(HistoriskPensjonStatus.UKJENT, "")
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.VET_IKKE)
+    }
+
+    @Test
+    fun `skal returnere VET_IKKE når søker ikke har en aktiv folkeregisteridentifikator`() {
+        val historiskIdent =
+            Folkeregisteridentifikator(
+                ident = personident,
+                status = FolkeregisteridentifikatorStatus.I_BRUK,
+                metadata = Metadata(historisk = true),
+            )
+        every { pdlClient.hentSøker(any()) } returns
+            PdlClientConfig.opprettPdlSøker().copy(folkeregisteridentifikator = listOf(historiskIdent))
 
         val response = hentHarTidligereInnvilgetVedtak()
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -3,35 +3,41 @@ package no.nav.familie.ef.sak.ekstern.soknad
 import io.mockk.every
 import no.nav.familie.ef.sak.OppslagSpringRunnerTest
 import no.nav.familie.ef.sak.behandling.BehandlingRepository
+import no.nav.familie.ef.sak.behandling.domain.Behandling
 import no.nav.familie.ef.sak.behandling.domain.BehandlingResultat
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.felles.domain.SporbarUtils
 import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient
 import no.nav.familie.ef.sak.infrastruktur.config.InfotrygdReplikaMock
+import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
+import no.nav.familie.ef.sak.no.nav.familie.ef.sak.infotrygd.InfotrygdPeriodeTestUtil.lagInfotrygdPeriode
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.pensjon.HistoriskPensjonStatus
 import no.nav.familie.ef.sak.repository.behandling
 import no.nav.familie.ef.sak.repository.fagsak
 import no.nav.familie.ef.sak.repository.fagsakpersoner
 import no.nav.familie.ef.sak.repository.innvilgetOgFerdigstilt
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseRepository
-import no.nav.familie.ef.sak.tilkjentytelse.domain.TilkjentYtelseType
 import no.nav.familie.ef.sak.økonomi.DataGenerator
 import no.nav.familie.ef.sak.økonomi.lagAndelTilkjentYtelse
-import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
-import no.nav.familie.kontrakter.ef.infotrygd.Vedtakstreff
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.resttestclient.exchange
+import org.springframework.cache.CacheManager
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import java.time.LocalDate
 
 class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
-    private val personident = "12345678901"
+    private val personident = PdlClientConfig.SØKER_FNR
     private val fagsakOvergangsstønad =
         fagsak(stønadstype = StønadType.OVERGANGSSTØNAD, identer = fagsakpersoner(setOf(personident)))
 
@@ -44,28 +50,29 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     @Autowired
     private lateinit var infotrygdReplikaClient: InfotrygdReplikaClient
 
+    @Autowired
+    private lateinit var historiskPensjonClient: HistoriskPensjonClient
+
+    @Autowired
+    @Qualifier("longCache")
+    private lateinit var longCache: CacheManager
+
     @BeforeEach
     fun setUp() {
         headers.setBearerAuth(søkerToken(personident))
         InfotrygdReplikaMock.resetMock(infotrygdReplikaClient)
-        every { infotrygdReplikaClient.hentInslagHosInfotrygd(any()) } returns
-            InfotrygdFinnesResponse(vedtak = emptyList(), saker = emptyList())
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns
+            InfotrygdPeriodeResponse(overgangsstønad = emptyList(), barnetilsyn = emptyList(), skolepenger = emptyList())
+        every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
+            HistoriskPensjonDto(HistoriskPensjonStatus.HAR_IKKE_HISTORIKK, "")
+        longCache.cacheNames.mapNotNull { longCache.getCache(it) }.forEach { it.clear() }
     }
 
     @Test
-    fun `skal returnere JA for innvilget vedtak med beløp 0`() {
+    fun `skal returnere JA for gjeldende innvilget vedtak på gammelt regelverk`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
         val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
-        val andelMedNullBeløp =
-            lagAndelTilkjentYtelse(
-                beløp = 0,
-                fraOgMed = LocalDate.of(2023, 1, 1),
-                tilOgMed = LocalDate.of(2023, 12, 31),
-                kildeBehandlingId = behandling.id,
-            )
-        tilkjentYtelseRepository.insert(
-            DataGenerator.tilfeldigTilkjentYtelse(behandling).copy(andelerTilkjentYtelse = listOf(andelMedNullBeløp)),
-        )
+        lagreAndel(behandling, beløp = 5000, tilOgMed = iDagPlusEttÅr())
 
         val response = hentHarTidligereInnvilgetVedtak()
 
@@ -74,49 +81,72 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `skal returnere JA for opphørt sak som tidligere hadde andeler`() {
+    fun `skal returnere NEI for gjeldende innvilget vedtak på nytt regelverk`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        val behandling =
+            behandlingRepository.insert(
+                behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt().copy(erRegelendring2026 = true),
+            )
+        lagreAndel(behandling, beløp = 5000, tilOgMed = iDagPlusEttÅr())
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
+    fun `skal returnere NEI for innvilget vedtak med kun historiske perioder`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
+        lagreAndel(behandling, beløp = 5000, tilOgMed = LocalDate.now().minusYears(1))
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
+    fun `skal returnere NEI for innvilget vedtak med beløp 0`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
+        lagreAndel(behandling, beløp = 0, tilOgMed = iDagPlusEttÅr())
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
+    fun `skal returnere NEI for opphørt sak`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
 
         val førsteBehandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
-        val andelMedBeløp =
-            lagAndelTilkjentYtelse(
-                beløp = 5000,
-                fraOgMed = LocalDate.of(2023, 1, 1),
-                tilOgMed = LocalDate.of(2023, 6, 30),
-                kildeBehandlingId = førsteBehandling.id,
-            )
-        tilkjentYtelseRepository.insert(
-            DataGenerator.tilfeldigTilkjentYtelse(førsteBehandling).copy(andelerTilkjentYtelse = listOf(andelMedBeløp)),
-        )
+        lagreAndel(førsteBehandling, beløp = 5000, tilOgMed = LocalDate.now().minusMonths(6))
 
-        val opphørtBehandling =
-            behandlingRepository.insert(
-                behandling(fagsakOvergangsstønad).copy(
-                    resultat = BehandlingResultat.OPPHØRT,
-                    status = BehandlingStatus.FERDIGSTILT,
-                    vedtakstidspunkt = SporbarUtils.now(),
-                ),
-            )
-        tilkjentYtelseRepository.insert(
-            DataGenerator.tilfeldigTilkjentYtelse(opphørtBehandling).copy(
-                andelerTilkjentYtelse = emptyList(),
-                type = TilkjentYtelseType.OPPHØR,
-                startdato = LocalDate.of(2023, 1, 1),
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad).copy(
+                resultat = BehandlingResultat.OPPHØRT,
+                status = BehandlingStatus.FERDIGSTILT,
+                vedtakstidspunkt = SporbarUtils.now(),
             ),
         )
 
         val response = hentHarTidligereInnvilgetVedtak()
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
     }
 
     @Test
     fun `skal returnere JA når person kun finnes i Infotrygd`() {
-        every { infotrygdReplikaClient.hentInslagHosInfotrygd(any()) } returns
-            InfotrygdFinnesResponse(
-                vedtak = listOf(Vedtakstreff(personident, StønadType.OVERGANGSSTØNAD, false)),
-                saker = emptyList(),
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns
+            InfotrygdPeriodeResponse(
+                overgangsstønad = listOf(lagInfotrygdPeriode(personident)),
+                barnetilsyn = emptyList(),
+                skolepenger = emptyList(),
             )
 
         val response = hentHarTidligereInnvilgetVedtak()
@@ -124,6 +154,48 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
     }
+
+    @Test
+    fun `skal returnere JA når historisk pensjon har historikk`() {
+        every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
+            HistoriskPensjonDto(HistoriskPensjonStatus.HAR_HISTORIKK, "")
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal returnere VET_IKKE når historisk pensjon er ukjent og ingen treff ellers`() {
+        every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
+            HistoriskPensjonDto(HistoriskPensjonStatus.UKJENT, "")
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.VET_IKKE)
+    }
+
+    private fun lagreAndel(
+        behandling: Behandling,
+        beløp: Int,
+        tilOgMed: LocalDate,
+        fraOgMed: LocalDate = LocalDate.now().minusYears(1),
+    ) {
+        val andel =
+            lagAndelTilkjentYtelse(
+                beløp = beløp,
+                fraOgMed = fraOgMed,
+                tilOgMed = tilOgMed,
+                kildeBehandlingId = behandling.id,
+            )
+        tilkjentYtelseRepository.insert(
+            DataGenerator.tilfeldigTilkjentYtelse(behandling).copy(andelerTilkjentYtelse = listOf(andel)),
+        )
+    }
+
+    private fun iDagPlusEttÅr() = LocalDate.now().plusYears(1)
 
     private fun hentHarTidligereInnvilgetVedtak() =
         testRestTemplate.exchange<Ressurs<TidligereVedtakStatus>>(

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -96,6 +96,90 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `skal returnere NEI når siste ferdigstilte behandling er på nytt regelverk selv om bruker finnes i Infotrygd`() {
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns
+            InfotrygdPeriodeResponse(
+                overgangsstønad = listOf(lagInfotrygdPeriode(personident)),
+                barnetilsyn = emptyList(),
+                skolepenger = emptyList(),
+            )
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt().copy(erRegelendring2026 = true),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
+    fun `skal returnere NEI når siste ferdigstilte behandling er på nytt regelverk selv om historisk pensjon har historikk`() {
+        every { historiskPensjonClient.hentHistoriskPensjonStatusForIdent(any(), any()) } returns
+            HistoriskPensjonDto(HistoriskPensjonStatus.HAR_HISTORIKK, "")
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt().copy(erRegelendring2026 = true),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
+    fun `skal bruke siste behandling slik at nyere gammelt vedtak gir JA selv om eldre behandling var på nytt regelverk`() {
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad)
+                .innvilgetOgFerdigstilt()
+                .copy(erRegelendring2026 = true, vedtakstidspunkt = SporbarUtils.now().minusDays(10)),
+        )
+        val nyesteBehandling =
+            behandlingRepository.insert(
+                behandling(fagsakOvergangsstønad)
+                    .innvilgetOgFerdigstilt()
+                    .copy(vedtakstidspunkt = SporbarUtils.now()),
+            )
+        lagreAndel(nyesteBehandling, beløp = 5000, tilOgMed = iDagPlusEttÅr())
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal ignorere henlagt behandling og bruke siste reelle behandling på nytt regelverk`() {
+        every { infotrygdReplikaClient.hentPerioder(any()) } returns
+            InfotrygdPeriodeResponse(
+                overgangsstønad = listOf(lagInfotrygdPeriode(personident)),
+                barnetilsyn = emptyList(),
+                skolepenger = emptyList(),
+            )
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad)
+                .innvilgetOgFerdigstilt()
+                .copy(erRegelendring2026 = true, vedtakstidspunkt = SporbarUtils.now().minusDays(5)),
+        )
+        behandlingRepository.insert(
+            behandling(
+                fagsak = fagsakOvergangsstønad,
+                resultat = BehandlingResultat.HENLAGT,
+                status = BehandlingStatus.FERDIGSTILT,
+            ).copy(vedtakstidspunkt = SporbarUtils.now()),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+    }
+
+    @Test
     fun `skal returnere NEI for innvilget vedtak med kun historiske perioder`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
         val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -44,6 +44,10 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     private val personident = PdlClientConfig.SØKER_FNR
     private val fagsakOvergangsstønad =
         fagsak(stønadstype = StønadType.OVERGANGSSTØNAD, identer = fagsakpersoner(setOf(personident)))
+    private val fagsakBarnetilsyn =
+        fagsak(stønadstype = StønadType.BARNETILSYN, identer = fagsakpersoner(setOf(personident)))
+    private val fagsakSkolepenger =
+        fagsak(stønadstype = StønadType.SKOLEPENGER, identer = fagsakpersoner(setOf(personident)))
 
     @Autowired
     private lateinit var tilkjentYtelseRepository: TilkjentYtelseRepository
@@ -230,6 +234,49 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
         assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal returnere JA når siste behandling er en gammel barnetilsyn`() {
+        testoppsettService.lagreFagsak(fagsakBarnetilsyn)
+        behandlingRepository.insert(behandling(fagsakBarnetilsyn).innvilgetOgFerdigstilt())
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal returnere JA når siste behandling er en gammel skolepenger`() {
+        testoppsettService.lagreFagsak(fagsakSkolepenger)
+        behandlingRepository.insert(behandling(fagsakSkolepenger).innvilgetOgFerdigstilt())
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
+    }
+
+    @Test
+    fun `skal bruke siste behandling på tvers av stønadsordninger slik at ny overgangsstønad gir NEI selv om eldre barnetilsyn var på gammelt regelverk`() {
+        testoppsettService.lagreFagsak(fagsakBarnetilsyn)
+        behandlingRepository.insert(
+            behandling(fagsakBarnetilsyn)
+                .innvilgetOgFerdigstilt()
+                .copy(vedtakstidspunkt = SporbarUtils.now().minusDays(10)),
+        )
+        testoppsettService.lagreFagsak(fagsakOvergangsstønad)
+        behandlingRepository.insert(
+            behandling(fagsakOvergangsstønad)
+                .innvilgetOgFerdigstilt()
+                .copy(erRegelendring2026 = true, vedtakstidspunkt = SporbarUtils.now()),
+        )
+
+        val response = hentHarTidligereInnvilgetVedtak()
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/ekstern/soknad/EksternSøknadControllerTest.kt
@@ -188,7 +188,7 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
     }
 
     @Test
-    fun `skal returnere NEI for innvilget vedtak med kun historiske perioder`() {
+    fun `skal returnere JA når siste behandling er på gammelt regelverk selv om perioden er utløpt`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
         val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
         lagreAndel(behandling, beløp = 5000, tilOgMed = LocalDate.now().minusYears(1))
@@ -196,11 +196,11 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
         val response = hentHarTidligereInnvilgetVedtak()
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
     }
 
     @Test
-    fun `skal returnere NEI for innvilget vedtak med beløp 0`() {
+    fun `skal returnere JA når siste behandling er på gammelt regelverk selv om beløpet er 0`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
         val behandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
         lagreAndel(behandling, beløp = 0, tilOgMed = iDagPlusEttÅr())
@@ -208,11 +208,11 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
         val response = hentHarTidligereInnvilgetVedtak()
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
     }
 
     @Test
-    fun `skal returnere NEI for opphørt sak`() {
+    fun `skal returnere JA når siste behandling er en opphørt sak på gammelt regelverk`() {
         testoppsettService.lagreFagsak(fagsakOvergangsstønad)
 
         val førsteBehandling = behandlingRepository.insert(behandling(fagsakOvergangsstønad).innvilgetOgFerdigstilt())
@@ -229,7 +229,7 @@ class EksternSøknadControllerTest : OppslagSpringRunnerTest() {
         val response = hentHarTidligereInnvilgetVedtak()
 
         assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
-        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.NEI)
+        assertThat(response.body?.data).isEqualTo(TidligereVedtakStatus.JA)
     }
 
     @Test


### PR DESCRIPTION
# Fiks: Riktig søknadsregel basert på regelendring 2026

### Hvorfor er denne endringen nødvendig? ✨

Endepunktet som brukes av søknadsdialogen for å sjekke om en bruker har hatt stønad tidligere, returnerte feil svar for personer som har en aktiv stønadsbehandling på det nye regelverket (2026-reglene).

Logikken er nå endret slik at vi ser på siste ferdigstilte, ikke-henlagte behandling på tvers av alle stønadsordninger:

- Er siste behandling på nytt regelverk, returnerer vi NEI (personen er allerede over på nye regler)
- Er siste behandling på gammelt regelverk, returnerer vi JA (personen har en eldre ordning)
- Finnes det ingen behandling i ny løsning, faller vi tilbake til Infotrygd, og så historisk pensjon

I tillegg returnerer vi nå VET_IKKE i stedet for å krasje dersom søker mangler en aktiv folkeregisteridentifikator i PDL.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29252).

Denne PRen er en del av en bredre oppgave og depender på denne → PRen.

### Verdt å nevne

* Testet i preprod med forskjellige caser
* Helt ny søker, nytt regelverk
* Søker med kun nye behandlinger, nytt regelverk
* Søker med gammel barnetilsyn, gammelt regelverk på overganggstønad
* Søker med gammel overgangsstønad, gammelt regelverk på overgangsstønad