### PR TITLE
Ikke valider lovvalg ved g-omregning

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterSteg.kt
@@ -35,6 +35,7 @@ import no.nav.familie.ef.sak.vedtak.dto.ResultatType.INNVILGE
 import no.nav.familie.ef.sak.vedtak.dto.ResultatType.INNVILGE_UTEN_UTBETALING
 import no.nav.familie.ef.sak.vedtak.dto.SendTilBeslutterDto
 import no.nav.familie.ef.sak.vilkår.VurderingService
+import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
 import no.nav.familie.kontrakter.felles.ef.StønadType
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
@@ -78,6 +79,7 @@ class SendTilBeslutterSteg(
 
     private fun validerBegrunnelseForRegelveksvalgErSatt(saksbehandling: Saksbehandling) {
         if (!featureToggleService.isEnabled(Toggle.REGELENDRINGER_2026)) return
+        if (saksbehandling.årsak == BehandlingÅrsak.G_OMREGNING) return
         val begrunnelse: String? = regelendring2026Repository.findByBehandlingId(saksbehandling.id)?.begrunnelse
         when (saksbehandling.stønadstype) {
             StønadType.OVERGANGSSTØNAD, StønadType.BARNETILSYN -> brukerfeilHvis(begrunnelse.isNullOrBlank()) { "Begrunnelse for valg av regelverk er påkrevd. Behandling: ${saksbehandling.id}" }

--- a/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/behandlingsflyt/steg/SendTilBeslutterStegTest.kt
@@ -213,6 +213,17 @@ internal class SendTilBeslutterStegTest {
     }
 
     @Test
+    internal fun `Skal ikke kaste feil hvis begrunnelse for regelverk ikke er satt og behandlingsårsak er G_OMREGNING`() {
+        val innvilgetBehandling = behandling.copy(resultat = INNVILGET, årsak = BehandlingÅrsak.G_OMREGNING)
+        every { vedtakService.hentVedtaksresultat(any()) } returns ResultatType.INNVILGE
+        every { featureToggleService.isEnabled(Toggle.REGELENDRINGER_2026) } returns true
+
+        beslutteVedtakSteg.validerSteg(innvilgetBehandling)
+
+        verify(exactly = 0) { regelendring2026Repository.findByBehandlingId(any()) }
+    }
+
+    @Test
     internal fun `Skal ikke kaste feil hvis SKOLEPENGER`() {
         val innvilgetBehandling = behandling.copy(resultat = INNVILGET, stønadstype = StønadType.SKOLEPENGER)
         every { vedtakService.hentVedtaksresultat(any()) } returns ResultatType.INNVILGE


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ikke mulig å g-omregne i en fagsak hvor en behandling er iverksatt før 1. juli, fordi det valideres på lovvalg (som naturligvis ikke er satt). Legger til et unntak i valideringen for g-omregninger.