### PR TITLE
Legger til "regelverk" for årsak underkjent ved beslutting av vedtak

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/TotrinnskontrollStatusDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/dto/TotrinnskontrollStatusDto.kt
@@ -38,4 +38,5 @@ enum class ÅrsakUnderkjent {
     VEDTAKSBREV,
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER,
     SIMULERING_ENDRET,
+    REGELVERK,
 }


### PR DESCRIPTION
# Legger til "regelverk" for årsak underkjent ved beslutting av vedtak

### Hvorfor er denne endringen nødvendig? ✨ 

Saksbehandler meldte inn at de ønsker regelverk endring som årsak til underkjennelse av vedtak. Legger derfor til "regelverksvalg" som årsak for underkjennelse av vedtak. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29918).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-sak-frontend/pull/3458)

### Verdt å nevne

* Har snakket med vår fagressurs LI og fikk forslaget "Kontroller regelverksvalg" for utledning av årsak. Dette virker bra og noe som er konkrekt, konsist og tydelig. 
* Har testet i dev der man har sendt en behandling til beslutter, fått den underkjent med årsak "regelverk", tatt opp behandlingen igjen og sett at det blir riktig. 
