### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -30,7 +30,7 @@ spec:
     limits:
       memory: 1024Mi
     requests:
-      memory: 512Mi
+      memory: 1024Mi
       cpu: 50m
   gcp:
     sqlInstances:

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -30,7 +30,7 @@ spec:
     limits:
       memory: 4096Mi
     requests:
-      memory: 1024Mi
+      memory: 4096Mi
       cpu: 100m
   gcp:
     sqlInstances:


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
