### PR TITLE
Kartlegging av a-inntekt feil

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektService.kt
@@ -4,6 +4,8 @@ import no.nav.familie.ef.sak.amelding.ekstern.AMeldingInntektClient
 import no.nav.familie.ef.sak.amelding.ekstern.ArbeidOgInntektClient
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.time.YearMonth
 import java.util.UUID
@@ -15,6 +17,9 @@ class InntektService(
     private val fagsakService: FagsakService,
     private val fagsakPersonService: FagsakPersonService,
 ) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
     fun hentInntekt(
         fagsakId: UUID,
         månedFom: YearMonth,
@@ -41,16 +46,32 @@ class InntektService(
 
     fun genererAInntektUrl(fagsakPersonId: UUID): String {
         val personIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
-        return arbeidOgInntektClient.genererAInntektUrl(personIdent)
+        val url = arbeidOgInntektClient.genererAInntektUrl(personIdent)
+        loggGenerertAInntektUrl(kilde = "fagsakPersonId=$fagsakPersonId", personIdent = personIdent, url = url)
+        return url
     }
 
     fun genererAInntektArbeidsforholdUrl(fagsakId: UUID): String {
         val personIdent = fagsakService.hentAktivIdent(fagsakId)
-        return arbeidOgInntektClient.genererAInntektArbeidsforholdUrl(personIdent)
+        val url = arbeidOgInntektClient.genererAInntektArbeidsforholdUrl(personIdent)
+        loggGenerertAInntektUrl(kilde = "fagsakId=$fagsakId (arbeidsforhold)", personIdent = personIdent, url = url)
+        return url
     }
 
     fun genererAInntektUrlFagsak(fagsakId: UUID): String {
         val personIdent = fagsakService.hentAktivIdent(fagsakId)
-        return arbeidOgInntektClient.genererAInntektUrl(personIdent)
+        val url = arbeidOgInntektClient.genererAInntektUrl(personIdent)
+        loggGenerertAInntektUrl(kilde = "fagsakId=$fagsakId", personIdent = personIdent, url = url)
+        return url
+    }
+
+    private fun loggGenerertAInntektUrl(
+        kilde: String,
+        personIdent: String,
+        url: String,
+    ) {
+        val saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker()
+        logger.info("Genererer a-inntekt-url for $kilde (saksbehandler=$saksbehandler)")
+        secureLogger.info("Genererer a-inntekt-url for $kilde (saksbehandler=$saksbehandler) personIdent=$personIdent url=$url")
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/InntektService.kt
@@ -47,31 +47,31 @@ class InntektService(
     fun genererAInntektUrl(fagsakPersonId: UUID): String {
         val personIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
         val url = arbeidOgInntektClient.genererAInntektUrl(personIdent)
-        loggGenerertAInntektUrl(kilde = "fagsakPersonId=$fagsakPersonId", personIdent = personIdent, url = url)
+        loggGenerertAInntektUrl(fagsakId = "fagsakPersonId=$fagsakPersonId", personIdent = personIdent, url = url)
         return url
     }
 
     fun genererAInntektArbeidsforholdUrl(fagsakId: UUID): String {
         val personIdent = fagsakService.hentAktivIdent(fagsakId)
         val url = arbeidOgInntektClient.genererAInntektArbeidsforholdUrl(personIdent)
-        loggGenerertAInntektUrl(kilde = "fagsakId=$fagsakId (arbeidsforhold)", personIdent = personIdent, url = url)
+        loggGenerertAInntektUrl(fagsakId = "fagsakId=$fagsakId (arbeidsforhold)", personIdent = personIdent, url = url)
         return url
     }
 
     fun genererAInntektUrlFagsak(fagsakId: UUID): String {
         val personIdent = fagsakService.hentAktivIdent(fagsakId)
         val url = arbeidOgInntektClient.genererAInntektUrl(personIdent)
-        loggGenerertAInntektUrl(kilde = "fagsakId=$fagsakId", personIdent = personIdent, url = url)
+        loggGenerertAInntektUrl(fagsakId = "fagsakId=$fagsakId", personIdent = personIdent, url = url)
         return url
     }
 
     private fun loggGenerertAInntektUrl(
-        kilde: String,
+        fagsakId: String,
         personIdent: String,
         url: String,
     ) {
         val saksbehandler = SikkerhetContext.hentSaksbehandlerEllerSystembruker()
-        logger.info("Genererer a-inntekt-url for $kilde (saksbehandler=$saksbehandler)")
-        secureLogger.info("Genererer a-inntekt-url for $kilde (saksbehandler=$saksbehandler) personIdent=$personIdent url=$url")
+        logger.info("Genererer a-inntekt-url for $fagsakId (saksbehandler=$saksbehandler)")
+        secureLogger.info("Genererer a-inntekt-url for $fagsakId (saksbehandler=$saksbehandler) personIdent=$personIdent url=$url")
     }
 }


### PR DESCRIPTION
# Kartlegging av a-inntekt feil (backend logging)

### Hvorfor er denne endringen nødvendig? ✨

Saksbehandlere melder at a-inntekt av og til viser forrige bruker når de åpner den fra EF-sak. Det er vanskelig å gjenskape, og vi vet ikke sikkert om feilen ligger hos oss eller hos a-inntekt (adeo).

For å finne ut av det legger vi på logging i backend når vi genererer a-inntekt url:

* Vanlig logg uten persondata, så vi ser at et kall skjer og hvem som klikket.
* Secure logg med personident og den faktiske url'en

Da kan vi sammenligne: hvis vi sendte riktig person, men a-inntekt viser feil, ligger feilen hos dem. Hvis vi sendte feil person, ligger den hos oss.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29582).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-sak-frontend/pull/3432).

### Verdt å nevne

* Backenden henter alltid ny ident per kall, så selve oppslaget er ikke cachet.
* Ren logging, ingen endring i hva endepunktene returnerer.