### PR TITLE
Bytter til å bruke m2m for replika klient

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
@@ -107,13 +107,13 @@ class RestClientConfig(
     @Bean("infotrygdReplikaRestClient")
     fun infotrygdReplikaRestClient(
         @Value("\${INFOTRYGD_REPLIKA_SCOPE}") scope: String,
-    ): RestClient = hybrid(scope)
+    ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope).medTimeout()
 
     /** infotrygd-replika (GCP) (InfotrygdReplikaGcpClient) */
     @Bean("infotrygdReplikaGcpRestClient")
     fun infotrygdReplikaGcpRestClient(
         @Value("\${INFOTRYGD_REPLIKA_GCP_SCOPE}") scope: String,
-    ): RestClient = hybrid(scope)
+    ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope).medTimeout()
 
     /** familie-klage (KlageClient) */
     @Bean("klageRestClient")


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Får mange errors på manglende rolle fra infotrygd replika, bytter til å bruke m2m for replika klient