### PR TITLE
Setter base image til Chainguard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 ENV TZ="Europe/Oslo"
 COPY target/familie-ef-sak.jar /app/app.jar
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"


### PR DESCRIPTION
# Setter base image til Chainguard

### Hvorfor er denne endringen nødvendig? ✨ 

Vi ønsker Chainguard base image for appene våres. Denne setter dette base image.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-26362).

### Verdt å nevne

Har testet ved å:

* Har deployet appen til dev og sett at den peker på image.