### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.deploy/preprod.yaml
+++ b/.deploy/preprod.yaml
@@ -31,7 +31,7 @@ spec:
       memory: 1024Mi
     requests:
       memory: 1024Mi
-      cpu: 50m
+      cpu: 300m
   gcp:
     sqlInstances:
       - name: familie-ef-sak-17

--- a/.deploy/prod.yaml
+++ b/.deploy/prod.yaml
@@ -28,10 +28,10 @@ spec:
     enabled: true
   resources:
     limits:
-      memory: 4096Mi
+      memory: 2048Mi
     requests:
-      memory: 4096Mi
-      cpu: 100m
+      memory: 2048Mi
+      cpu: 600m
   gcp:
     sqlInstances:
       - type: POSTGRES_14 # IF This is changed, all data will be lost. Read on nais.io how to upgrade


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.