### PR TITLE
Gjør om delete og insert til upsert for å unngå feil i mellomlagring av frittstående brev

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepository.kt
@@ -3,7 +3,10 @@ package no.nav.familie.ef.sak.brev
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Repository
@@ -14,4 +17,26 @@ interface MellomlagerFrittståendeSanitybrevRepository :
         fagsakId: UUID,
         saksehandlerIdent: String,
     ): MellomlagretFrittståendeSanitybrev?
+
+    // Bruker en atomisk upsert for å unngå race condition (duplicate key) ved samtidige mellomlagringer
+    // av samme fagsakId/saksbehandlerIdent, som kan oppstå ved f.eks. autolagring og manuell lagring nesten samtidig.
+    @Modifying
+    @Query(
+        """
+        INSERT INTO mellomlagret_frittstaende_sanitybrev (id, fagsak_id, brevverdier, brevmal, saksbehandler_ident, opprettet_tid)
+        VALUES (:id, :fagsakId, :brevverdier, :brevmal, :saksbehandlerIdent, :opprettetTid)
+        ON CONFLICT (fagsak_id, saksbehandler_ident) DO UPDATE SET
+            brevverdier = excluded.brevverdier,
+            brevmal = excluded.brevmal,
+            opprettet_tid = excluded.opprettet_tid
+        """,
+    )
+    fun upsert(
+        id: UUID,
+        fagsakId: UUID,
+        brevverdier: String,
+        brevmal: String,
+        saksbehandlerIdent: String,
+        opprettetTid: LocalDateTime,
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/MellomlagringBrevService.kt
@@ -1,12 +1,12 @@
 package no.nav.familie.ef.sak.brev
 
-import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponse
 import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevSanity
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -36,14 +36,16 @@ class MellomlagringBrevService(
         brevverdier: String,
         brevmal: String,
     ): UUID {
-        slettMellomlagretFrittståendeBrev(fagsakId, SikkerhetContext.hentSaksbehandler())
-        val mellomlagretBrev =
-            MellomlagretFrittståendeSanitybrev(
-                fagsakId = fagsakId,
-                brevverdier = brevverdier,
-                brevmal = brevmal,
-            )
-        return mellomlagerFrittståendeSanitybrevRepository.insert(mellomlagretBrev).fagsakId
+        // Bruker upsert fremfor delete+insert for å unngå duplicate key ved samtidige mellomlagringer
+        mellomlagerFrittståendeSanitybrevRepository.upsert(
+            UUID.randomUUID(),
+            fagsakId,
+            brevverdier,
+            brevmal,
+            SikkerhetContext.hentSaksbehandler(),
+            LocalDateTime.now(),
+        )
+        return fagsakId
     }
 
     fun hentMellomlagretFrittståendeSanitybrev(fagsakId: UUID): MellomlagretBrevResponse? =

--- a/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/brev/MellomlagerFrittståendeSanitybrevRepositoryTest.kt
@@ -5,10 +5,13 @@ import no.nav.familie.ef.sak.brev.MellomlagerFrittståendeSanitybrevRepository
 import no.nav.familie.ef.sak.brev.domain.MellomlagretFrittståendeSanitybrev
 import no.nav.familie.ef.sak.repository.fagsak
 import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 
 internal class MellomlagerFrittståendeSanitybrevRepositoryTest : OppslagSpringRunnerTest() {
     @Autowired
@@ -59,5 +62,34 @@ internal class MellomlagerFrittståendeSanitybrevRepositoryTest : OppslagSpringR
             .usingRecursiveComparison()
             .ignoringFields("opprettetTid")
             .isEqualTo(mellomlagretBrev)
+    }
+
+    @Test
+    internal fun `upsert skal oppdatere eksisterende mellomlagret brev uten å feile på duplicate key`() {
+        val saksbehandlerIdent = "12345678910"
+        val fagsak = testoppsettService.lagreFagsak(fagsak())
+        val opprinneligDato = LocalDateTime.now().minusDays(1)
+
+        mellomlagerFrittståendeSanitybrevRepository.upsert(
+            UUID.randomUUID(),
+            fagsak.id,
+            "{}",
+            "mal",
+            saksbehandlerIdent,
+            opprinneligDato,
+        )
+        mellomlagerFrittståendeSanitybrevRepository.upsert(
+            UUID.randomUUID(),
+            fagsak.id,
+            "{\"felt\":1}",
+            "mal2",
+            saksbehandlerIdent,
+            LocalDateTime.now(),
+        )
+
+        val lagret = mellomlagerFrittståendeSanitybrevRepository.findByFagsakIdAndSaksbehandlerIdent(fagsak.id, saksbehandlerIdent)
+        assertThat(lagret).isNotNull
+        assertThat(lagret!!.brevverdier).isEqualTo("{\"felt\":1}")
+        assertThat(lagret.brevmal).isEqualTo("mal2")
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ser man får duplicate key exception for frittstående brev også. Løser det på samme måte som her: https://github.com/navikt/familie-ef-sak/pull/3237