### PR TITLE
Upsert begrunnelse i regelendring2026 for å unngå errors med insert av duplikate primary keys

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/Regelendring2026Repository.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/Regelendring2026Repository.kt
@@ -3,6 +3,8 @@ package no.nav.familie.ef.sak.behandling
 import no.nav.familie.ef.sak.behandling.domain.Regelendring2026
 import no.nav.familie.ef.sak.repository.InsertUpdateRepository
 import no.nav.familie.ef.sak.repository.RepositoryInterface
+import org.springframework.data.jdbc.repository.query.Modifying
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.stereotype.Repository
 import java.util.UUID
 
@@ -11,4 +13,18 @@ interface Regelendring2026Repository :
     RepositoryInterface<Regelendring2026, UUID>,
     InsertUpdateRepository<Regelendring2026> {
     fun findByBehandlingId(behandlingId: UUID): Regelendring2026?
+
+    @Modifying
+    @Query(
+        """
+        INSERT INTO regelendring_2026 (behandling_id, begrunnelse)
+        VALUES (:behandlingId, :begrunnelse)
+        ON CONFLICT (behandling_id) DO UPDATE SET
+            begrunnelse = excluded.begrunnelse
+        """,
+    )
+    fun upsert(
+        behandlingId: UUID,
+        begrunnelse: String,
+    )
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/Regelendring2026Service.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/Regelendring2026Service.kt
@@ -26,18 +26,6 @@ class Regelendring2026Service(
             "Behandlingen eies av en annen saksbehandler"
         }
 
-        val eksisterende = hent(behandlingId)
-        if (eksisterende != null) {
-            regelendring2026Repository.update(
-                eksisterende.copy(begrunnelse = begrunnelse),
-            )
-        } else {
-            regelendring2026Repository.insert(
-                Regelendring2026(
-                    behandlingId = behandlingId,
-                    begrunnelse = begrunnelse,
-                ),
-            )
-        }
+        regelendring2026Repository.upsert(behandlingId, begrunnelse)
     }
 }


### PR DESCRIPTION
Dette oppstår hvis flere podder forsøker å inserte samtidig. Følger samme mønster som implementert i mellomlagring av brev. Klarte forøvrig ikke å gjenskape dette ved å klikke på lagringsknappen flere ganger.