### PR TITLE
Skyggekjør infotrygd kall mot gcp

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -89,6 +89,7 @@ spec:
         - application: familie-ef-iverksett
         - application: familie-dokument
         - application: familie-ks-sak
+        - application: familie-ef-infotrygd-replika
         - application: familie-ef-proxy
           cluster: dev-fss
         - application: historisk-pensjon

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -86,6 +86,7 @@ spec:
         - application: familie-ef-iverksett
         - application: familie-dokument
         - application: familie-ks-sak
+        - application: familie-ef-infotrygd-replika
         - application: historisk-pensjon
           namespace: historisk
         - application: familie-ef-proxy

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
@@ -1,11 +1,15 @@
 package no.nav.familie.ef.sak.infotrygd
 
+import no.nav.familie.ef.sak.infotrygd.skygge.SkyggeInfotrygdOperasjon
+import no.nav.familie.ef.sak.infotrygd.skygge.SkyggeInfotrygdTask
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
+import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.restklient.client.AbstractPingableRestClient
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -19,7 +23,9 @@ class InfotrygdReplikaClient(
     private val infotrygdReplikaUri: URI,
     @Qualifier("azure")
     restOperations: RestOperations,
+    private val taskService: TaskService,
 ) : AbstractPingableRestClient(restOperations, "infotrygd.replika") {
+    private val logger = LoggerFactory.getLogger(javaClass)
     private val perioderUri: URI =
         UriComponentsBuilder
             .fromUri(infotrygdReplikaUri)
@@ -56,11 +62,23 @@ class InfotrygdReplikaClient(
             .build()
             .toUri()
 
-    fun hentPerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse = postForEntity(perioderUri, request)
+    fun hentPerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse {
+        val response = postForEntity<InfotrygdPeriodeResponse>(perioderUri, request)
+        skyggekjør(SkyggeInfotrygdOperasjon.HENT_PERIODER, request, response, request.personIdenter)
+        return response
+    }
 
-    fun hentSammenslåttePerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse = postForEntity(sammenslåttePerioderUri, request)
+    fun hentSammenslåttePerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse {
+        val response = postForEntity<InfotrygdPeriodeResponse>(sammenslåttePerioderUri, request)
+        skyggekjør(SkyggeInfotrygdOperasjon.HENT_SAMMENSLÅTTE_PERIODER, request, response, request.personIdenter)
+        return response
+    }
 
-    fun hentSaker(request: InfotrygdSøkRequest): InfotrygdSakResponse = postForEntity(finnSakerUri, request)
+    fun hentSaker(request: InfotrygdSøkRequest): InfotrygdSakResponse {
+        val response = postForEntity<InfotrygdSakResponse>(finnSakerUri, request)
+        skyggekjør(SkyggeInfotrygdOperasjon.HENT_SAKER, request, response, request.personIdenter)
+        return response
+    }
 
     fun hentPersonerForMigrering(antall: Int): Set<String> {
         val response = getForEntity<Map<String, Any>>(migreringspersonerUri(antall))
@@ -73,7 +91,9 @@ class InfotrygdReplikaClient(
      */
     fun hentInslagHosInfotrygd(request: InfotrygdSøkRequest): InfotrygdFinnesResponse {
         require(request.personIdenter.isNotEmpty()) { "Identer har ingen verdier" }
-        return postForEntity(eksistererUri, request)
+        val response = postForEntity<InfotrygdFinnesResponse>(eksistererUri, request)
+        skyggekjør(SkyggeInfotrygdOperasjon.HENT_INNSLAG_HOS_INFOTRYGD, request, response, request.personIdenter)
+        return response
     }
 
     override val pingUri: URI
@@ -83,4 +103,24 @@ class InfotrygdReplikaClient(
                 .pathSegment("api/ping")
                 .build()
                 .toUri()
+
+    /**
+     * Oppretter en asynkron task som gjør det samme kallet mot familie-ef-infotrygd-replika (GCP) og sammenligner
+     * responsen med [forventetRespons] (svaret vi nettopp fikk fra familie-ef-infotrygd on-prem). Brukes til å
+     * verifisere at migreringen til GCP-replikaen gir identiske svar, se [SkyggeInfotrygdTask].
+     *
+     * Skal aldri kunne påvirke det ordinære kallet mot on-prem, så eventuelle feil ved oppretting av skyggetasken logges her
+     */
+    private fun skyggekjør(
+        operasjon: SkyggeInfotrygdOperasjon,
+        request: Any,
+        forventetRespons: Any,
+        personIdenter: Set<String>,
+    ) {
+        try {
+            taskService.save(SkyggeInfotrygdTask.opprettTask(operasjon, request, forventetRespons, personIdenter))
+        } catch (e: Exception) {
+            logger.error("Klarte ikke å opprette skyggetask for $operasjon mot familie-ef-infotrygd-replika", e)
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaGcpClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaGcpClient.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.ef.sak.infotrygd
+
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
+import no.nav.familie.restklient.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestOperations
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+/**
+ * Klient mot familie-ef-infotrygd-replika i GCP.
+ *
+ * Brukes utelukkende til å skyggekjøre kall som allerede har blitt gjort mot [InfotrygdReplikaClient] (familie-ef-infotrygd on-prem),
+ * for å verifisere at migreringen til GCP-replikaen gir samme svar. Skal ikke brukes i den ordinære saksbehandlingsflyten
+ * før migreringen er ferdig verifisert, se [no.nav.familie.ef.sak.infotrygd.skygge.SkyggeInfotrygdTask].
+ */
+@Service
+class InfotrygdReplikaGcpClient(
+    @Value("\${INFOTRYGD_REPLIKA_GCP_API_URL}")
+    private val infotrygdReplikaGcpUri: URI,
+    @Qualifier("azure")
+    restOperations: RestOperations,
+) : AbstractRestClient(restOperations, "infotrygd.replika.gcp") {
+    private val perioderUri: URI =
+        UriComponentsBuilder
+            .fromUri(infotrygdReplikaGcpUri)
+            .pathSegment("api/perioder")
+            .build()
+            .toUri()
+
+    private val sammenslåttePerioderUri: URI =
+        UriComponentsBuilder
+            .fromUri(infotrygdReplikaGcpUri)
+            .pathSegment("api/perioder/sammenslatte")
+            .build()
+            .toUri()
+
+    private val finnSakerUri: URI =
+        UriComponentsBuilder
+            .fromUri(infotrygdReplikaGcpUri)
+            .pathSegment("api/saker/finn")
+            .build()
+            .toUri()
+
+    private val eksistererUri: URI =
+        UriComponentsBuilder
+            .fromUri(infotrygdReplikaGcpUri)
+            .pathSegment("api/stonad/eksisterer")
+            .build()
+            .toUri()
+
+    fun hentPerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse = postForEntity(perioderUri, request)
+
+    fun hentSammenslåttePerioder(request: InfotrygdPeriodeRequest): InfotrygdPeriodeResponse = postForEntity(sammenslåttePerioderUri, request)
+
+    fun hentSaker(request: InfotrygdSøkRequest): InfotrygdSakResponse = postForEntity(finnSakerUri, request)
+
+    fun hentInslagHosInfotrygd(request: InfotrygdSøkRequest): InfotrygdFinnesResponse {
+        require(request.personIdenter.isNotEmpty()) { "Identer har ingen verdier" }
+        return postForEntity(eksistererUri, request)
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggeInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggeInfotrygdTask.kt
@@ -1,0 +1,164 @@
+package no.nav.familie.ef.sak.infotrygd.skygge
+
+import no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaGcpClient
+import no.nav.familie.ef.sak.infrastruktur.config.readValue
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.prosessering.AsyncTaskStep
+import no.nav.familie.prosessering.TaskStepBeskrivelse
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import java.util.Properties
+
+/**
+ * Skyggekjører kall som allerede er gjort mot familie-ef-infotrygd (on-prem) på nytt mot familie-ef-infotrygd-replika (GCP),
+ * for å verifisere at migreringen til GCP gir identiske svar.
+ *
+ * Tasken oppretter IKKE selv kallet mot on-prem - den mottar requesten og fasitsvaret (on-prem-responsen) som ble hentet
+ * i [no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient], gjør det samme kallet mot GCP-replikaen, og sammenligner
+ * responsene. Ved avvik logges det en error (med detaljer i secureLogger siden responsene kan inneholde personopplysninger)
+ * og tasken feiler slik at avviket blir synlig og kan følges opp manuelt.
+ */
+@Service
+@TaskStepBeskrivelse(
+    taskStepType = SkyggeInfotrygdTask.TYPE,
+    maxAntallFeil = 3,
+    settTilManuellOppfølgning = true,
+    triggerTidVedFeilISekunder = 60L,
+    beskrivelse = "Skyggekjører kall mot familie-ef-infotrygd-replika (GCP) og sammenligner med fasitsvar fra familie-ef-infotrygd (on-prem)",
+)
+class SkyggeInfotrygdTask(
+    private val infotrygdReplikaGcpClient: InfotrygdReplikaGcpClient,
+) : AsyncTaskStep {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun doTask(task: Task) {
+        val payload = jsonMapper.readValue<SkyggeInfotrygdPayload>(task.payload)
+        when (payload.operasjon) {
+            SkyggeInfotrygdOperasjon.HENT_PERIODER -> {
+                sammenlign(
+                    payload = payload,
+                    faktiskRespons = { infotrygdReplikaGcpClient.hentPerioder(jsonMapper.readValue<InfotrygdPeriodeRequest>(payload.request)) },
+                    normaliser = InfotrygdPeriodeResponse::normalisert,
+                )
+            }
+
+            SkyggeInfotrygdOperasjon.HENT_SAMMENSLÅTTE_PERIODER -> {
+                sammenlign(
+                    payload = payload,
+                    faktiskRespons = {
+                        infotrygdReplikaGcpClient.hentSammenslåttePerioder(jsonMapper.readValue<InfotrygdPeriodeRequest>(payload.request))
+                    },
+                    normaliser = InfotrygdPeriodeResponse::normalisert,
+                )
+            }
+
+            SkyggeInfotrygdOperasjon.HENT_SAKER -> {
+                sammenlign(
+                    payload = payload,
+                    faktiskRespons = { infotrygdReplikaGcpClient.hentSaker(jsonMapper.readValue<InfotrygdSøkRequest>(payload.request)) },
+                    normaliser = InfotrygdSakResponse::normalisert,
+                )
+            }
+
+            SkyggeInfotrygdOperasjon.HENT_INNSLAG_HOS_INFOTRYGD -> {
+                sammenlign(
+                    payload = payload,
+                    faktiskRespons = {
+                        infotrygdReplikaGcpClient.hentInslagHosInfotrygd(jsonMapper.readValue<InfotrygdSøkRequest>(payload.request))
+                    },
+                    normaliser = InfotrygdFinnesResponse::normalisert,
+                )
+            }
+        }
+    }
+
+    private inline fun <reified T> sammenlign(
+        payload: SkyggeInfotrygdPayload,
+        faktiskRespons: () -> T,
+        normaliser: (T) -> T,
+    ) {
+        val forventet = normaliser(jsonMapper.readValue<T>(payload.forventetRespons))
+        val faktisk = normaliser(faktiskRespons())
+
+        if (forventet != faktisk) {
+            secureLogger.error(
+                "Skyggekjøring av ${payload.operasjon} feilet - avvik mellom familie-ef-infotrygd (on-prem) og " +
+                    "familie-ef-infotrygd-replika (GCP).\nrequest=${payload.request}\nonPrem=$forventet\ngcp=$faktisk",
+            )
+            logger.error(
+                "Skyggekjøring av ${payload.operasjon} feilet - responsen fra familie-ef-infotrygd-replika (GCP) er " +
+                    "ulik responsen fra familie-ef-infotrygd (on-prem). Se secureLogger for detaljer.",
+            )
+            throw TaskExceptionUtenStackTrace(
+                "Skyggekjøring av ${payload.operasjon} feilet - avvik mellom on-prem og GCP-replika for infotrygd",
+            )
+        }
+    }
+
+    companion object {
+        const val TYPE = "skyggekjørInfotrygd"
+
+        fun opprettTask(
+            operasjon: SkyggeInfotrygdOperasjon,
+            request: Any,
+            forventetRespons: Any,
+            personIdenter: Set<String>,
+        ): Task {
+            val payload =
+                SkyggeInfotrygdPayload(
+                    operasjon = operasjon,
+                    request = jsonMapper.writeValueAsString(request),
+                    forventetRespons = jsonMapper.writeValueAsString(forventetRespons),
+                )
+            return Task(
+                type = TYPE,
+                payload = jsonMapper.writeValueAsString(payload),
+                properties =
+                    Properties().apply {
+                        this["operasjon"] = operasjon.name
+                        this["personIdenter"] = personIdenter.joinToString(",")
+                    },
+            )
+        }
+    }
+}
+
+data class SkyggeInfotrygdPayload(
+    val operasjon: SkyggeInfotrygdOperasjon,
+    val request: String,
+    val forventetRespons: String,
+)
+
+enum class SkyggeInfotrygdOperasjon {
+    HENT_PERIODER,
+    HENT_SAMMENSLÅTTE_PERIODER,
+    HENT_SAKER,
+    HENT_INNSLAG_HOS_INFOTRYGD,
+}
+
+/**
+ * Perioder/saker/treff kan i praksis komme i ulik rekkefølge fra on-prem og GCP-replikaen uten at det er et reelt avvik,
+ * så listene sorteres på en stabil, innholdsbasert nøkkel før sammenligning.
+ */
+private fun InfotrygdPeriodeResponse.normalisert(): InfotrygdPeriodeResponse =
+    copy(
+        overgangsstønad = overgangsstønad.sortedBy { it.toString() },
+        barnetilsyn = barnetilsyn.sortedBy { it.toString() },
+        skolepenger = skolepenger.sortedBy { it.toString() },
+    )
+
+private fun InfotrygdSakResponse.normalisert(): InfotrygdSakResponse = copy(saker = saker.sortedBy { it.toString() })
+
+private fun InfotrygdFinnesResponse.normalisert(): InfotrygdFinnesResponse =
+    copy(
+        vedtak = vedtak.sortedBy { it.toString() },
+        saker = saker.sortedBy { it.toString() },
+    )

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggeInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggeInfotrygdTask.kt
@@ -98,7 +98,7 @@ class SkyggeInfotrygdTask(
                     "ulik responsen fra familie-ef-infotrygd (on-prem). Se secureLogger for detaljer.",
             )
             throw TaskExceptionUtenStackTrace(
-                "Skyggekjøring av ${payload.operasjon} feilet - avvik mellom on-prem og GCP-replika for infotrygd",
+                "Skyggekjøring av ${payload.operasjon} feilet - avvik mellom on-prem og GCP-replika for infotrygd. Se securelogger for detaljer.",
             )
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,15 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      infotrygd-replika-gcp:
+        resource-url: ${INFOTRYGD_REPLIKA_GCP_API_URL}
+        token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
+        grant-type: client_credentials
+        scope: ${INFOTRYGD_REPLIKA_GCP_SCOPE}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic
       familie-ef-iverksett-clientcredentials:
         resource-url: ${FAMILIE_EF_IVERKSETT_URL}
         token-endpoint-url: ${AZUREAD_TOKEN_ENDPOINT_URL}
@@ -243,6 +252,7 @@ FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.tilbake.tilbakekreving-backend/.d
 FAMILIE_KLAGE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-klage/.default
 FAMILIE_EF_PROXY_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-proxy/.default
 INFOTRYGD_REPLIKA_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-infotrygd/.default
+INFOTRYGD_REPLIKA_GCP_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-infotrygd-replika/.default
 ARBEIDSSOKER_SCOPE: api://${DEPLOY_ENV}-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default
 FAMILIE_INTEGRASJONER_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-integrasjoner/.default
 HISTORISK_PENSJON_SCOPE: api://${DEPLOY_ENV}-gcp.historisk.historisk-pensjon/.default
@@ -321,6 +331,7 @@ FAMILIE_KLAGE_URL: http://familie-klage
 
 FAMILIE_INTEGRASJONER_URL: https://familie-integrasjoner.${ON_PREM_URL_ENV}-fss-pub.nais.io
 INFOTRYGD_REPLIKA_API_URL: https://familie-ef-infotrygd.${ON_PREM_URL_ENV}-fss-pub.nais.io
+INFOTRYGD_REPLIKA_GCP_API_URL: http://familie-ef-infotrygd-replika
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
 REPR_API_URL: http://repr-api.repr
 FAMILIE_EF_PROXY_URL: https://familie-ef-proxy.${ON_PREM_URL_ENV}-fss-pub.nais.io


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å verifisere at migreringen har gått fint ved å skyggekjøre alle kall mot familie-ef-infotrygd-replika. Det opprettes en task ved hvert kall mot familie-ef-infotrygd. Tasken med navn `skyggekjørInfotrygd` kjører et kall mot familie-ef-infotrygd-replika og sammenligner responsen derfra mot responsen vi fikk fra familie-infotrygd. Dersom det er avvik i responsen mellom de to appene vil skyggekjøringstasken bli satt til feilet, og vil bli synlig i prosessering uten at det påvirker kallet mot infotrygd.

Migreringen av data i prod er ikke ferdig enda, men kommer til å merge denne PR'n når det er det.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29653)