### PR TITLE
Viser regelverk i blankett

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettPdfRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettPdfRequest.kt
@@ -31,6 +31,7 @@ data class BlankettPdfBehandling(
     val kontantstøttePerioderFraKs: List<KontantstøttePeriode>,
     val registeropplysningerOpprettetDato: LocalDate,
     val erRegelendring2026: Boolean = false,
+    val featureToggleRegelendringer2026: Boolean = false,
 )
 
 data class PersonopplysningerDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettPdfRequest.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettPdfRequest.kt
@@ -30,6 +30,7 @@ data class BlankettPdfBehandling(
     val harKontantstøttePerioder: Boolean?,
     val kontantstøttePerioderFraKs: List<KontantstøttePeriode>,
     val registeropplysningerOpprettetDato: LocalDate,
+    val erRegelendring2026: Boolean = false,
 )
 
 data class PersonopplysningerDto(

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ef.sak.behandling.dto.tilDto
 import no.nav.familie.ef.sak.behandling.revurdering.ÅrsakRevurderingService
 import no.nav.familie.ef.sak.brev.BrevClient
 import no.nav.familie.ef.sak.felles.domain.Fil
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.GrunnlagsdataService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.søknad.SøknadDatoerDto
@@ -32,6 +34,7 @@ class BlankettService(
     private val årsakRevurderingService: ÅrsakRevurderingService,
     private val grunnlagsdataService: GrunnlagsdataService,
     private val samværsavtaleService: SamværsavtaleService,
+    private val featureToggleService: FeatureToggleService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -57,6 +60,7 @@ class BlankettService(
                     kontantstøttePerioderFraKs = grunnlagsdata.kontantstøttePerioder,
                     registeropplysningerOpprettetDato = vilkårVurderinger.grunnlag.registeropplysningerOpprettetTid.toLocalDate(),
                     erRegelendring2026 = behandling.erRegelendring2026,
+                    featureToggleRegelendringer2026 = featureToggleService.isEnabled(Toggle.REGELENDRINGER_2026),
                 ),
                 lagPersonopplysningerDto(behandling),
                 vilkårVurderinger,

--- a/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/blankett/BlankettService.kt
@@ -56,6 +56,7 @@ class BlankettService(
                     harKontantstøttePerioder = grunnlagsdata.harKontantstøttePerioder,
                     kontantstøttePerioderFraKs = grunnlagsdata.kontantstøttePerioder,
                     registeropplysningerOpprettetDato = vilkårVurderinger.grunnlag.registeropplysningerOpprettetTid.toLocalDate(),
+                    erRegelendring2026 = behandling.erRegelendring2026,
                 ),
                 lagPersonopplysningerDto(behandling),
                 vilkårVurderinger,


### PR DESCRIPTION
Sender med 'erRegelendring2026' flagg som brukes av brev til å vise behandling er gjort etter gammelt eller nytt regelverk i blankett.

Sender også med toggle da vi ikke skal vise det nye feltet før 1. juli.

Hører sammen med https://github.com/navikt/familie-brev/pull/921

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29586)