### PR TITLE
Sender med versjon av søknad som ble fylt ut, denne verdien skal bruk…

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/Søknadsverdier.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/søknad/domain/Søknadsverdier.kt
@@ -21,6 +21,7 @@ data class Søknadsverdier(
     val adresseopplysninger: Adresseopplysninger?,
     val dokumentasjon: DokumentasjonFraSøknadDto,
     val inntekter: List<String> = emptyList(),
+    val erSøknadRegelendring2026: Boolean = false,
 )
 
 data class DokumentasjonFraSøknadDto(
@@ -104,4 +105,5 @@ fun SøknadsskjemaOvergangsstønad.tilSøknadsverdier() =
         datoPåbegyntSøknad = this.datoPåbegyntSøknad,
         dokumentasjon = DokumentasjonMapper.tilDokumentasjonDto(this),
         inntekter = this.inntekter?.verdier ?: emptyList(),
+        erSøknadRegelendring2026 = this.erRegelendring2026,
     )

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VilkårGrunnlagService.kt
@@ -100,6 +100,7 @@ class VilkårGrunnlagService(
             harAvsluttetArbeidsforhold = grunnlagsdata.harAvsluttetArbeidsforhold,
             harKontantstøttePerioder = grunnlagsdata.harKontantstøttePerioder,
             kontantstøttePerioder = grunnlagsdata.kontantstøttePerioder,
+            erSøknadRegelendring2026 = søknad?.erSøknadRegelendring2026 ?: false,
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/dto/VilkårDto.kt
@@ -27,6 +27,7 @@ data class VilkårGrunnlagDto(
     val harAvsluttetArbeidsforhold: Boolean?,
     val harKontantstøttePerioder: Boolean?,
     val kontantstøttePerioder: List<KontantstøttePeriode>,
+    val erSøknadRegelendring2026: Boolean = false,
 )
 
 data class PersonaliaDto(


### PR DESCRIPTION
…es til å velge aktivitet komponentet som vises i frontend

### Hvorfor er denne endringen nødvendig? ✨

[Hører med](https://github.com/navikt/familie-ef-sak-frontend/pull/3456) 