### PR TITLE
Lagre skyggekjøring i egen transaksjon

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/InfotrygdReplikaClient.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.infotrygd
 
 import no.nav.familie.ef.sak.infotrygd.skygge.SkyggeInfotrygdOperasjon
 import no.nav.familie.ef.sak.infotrygd.skygge.SkyggekjørInfotrygdTask
+import no.nav.familie.ef.sak.infotrygd.skygge.SkyggekjøringTaskLagrer
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
@@ -9,7 +10,6 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
-import no.nav.familie.prosessering.internal.TaskService
 import no.nav.familie.restklient.client.AbstractPingableRestClient
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -25,7 +25,7 @@ class InfotrygdReplikaClient(
     private val infotrygdReplikaUri: URI,
     @Qualifier("azure")
     restOperations: RestOperations,
-    private val taskService: TaskService,
+    private val skyggekjøringTaskLagrer: SkyggekjøringTaskLagrer,
     private val featureToggleService: FeatureToggleService,
 ) : AbstractPingableRestClient(restOperations, "infotrygd.replika") {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -112,6 +112,9 @@ class InfotrygdReplikaClient(
      * responsen med [forventetRespons] (svaret vi nettopp fikk fra familie-ef-infotrygd on-prem). Brukes til å
      * verifisere at migreringen til GCP-replikaen gir identiske svar, se [SkyggekjørInfotrygdTask].
      *
+     * [SkyggekjøringTaskLagrer] oppretter kun tasken dersom en identisk (samme payload/type) ikke allerede finnes -
+     * se den for hvorfor dette er trygt og effektivt på tvers av transaksjonskontekster.
+     *
      * Skal aldri kunne påvirke det ordinære kallet mot on-prem, så eventuelle feil ved oppretting av skyggetasken logges her
      */
     private fun skyggekjør(
@@ -122,7 +125,9 @@ class InfotrygdReplikaClient(
     ) {
         if (featureToggleService.isEnabled(Toggle.SKYGGEKJØR_INFOTRYGD)) {
             try {
-                taskService.save(SkyggekjørInfotrygdTask.opprettTask(operasjon, request, forventetRespons, personIdenter))
+                skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(
+                    SkyggekjørInfotrygdTask.opprettTask(operasjon, request, forventetRespons, personIdenter),
+                )
             } catch (e: Exception) {
                 logger.error("Klarte ikke å opprette skyggetask for $operasjon mot familie-ef-infotrygd-replika", e)
             }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjørInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjørInfotrygdTask.kt
@@ -15,7 +15,6 @@ import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.error.TaskExceptionUtenStackTrace
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.LocalDateTime
 import java.util.Properties
 
 /**
@@ -136,7 +135,6 @@ data class SkyggeInfotrygdPayload(
     val operasjon: SkyggeInfotrygdOperasjon,
     val request: String,
     val forventetRespons: String,
-    val timestamp: LocalDateTime = LocalDateTime.now(),
 )
 
 enum class SkyggeInfotrygdOperasjon {

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
@@ -1,0 +1,70 @@
+package no.nav.familie.ef.sak.infotrygd.skygge
+
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.relational.core.conversion.DbActionExecutionException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Sjekk-og-lagre kjøres i [Propagation.REQUIRES_NEW]: [no.nav.familie.ef.sak.infotrygd.InfotrygdReplikaClient] kan
+ * kalles dypt inne fra store forretningstransaksjoner (migrering, ekstern søknad m.m.), og vi ønsker verken å
+ * (a) holde en lås på den unike indeksen like lenge som en slik transaksjon, eller (b) miste en skyggetask fordi
+ * en helt urelatert del av en større transaksjon ruller tilbake. Egen transaksjon gir oss dette uavhengig av
+ * kallsted, uten at vi må stole på at skyggekjøring bare kalles fra transaksjonsløse ("trygge") deler av koden.
+ *
+ * For å unngå at to podder som skyggekjører nøyaktig samme kall samtidig faktisk *forsøker* å lagre samme task
+ * (og dermed må håndtere en exception fra den unike indeksen, se catch under), tas det først en Postgres
+ * advisory-lås ([laasForPayloadOgType]) nøkkelet på (type, payload). Den er transaksjonsscopet og frigis
+ * automatisk ved commit/rollback, og serialiserer kun samtidige kall for *nøyaktig* samme skyggetask - andre
+ * skyggekjøringer blokkeres ikke. Den første som får låsen gjør sjekk+lagre+commit; de påfølgende ser deretter
+ * allerede den lagrede tasken i sjekken og hopper over lagring i stedet for å forsøke et duplikat-insert.
+ */
+@Component
+class SkyggekjøringTaskLagrer(
+    private val taskService: TaskService,
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun lagreHvisIkkeFinnesFraFør(task: Task) {
+        laasForPayloadOgType(task.payload, task.type)
+
+        val eksisterende = taskService.finnTaskMedPayloadOgType(task.payload, task.type)
+        if (eksisterende != null) {
+            logger.info("Skyggetask av type ${task.type} med lik payload finnes allerede (id=${eksisterende.id}) - hopper over")
+            return
+        }
+        try {
+            taskService.save(task)
+        } catch (e: DuplicateKeyException) {
+            logger.info("Skyggetask av type ${task.type} ble opprettet samtidig av et annet kall - hopper over")
+        } catch (e: DbActionExecutionException) {
+            if (e.cause is DuplicateKeyException) {
+                logger.info("Skyggetask av type ${task.type} ble opprettet samtidig av et annet kall - hopper over")
+            } else {
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Tar en transaksjonsscopet Postgres advisory-lås (`pg_advisory_xact_lock`) nøkkelet på (type, payload), slik
+     * at samtidige kall for nøyaktig samme skyggetask - fra denne eller andre podder - blir serialisert i stedet
+     * for å forsøke duplikate inserts. Nøkkelen er en 32-bits hash av (type, payload); en eventuell hash-kollisjon
+     * med en helt annen skyggetask fører i verste fall til at de kortvarig serialiseres unødvendig, ikke til noen
+     * korrekthetsfeil. Låsen frigis automatisk når [Propagation.REQUIRES_NEW]-transaksjonen commit'er/ruller tilbake.
+     */
+    private fun laasForPayloadOgType(
+        payload: String,
+        type: String,
+    ) {
+        val låsnøkkel = "$type|$payload".hashCode()
+        jdbcTemplate.execute("SELECT pg_advisory_xact_lock($låsnøkkel)")
+    }
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
@@ -18,11 +18,10 @@ import org.springframework.transaction.annotation.Transactional
  * kallsted, uten at vi må stole på at skyggekjøring bare kalles fra transaksjonsløse ("trygge") deler av koden.
  *
  * For å unngå at to podder som skyggekjører nøyaktig samme kall samtidig faktisk *forsøker* å lagre samme task
- * (og dermed må håndtere en exception fra den unike indeksen, se catch under), tas det først en Postgres
- * advisory-lås ([låsForPayloadOgType]) nøkkelet på (type, payload). Den er transaksjonsscopet og frigis
+ * (og dermed må håndtere en exception fra den unike indeksen, se catch under), forsøkes det først en Postgres
+ * advisory-lås ([forsøkLåsForPayloadOgType]) nøkkelet på (type, payload). Den er transaksjonsscopet og frigis
  * automatisk ved commit/rollback, og serialiserer kun samtidige kall for *nøyaktig* samme skyggetask - andre
- * skyggekjøringer blokkeres ikke. Den første som får låsen gjør sjekk+lagre+commit; de påfølgende ser deretter
- * allerede den lagrede tasken i sjekken og hopper over lagring i stedet for å forsøke et duplikat-insert.
+ * skyggekjøringer blokkeres ikke.
  */
 @Component
 class SkyggekjøringTaskLagrer(
@@ -33,7 +32,10 @@ class SkyggekjøringTaskLagrer(
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun lagreHvisIkkeFinnesFraFør(task: Task) {
-        låsForPayloadOgType(task.payload, task.type)
+        if (!forsøkLåsForPayloadOgType(task.payload, task.type)) {
+            logger.info("Skyggetask av type ${task.type} håndteres allerede av et samtidig kall - hopper over")
+            return
+        }
 
         val eksisterende = taskService.finnTaskMedPayloadOgType(task.payload, task.type)
         if (eksisterende != null) {
@@ -53,18 +55,11 @@ class SkyggekjøringTaskLagrer(
         }
     }
 
-    /**
-     * Tar en transaksjonsscopet Postgres advisory-lås (`pg_advisory_xact_lock`) nøkkelet på (type, payload), slik
-     * at samtidige kall for nøyaktig samme skyggetask - fra denne eller andre podder - blir serialisert i stedet
-     * for å forsøke duplikate inserts. Nøkkelen er en 32-bits hash av (type, payload); en eventuell hash-kollisjon
-     * med en helt annen skyggetask fører i verste fall til at de kortvarig serialiseres unødvendig, ikke til noen
-     * korrekthetsfeil. Låsen frigis automatisk når [Propagation.REQUIRES_NEW]-transaksjonen commit'er/ruller tilbake.
-     */
-    private fun låsForPayloadOgType(
+    private fun forsøkLåsForPayloadOgType(
         payload: String,
         type: String,
-    ) {
+    ): Boolean {
         val låsnøkkel = "$type|$payload".hashCode()
-        jdbcTemplate.execute("SELECT pg_advisory_xact_lock($låsnøkkel)")
+        return jdbcTemplate.queryForObject("SELECT pg_try_advisory_xact_lock($låsnøkkel)", Boolean::class.java) ?: false
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrer.kt
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional
  *
  * For å unngå at to podder som skyggekjører nøyaktig samme kall samtidig faktisk *forsøker* å lagre samme task
  * (og dermed må håndtere en exception fra den unike indeksen, se catch under), tas det først en Postgres
- * advisory-lås ([laasForPayloadOgType]) nøkkelet på (type, payload). Den er transaksjonsscopet og frigis
+ * advisory-lås ([låsForPayloadOgType]) nøkkelet på (type, payload). Den er transaksjonsscopet og frigis
  * automatisk ved commit/rollback, og serialiserer kun samtidige kall for *nøyaktig* samme skyggetask - andre
  * skyggekjøringer blokkeres ikke. Den første som får låsen gjør sjekk+lagre+commit; de påfølgende ser deretter
  * allerede den lagrede tasken i sjekken og hopper over lagring i stedet for å forsøke et duplikat-insert.
@@ -33,7 +33,7 @@ class SkyggekjøringTaskLagrer(
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     fun lagreHvisIkkeFinnesFraFør(task: Task) {
-        laasForPayloadOgType(task.payload, task.type)
+        låsForPayloadOgType(task.payload, task.type)
 
         val eksisterende = taskService.finnTaskMedPayloadOgType(task.payload, task.type)
         if (eksisterende != null) {
@@ -60,7 +60,7 @@ class SkyggekjøringTaskLagrer(
      * med en helt annen skyggetask fører i verste fall til at de kortvarig serialiseres unødvendig, ikke til noen
      * korrekthetsfeil. Låsen frigis automatisk når [Propagation.REQUIRES_NEW]-transaksjonen commit'er/ruller tilbake.
      */
-    private fun laasForPayloadOgType(
+    private fun låsForPayloadOgType(
         payload: String,
         type: String,
     ) {

--- a/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrerTest.kt
@@ -7,6 +7,7 @@ import io.mockk.verifyOrder
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
 import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.dao.DuplicateKeyException
 import org.springframework.data.relational.core.conversion.DbAction
@@ -15,10 +16,28 @@ import org.springframework.jdbc.core.JdbcTemplate
 
 class SkyggekjøringTaskLagrerTest {
     private val taskService = mockk<TaskService>()
-    private val jdbcTemplate = mockk<JdbcTemplate>(relaxed = true)
+    private val jdbcTemplate = mockk<JdbcTemplate>()
     private val skyggekjøringTaskLagrer = SkyggekjøringTaskLagrer(taskService, jdbcTemplate)
 
     private val task = Task(type = "skyggekjørInfotrygd", payload = "{\"foo\":\"bar\"}", properties = java.util.Properties())
+    private val forventetLåsnøkkel = "${task.type}|${task.payload}".hashCode()
+    private val forventetLåsSql = "SELECT pg_try_advisory_xact_lock($forventetLåsnøkkel)"
+
+    @BeforeEach
+    fun setup() {
+        // Låsen tas som hovedregel - egne tester overstyrer dette for å simulere at et annet samtidig kall alt holder den.
+        every { jdbcTemplate.queryForObject(forventetLåsSql, Boolean::class.java) } returns true
+    }
+
+    @Test
+    fun `lagrer ikke ny task dersom advisory-låsen for type og payload allerede holdes av et samtidig kall`() {
+        every { jdbcTemplate.queryForObject(forventetLåsSql, Boolean::class.java) } returns false
+
+        skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task)
+
+        verify(exactly = 0) { taskService.finnTaskMedPayloadOgType(any(), any()) }
+        verify(exactly = 0) { taskService.save(any()) }
+    }
 
     @Test
     fun `lagrer ikke ny task dersom en identisk task allerede finnes`() {
@@ -30,15 +49,14 @@ class SkyggekjøringTaskLagrerTest {
     }
 
     @Test
-    fun `tar advisory-lås nøkkelet på type og payload før sjekk mot databasen`() {
+    fun `forsøker advisory-lås nøkkelet på type og payload før sjekk mot databasen`() {
         every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
         every { taskService.save(task) } returns task
 
         skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task)
 
-        val forventetNøkkel = "${task.type}|${task.payload}".hashCode()
         verifyOrder {
-            jdbcTemplate.execute("SELECT pg_advisory_xact_lock($forventetNøkkel)")
+            jdbcTemplate.queryForObject(forventetLåsSql, Boolean::class.java)
             taskService.finnTaskMedPayloadOgType(task.payload, task.type)
             taskService.save(task)
         }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjøringTaskLagrerTest.kt
@@ -1,0 +1,83 @@
+package no.nav.familie.ef.sak.infotrygd.skygge
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import no.nav.familie.prosessering.domene.Task
+import no.nav.familie.prosessering.internal.TaskService
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.data.relational.core.conversion.DbAction
+import org.springframework.data.relational.core.conversion.DbActionExecutionException
+import org.springframework.jdbc.core.JdbcTemplate
+
+class SkyggekjøringTaskLagrerTest {
+    private val taskService = mockk<TaskService>()
+    private val jdbcTemplate = mockk<JdbcTemplate>(relaxed = true)
+    private val skyggekjøringTaskLagrer = SkyggekjøringTaskLagrer(taskService, jdbcTemplate)
+
+    private val task = Task(type = "skyggekjørInfotrygd", payload = "{\"foo\":\"bar\"}", properties = java.util.Properties())
+
+    @Test
+    fun `lagrer ikke ny task dersom en identisk task allerede finnes`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns mockk<Task>(relaxed = true)
+
+        skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task)
+
+        verify(exactly = 0) { taskService.save(any()) }
+    }
+
+    @Test
+    fun `tar advisory-lås nøkkelet på type og payload før sjekk mot databasen`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
+        every { taskService.save(task) } returns task
+
+        skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task)
+
+        val forventetNøkkel = "${task.type}|${task.payload}".hashCode()
+        verifyOrder {
+            jdbcTemplate.execute("SELECT pg_advisory_xact_lock($forventetNøkkel)")
+            taskService.finnTaskMedPayloadOgType(task.payload, task.type)
+            taskService.save(task)
+        }
+    }
+
+    @Test
+    fun `lagrer ny task dersom ingen identisk task finnes fra før`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
+        every { taskService.save(task) } returns task
+
+        skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task)
+
+        verify(exactly = 1) { taskService.save(task) }
+    }
+
+    @Test
+    fun `svelger DuplicateKeyException dersom en annen tråd rekker å lagre samme task først`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
+        every { taskService.save(task) } throws DuplicateKeyException("task_payload_type_idx")
+
+        assertThatCode { skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `svelger DbActionExecutionException som skyldes DuplicateKeyException`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
+        every { taskService.save(task) } throws
+            DbActionExecutionException(mockk<DbAction<*>>(relaxed = true), DuplicateKeyException("task_payload_type_idx"))
+
+        assertThatCode { skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task) }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `kaster videre DbActionExecutionException som ikke skyldes DuplicateKeyException`() {
+        every { taskService.finnTaskMedPayloadOgType(task.payload, task.type) } returns null
+        val exception = DbActionExecutionException(mockk<DbAction<*>>(relaxed = true), RuntimeException("noe annet gikk galt"))
+        every { taskService.save(task) } throws exception
+
+        assertThatCode { skyggekjøringTaskLagrer.lagreHvisIkkeFinnesFraFør(task) }
+            .isInstanceOf(DbActionExecutionException::class.java)
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Forsøker å fikse transaksjonsfeilene som dukket opp ved aktivering av skyggekjøring i prod.
Det er gjort to tiltak:
 - Ikke lagre ned task dersom det finnes lik task (samme personident og infotrygd-operasjon i payload)
 - Bedre transaksjonshåndtering med låsing og at lagring av task lagres i egen transaksjon

Testet i preprod