### PR TITLE
Gjør om delete og insert til insert med update som fallback, for å unngå race condition mellom to pods som begge prøver å inserte

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerBrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerBrevRepository.kt
@@ -3,10 +3,35 @@ package no.nav.familie.ef.sak.brev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 import java.util.UUID
 
 @Repository
 interface MellomlagerBrevRepository :
     RepositoryInterface<MellomlagretBrev, UUID>,
-    InsertUpdateRepository<MellomlagretBrev>
+    InsertUpdateRepository<MellomlagretBrev> {
+    // Bruker en atomisk upsert for å unngå race condition (duplicate key) ved samtidige mellomlagringer
+    // av samme behandlingId, som kan oppstå ved f.eks. autolagring og manuell lagring nesten samtidig.
+    @Modifying
+    @Query(
+        """
+        INSERT INTO mellomlagret_brev (behandling_id, brevverdier, brevmal, sanity_versjon, opprettet_tid)
+        VALUES (:behandlingId, :brevverdier, :brevmal, :sanityVersjon, :opprettetTid)
+        ON CONFLICT (behandling_id) DO UPDATE SET
+            brevverdier = excluded.brevverdier,
+            brevmal = excluded.brevmal,
+            sanity_versjon = excluded.sanity_versjon,
+            opprettet_tid = excluded.opprettet_tid
+        """,
+    )
+    fun upsert(
+        behandlingId: UUID,
+        brevverdier: String,
+        brevmal: String,
+        sanityVersjon: String,
+        opprettetTid: LocalDate,
+    )
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.brev
 
-import no.nav.familie.ef.sak.brev.domain.MellomlagretBrev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponse
 import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevSanity
@@ -21,16 +20,15 @@ class MellomlagringBrevService(
         brevmal: String,
         sanityVersjon: String,
     ): UUID {
-        slettMellomlagringHvisFinnes(behandlingId)
-        val mellomlagretBrev =
-            MellomlagretBrev(
-                behandlingId,
-                brevverdier,
-                brevmal,
-                sanityVersjon,
-                LocalDate.now(),
-            )
-        return mellomlagerBrevRepository.insert(mellomlagretBrev).behandlingId
+        // Bruker upsert fremfor delete+insert for å unngå duplicate key ved samtidige mellomlagringer
+        mellomlagerBrevRepository.upsert(
+            behandlingId,
+            brevverdier,
+            brevmal,
+            sanityVersjon,
+            LocalDate.now(),
+        )
+        return behandlingId
     }
 
     fun mellomLagreFrittståendeSanitybrev(

--- a/src/test/kotlin/no/nav/familie/ef/sak/repository/MellomlagringBrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/repository/MellomlagringBrevRepositoryTest.kt
@@ -26,4 +26,20 @@ internal class MellomlagringBrevRepositoryTest : OppslagSpringRunnerTest() {
 
         assertThat(mellomlagerBrevRepository.findById(behandling.id)).get().usingRecursiveComparison().isEqualTo(mellomlagretBrev)
     }
+
+    @Test
+    internal fun `upsert skal oppdatere eksisterende mellomlagret brev uten å feile på duplicate key`() {
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val behandling = behandlingRepository.insert(behandling(fagsak))
+        val opprinneligDato = LocalDate.now().minusDays(1)
+
+        mellomlagerBrevRepository.upsert(behandling.id, "{}", "mal", "1", opprinneligDato)
+        mellomlagerBrevRepository.upsert(behandling.id, "{\"felt\":1}", "mal2", "2", LocalDate.now())
+
+        val lagret = mellomlagerBrevRepository.findById(behandling.id).get()
+        assertThat(lagret.brevverdier).isEqualTo("{\"felt\":1}")
+        assertThat(lagret.brevmal).isEqualTo("mal2")
+        assertThat(lagret.sanityVersjon).isEqualTo("2")
+        assertThat(lagret.opprettetTid).isEqualTo(LocalDate.now())
+    }
 }


### PR DESCRIPTION
Endrer fra delete og insert til upsert av mellomlagring av brev, for å unngå feil som har dukket opp i prod i det siste: ERROR: duplicate key value violates unique constraint "mellomlagret_brev_pkey" (behandlingId)

Det er antakelig to podder som forsøker å gjøre det samme samtidig (insert) og får dermed duplicate primary key. 

Har ikke klart å reprodusere i dev, men har testet at brev og endring på brevsiden fortsatt funker fint.