### PR TITLE
Grupperer alle github actions oppdateringer av dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,5 +33,7 @@ updates:
       time: "04:00"
     cooldown:
       default-days: 4
-      exclude:
-        - "no.nav.familie*"
+    groups:
+      github-actions:
+        pattern:
+          - "*"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Grupperer oppdateringer av github actions, inkludert nais-actions.

Fjernet exclude på no.nav.familie da det ikke vil være aktuelt for github actions.