### PR TITLE
Se personopplysninger uten fullmakt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/henlegg/HenleggBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/henlegg/HenleggBehandlingController.kt
@@ -87,14 +87,14 @@ class HenleggBehandlingController(
         val harVerge = personopplysninger.vergemål.isNotEmpty()
         val harFullmakt: Boolean =
             personopplysninger.fullmakt
-                .filter {
+                ?.filter {
                     it.gyldigTilOgMed == null ||
                         (
                             it.gyldigTilOgMed.isEqualOrAfter(
                                 LocalDate.now(),
                             )
                         )
-                }.isNotEmpty()
+                }?.isNotEmpty() ?: true
         feilHvis(harVerge || harFullmakt) {
             "Skal ikke sende brev hvis person er tilknyttet vergemål eller fullmakt"
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -39,7 +39,7 @@ class GrunnlagsdataRegisterService(
     ): GrunnlagsdataDomene {
         val grunnlagsdataFraPdl = hentGrunnlagsdataFraPdl(personIdent, emptyList())
         feilHvis(grunnlagsdataFraPdl.søker.fullmakt == null, HttpStatus.FORBIDDEN) {
-            "Fullmakt er ukjent, mangler geografisk tilgang i tilgangsmaskinen. " +
+            "Fullmakt er ukjent (${grunnlagsdataFraPdl.fullmaktIkkeTilgangÅrsak ?: "ukjent årsak"}). " +
                 "Kan derfor ikke opprette/lagre grunnlagsdata for denne personen."
         }
         val medlUnntak = medlService.hentMedlemskapsunntak(personIdent)
@@ -79,6 +79,7 @@ class GrunnlagsdataRegisterService(
             søker = mapSøker(grunnlagsdataFraPdl.søker, grunnlagsdataFraPdl.andrePersoner),
             annenForelder = mapAnnenForelder(grunnlagsdataFraPdl.barneForeldre, emptyMap()),
             barn = mapBarn(grunnlagsdataFraPdl.barn),
+            fullmaktIkkeTilgangÅrsak = grunnlagsdataFraPdl.fullmaktIkkeTilgangÅrsak,
         )
     }
 
@@ -87,7 +88,8 @@ class GrunnlagsdataRegisterService(
         barneforeldreFraSøknad: List<String>,
     ): GrunnlagsdataFraPdl {
         val søker = personService.hentSøker(personIdent)
-        val søkerMedFullmakt = søker.copy(fullmakt = fullmaktService.hentFullmakt(personIdent))
+        val fullmaktResultat = fullmaktService.hentFullmakt(personIdent)
+        val søkerMedFullmakt = søker.copy(fullmakt = fullmaktResultat.fullmakter)
         val barn = hentPdlBarn(søkerMedFullmakt)
         val andreForeldre = hentPdlBarneForeldre(barn, personIdent, barneforeldreFraSøknad)
         val dataTilAndreIdenter = hentDataTilAndreIdenter(søkerMedFullmakt)
@@ -97,6 +99,7 @@ class GrunnlagsdataRegisterService(
             barn = barn,
             barneForeldre = andreForeldre,
             andrePersoner = dataTilAndreIdenter,
+            fullmaktIkkeTilgangÅrsak = fullmaktResultat.ikkeTilgangÅrsak,
         )
     }
 
@@ -144,6 +147,7 @@ data class GrunnlagsdataFraPdl(
     val barn: Map<String, PdlPersonForelderBarn>,
     val barneForeldre: Map<String, PdlAnnenForelder>,
     val andrePersoner: Map<String, PdlPersonKort>,
+    val fullmaktIkkeTilgangÅrsak: String? = null, // satt dersom søker.fullmakt er null pga. manglende tilgang i tilgangsmaskinen
 )
 
 fun GrunnlagsdataFraPdl.gjeldendeIdentForSøker() =

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/GrunnlagsdataRegisterService.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.arbeidsforhold.ekstern.ArbeidsforholdService
 import no.nav.familie.ef.sak.felles.util.Timer.loggTid
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.kontantstøtte.HentUtbetalingsinfoKontantstøtteDto
 import no.nav.familie.ef.sak.kontantstøtte.KontantstøtteService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.GrunnlagsdataDomene
@@ -20,6 +21,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonForeld
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlPersonKort
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.PdlSøker
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.gjeldende
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 
 @Service
@@ -36,6 +38,10 @@ class GrunnlagsdataRegisterService(
         barneforeldreFraSøknad: List<String>,
     ): GrunnlagsdataDomene {
         val grunnlagsdataFraPdl = hentGrunnlagsdataFraPdl(personIdent, emptyList())
+        feilHvis(grunnlagsdataFraPdl.søker.fullmakt == null, HttpStatus.FORBIDDEN) {
+            "Fullmakt er ukjent, mangler geografisk tilgang i tilgangsmaskinen. " +
+                "Kan derfor ikke opprette/lagre grunnlagsdata for denne personen."
+        }
         val medlUnntak = medlService.hentMedlemskapsunntak(personIdent)
         val tidligereVedtaksperioder =
             tidligereVedtaksperioderService.hentTidligereVedtaksperioder(grunnlagsdataFraPdl.søker.folkeregisteridentifikator)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerController.kt
@@ -1,14 +1,17 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
 import no.nav.familie.ef.sak.fagsak.FagsakPersonService
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
+import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.endringer.EndringerIPersonOpplysningerService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.endringer.EndringerIPersonopplysningerDto
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.navkontor.NavKontorEnhet
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
@@ -50,7 +53,28 @@ class PersonopplysningerController(
     ): Ressurs<PersonopplysningerDto> {
         tilgangService.validerTilgangTilFagsakPerson(fagsakPersonId, AuditLoggerEvent.ACCESS)
         val aktivIdent = fagsakPersonService.hentAktivIdent(fagsakPersonId)
-        return Ressurs.success(personopplysningerService.hentPersonopplysningerFraRegister(aktivIdent))
+        val personopplysninger = personopplysningerService.hentPersonopplysningerFraRegister(aktivIdent)
+        validerFullmaktIkkeUkjentForSaksbehandler(personopplysninger)
+        return Ressurs.success(personopplysninger)
+    }
+
+    /**
+     * Om fullmakt er ukjent (`null`) avgjøres alltid av svaret fra tilgangsmaskinen (se [FullmaktClient]) - ikke av
+     * hvilken rolle innlogget bruker har. Rollen avgjør kun hvordan dette skal presenteres videre:
+     * - Veileder (bl.a. utviklere i produksjon, men også andre som kun har denne rollen) får se personopplysninger
+     *   med fullmakt markert som ukjent i grensesnittet.
+     * - En reell saksbehandler/beslutter får i stedet en tydelig feilmelding om at fullmaktsdata mangler,
+     *   med et hint om årsaken fra tilgangsmaskinen der det er tilgjengelig.
+     */
+    private fun validerFullmaktIkkeUkjentForSaksbehandler(personopplysninger: PersonopplysningerDto) {
+        feilHvis(
+            personopplysninger.fullmakt == null && tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER),
+            HttpStatus.FORBIDDEN,
+        ) {
+            "Du har ikke tilgang til fullmaktsdata for denne personen" +
+                (personopplysninger.fullmaktIkkeTilgangÅrsak?.let { " ($it)" } ?: "") +
+                "."
+        }
     }
 
     @PostMapping("/nav-kontor")

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -87,6 +87,7 @@ data class Personopplysninger(
     val søker: Søker,
     val annenForelder: List<AnnenForelderMedIdent>,
     val barn: List<BarnMedIdent>,
+    val fullmaktIkkeTilgangÅrsak: String? = null, // kun relevant ved visning, ikke persistert - se Søker.fullmakt
 )
 
 data class Søker(

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/domene/GrunnlagsdataDomene.kt
@@ -96,7 +96,7 @@ data class Søker(
     val forelderBarnRelasjon: List<ForelderBarnRelasjon>,
     val fødsel: List<Fødsel>, // Er en liste i PDLSøker
     val folkeregisterpersonstatus: List<Folkeregisterpersonstatus>,
-    val fullmakt: List<FullmaktMedNavn>,
+    val fullmakt: List<FullmaktMedNavn>?, // null = ukjent, f.eks. pga. manglende geografisk tilgang i tilgangsmaskinen
     val kjønn: KjønnType,
     val kontaktadresse: List<Kontaktadresse>,
     val navn: Navn,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -22,7 +22,8 @@ data class PersonopplysningerDto(
     val statsborgerskap: List<StatsborgerskapDto>,
     val sivilstand: List<SivilstandDto>,
     val adresse: List<AdresseDto>,
-    val fullmakt: List<FullmaktDto>?, // null = ukjent, f.eks. pga. manglende geografisk tilgang i tilgangsmaskinen
+    val fullmakt: List<FullmaktDto>?, // null = ukjent, f.eks. pga. manglende tilgang i tilgangsmaskinen
+    val fullmaktIkkeTilgangÅrsak: String? = null, // satt dersom fullmakt er null - beskriver hvorfor tilgangen mangler
     val egenAnsatt: Boolean,
     val barn: List<BarnDto>,
     val innflyttingTilNorge: List<InnflyttingDto>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/dto/PersonopplysningerDto.kt
@@ -22,7 +22,7 @@ data class PersonopplysningerDto(
     val statsborgerskap: List<StatsborgerskapDto>,
     val sivilstand: List<SivilstandDto>,
     val adresse: List<AdresseDto>,
-    val fullmakt: List<FullmaktDto>,
+    val fullmakt: List<FullmaktDto>?, // null = ukjent, f.eks. pga. manglende geografisk tilgang i tilgangsmaskinen
     val egenAnsatt: Boolean,
     val barn: List<BarnDto>,
     val innflyttingTilNorge: List<InnflyttingDto>,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -1,12 +1,17 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import java.net.URI
 import java.time.LocalDate
+
+// Feilkode fra tilgangsmaskinen når saksbehandler er geografisk avvist tilgang til å slå opp fullmakt
+private const val SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK = "SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK"
 
 @Service
 class FullmaktClient(
@@ -15,14 +20,29 @@ class FullmaktClient(
     @Qualifier("reprApiRestClient")
     private val restClient: RestClient,
 ) {
-    fun hentFullmakt(ident: String): List<FullmaktResponse> {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * @return liste med fullmakter, eller `null` dersom vi ikke fikk hentet fullmakt fordi saksbehandler
+     * mangler geografisk tilgang i tilgangsmaskinen. `null` skal tolkes som "ukjent" og ikke "ingen fullmakt".
+     */
+    fun hentFullmakt(ident: String): List<FullmaktResponse>? {
         val url = URI.create("$fullmaktUrl/api/internbruker/fullmakt/fullmaktsgiver")
-        return restClient
-            .post()
-            .uri(url)
-            .body(FullmaktRequest(ident))
-            .retrieve()
-            .body<List<FullmaktResponse>>()!!
+        return try {
+            restClient
+                .post()
+                .uri(url)
+                .body(FullmaktRequest(ident))
+                .retrieve()
+                .body<List<FullmaktResponse>>()!!
+        } catch (e: HttpClientErrorException.Forbidden) {
+            if (e.responseBodyAsString.contains(SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK)) {
+                logger.warn("Saksbehandler mangler geografisk tilgang i tilgangsmaskinen til å hente fullmakt. Viser fullmakt som ukjent.")
+                null
+            } else {
+                throw e
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClient.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt
 
+import no.nav.familie.kontrakter.felles.jsonMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -23,28 +24,55 @@ class FullmaktClient(
     private val logger = LoggerFactory.getLogger(javaClass)
 
     /**
-     * @return liste med fullmakter, eller `null` dersom vi ikke fikk hentet fullmakt fordi saksbehandler
-     * mangler geografisk tilgang i tilgangsmaskinen. `null` skal tolkes som "ukjent" og ikke "ingen fullmakt".
+     * Fullmakt kan ikke hentes ut dersom innlogget bruker mangler tilgang i tilgangsmaskinen (403 Forbidden).
+     * Vi vet ikke på forhånd om, eller hvorfor, dette skjer - det er svaret fra tilgangsmaskinen som avgjør dette.
+     * Kallet gir derfor aldri feil videre til kalleren ved 403, men returnerer i stedet [FullmaktOppslagResultat]
+     * med `fullmakter = null` og en beskrivelse av årsaken, slik at kalleren selv kan avgjøre hvordan dette skal
+     * håndteres/vises videre (se [FullmaktService.hentFullmakt]).
      */
-    fun hentFullmakt(ident: String): List<FullmaktResponse>? {
+    fun hentFullmakt(ident: String): FullmaktOppslagResultat {
         val url = URI.create("$fullmaktUrl/api/internbruker/fullmakt/fullmaktsgiver")
         return try {
-            restClient
-                .post()
-                .uri(url)
-                .body(FullmaktRequest(ident))
-                .retrieve()
-                .body<List<FullmaktResponse>>()!!
+            val fullmakter =
+                restClient
+                    .post()
+                    .uri(url)
+                    .body(FullmaktRequest(ident))
+                    .retrieve()
+                    .body<List<FullmaktResponse>>()!!
+            FullmaktOppslagResultat(fullmakter = fullmakter)
         } catch (e: HttpClientErrorException.Forbidden) {
-            if (e.responseBodyAsString.contains(SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK)) {
-                logger.warn("Saksbehandler mangler geografisk tilgang i tilgangsmaskinen til å hente fullmakt. Viser fullmakt som ukjent.")
-                null
-            } else {
-                throw e
-            }
+            val årsak = utledÅrsak(e)
+            logger.warn("Mangler tilgang til å hente fullmakt i tilgangsmaskinen. Årsak: $årsak. Viser fullmakt som ukjent.")
+            FullmaktOppslagResultat(fullmakter = null, ikkeTilgangÅrsak = årsak)
         }
     }
+
+    private fun utledÅrsak(e: HttpClientErrorException.Forbidden): String {
+        val errorCode = hentErrorCode(e.responseBodyAsString)
+        return when (errorCode) {
+            SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK -> "mangler geografisk tilgang i tilgangsmaskinen"
+            null -> e.responseBodyAsString.ifBlank { e.message ?: "ukjent årsak" }
+            else -> "tilgangsmaskinen avviste kallet med feilkode $errorCode"
+        }
+    }
+
+    private fun hentErrorCode(responseBody: String): String? =
+        try {
+            jsonMapper
+                .readTree(responseBody)
+                .path("errorCode")
+                .asText()
+                .takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            null
+        }
 }
+
+data class FullmaktOppslagResultat(
+    val fullmakter: List<FullmaktResponse>?,
+    val ikkeTilgangÅrsak: String? = null,
+)
 
 data class FullmaktRequest(
     val ident: String,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktService.kt
@@ -9,8 +9,12 @@ import org.springframework.stereotype.Service
 class FullmaktService(
     val fullmaktClient: FullmaktClient,
 ) {
-    fun hentFullmakt(ident: String): List<Fullmakt> {
-        val fullmaktResponse = fullmaktClient.hentFullmakt(ident)
+    /**
+     * @return `null` dersom fullmakt er ukjent, f.eks. fordi saksbehandler mangler geografisk tilgang
+     * i tilgangsmaskinen. Dette skal ikke tolkes som at personen ikke har noen fullmakter.
+     */
+    fun hentFullmakt(ident: String): List<Fullmakt>? {
+        val fullmaktResponse = fullmaktClient.hentFullmakt(ident) ?: return null
         return fullmaktResponse.map {
             Fullmakt(
                 it.gyldigFraOgMed,

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktService.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktService.kt
@@ -2,7 +2,6 @@ package no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt
 
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Fullmakt
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.MotpartsRolle
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,19 +9,28 @@ class FullmaktService(
     val fullmaktClient: FullmaktClient,
 ) {
     /**
-     * @return `null` dersom fullmakt er ukjent, f.eks. fordi saksbehandler mangler geografisk tilgang
-     * i tilgangsmaskinen. Dette skal ikke tolkes som at personen ikke har noen fullmakter.
+     * @return [FullmaktResultat] med `fullmakter = null` dersom fullmakt er ukjent, f.eks. fordi innlogget bruker
+     * mangler tilgang i tilgangsmaskinen. Dette skal ikke tolkes som at personen ikke har noen fullmakter.
+     * `ikkeTilgangÅrsak` beskriver hvorfor fullmakt ikke kunne hentes, og kan brukes til å gi en mer presis
+     * feilmelding videre i kjeden.
      */
-    fun hentFullmakt(ident: String): List<Fullmakt>? {
-        val fullmaktResponse = fullmaktClient.hentFullmakt(ident) ?: return null
-        return fullmaktResponse.map {
-            Fullmakt(
-                it.gyldigFraOgMed,
-                it.gyldigTilOgMed,
-                it.fullmektig,
-                MotpartsRolle.FULLMEKTIG,
-                it.omraade.map { it.tema },
-            )
-        }
+    fun hentFullmakt(ident: String): FullmaktResultat {
+        val resultat = fullmaktClient.hentFullmakt(ident)
+        val fullmakter =
+            resultat.fullmakter?.map {
+                Fullmakt(
+                    it.gyldigFraOgMed,
+                    it.gyldigTilOgMed,
+                    it.fullmektig,
+                    MotpartsRolle.FULLMEKTIG,
+                    it.omraade.map { it.tema },
+                )
+            }
+        return FullmaktResultat(fullmakter, resultat.ikkeTilgangÅrsak)
     }
 }
+
+data class FullmaktResultat(
+    val fullmakter: List<Fullmakt>?,
+    val ikkeTilgangÅrsak: String? = null,
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/GrunnlagsdataMapper.kt
@@ -136,10 +136,11 @@ object GrunnlagsdataMapper {
             )
         }
 
+    // Returnerer `null` dersom fullmakt er ukjent (f.eks. pga. manglende geografisk tilgang), ikke ved ingen fullmakter
     private fun mapFullmakt(
         pdlSøker: PdlSøker,
         andrePersoner: Map<String, PdlPersonKort>,
-    ): List<FullmaktMedNavn> =
+    ): List<FullmaktMedNavn>? =
         pdlSøker.fullmakt?.map {
             FullmaktMedNavn(
                 gyldigFraOgMed = it.gyldigFraOgMed,
@@ -148,5 +149,5 @@ object GrunnlagsdataMapper {
                 navn = andrePersoner[it.motpartsPersonident]?.navn?.gjeldende()?.visningsnavn(),
                 områder = it.omraader,
             )
-        } ?: emptyList()
+        }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -73,7 +73,7 @@ class PersonopplysningerMapper(
             adresse = tilAdresser(søker),
             fullmakt =
                 søker.fullmakt
-                    .map {
+                    ?.map {
                         FullmaktDto(
                             gyldigFraOgMed = it.gyldigFraOgMed,
                             gyldigTilOgMed = it.gyldigTilOgMed,
@@ -81,7 +81,7 @@ class PersonopplysningerMapper(
                             navn = it.navn,
                             områder = it.områder?.let { it.map { område -> mapOmråde(område) } } ?: emptyList(),
                         )
-                    }.sortedByDescending { it.gyldigFraOgMed },
+                    }?.sortedByDescending { it.gyldigFraOgMed },
             egenAnsatt = egenAnsatt,
             barn =
                 personopplysninger.barn

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/mapper/PersonopplysningerMapper.kt
@@ -82,6 +82,7 @@ class PersonopplysningerMapper(
                             områder = it.områder?.let { it.map { område -> mapOmråde(område) } } ?: emptyList(),
                         )
                     }?.sortedByDescending { it.gyldigFraOgMed },
+            fullmaktIkkeTilgangÅrsak = personopplysninger.fullmaktIkkeTilgangÅrsak,
             egenAnsatt = egenAnsatt,
             barn =
                 personopplysninger.barn

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FullmaktClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/FullmaktClientMock.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktOppslagResultat
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktResponse
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.Handling
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.Område
@@ -20,13 +21,15 @@ class FullmaktClientMock {
     fun fullmaktClient(): FullmaktClient {
         val fullmaktClient: FullmaktClient = mockk()
         every { fullmaktClient.hentFullmakt(any()) } returns
-            listOf(
-                FullmaktResponse(
-                    LocalDate.now().minusYears(1),
-                    LocalDate.now().plusYears(1),
-                    "01010199999",
-                    "Navn",
-                    listOf(Område("ENF", listOf(Handling.LES))),
+            FullmaktOppslagResultat(
+                listOf(
+                    FullmaktResponse(
+                        LocalDate.now().minusYears(1),
+                        LocalDate.now().plusYears(1),
+                        "01010199999",
+                        "Navn",
+                        listOf(Område("ENF", listOf(Handling.LES))),
+                    ),
                 ),
             )
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/PersonopplysningerControllerTest.kt
@@ -1,0 +1,97 @@
+package no.nav.familie.ef.sak.opplysninger.personopplysninger
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.ef.sak.behandlingsflyt.steg.BehandlerRolle
+import no.nav.familie.ef.sak.fagsak.FagsakPersonService
+import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.Kjønn
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.NavnDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.PersonopplysningerDto
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.endringer.EndringerIPersonOpplysningerService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+internal class PersonopplysningerControllerTest {
+    private val personopplysningerService = mockk<PersonopplysningerService>()
+    private val tilgangService = mockk<TilgangService>(relaxed = true)
+    private val fagsakPersonService = mockk<FagsakPersonService>()
+
+    private val personopplysningerController =
+        PersonopplysningerController(
+            personopplysningerService = personopplysningerService,
+            endringerIPersonOpplysningerService = mockk<EndringerIPersonOpplysningerService>(relaxed = true),
+            tilgangService = tilgangService,
+            fagsakPersonService = fagsakPersonService,
+        )
+
+    private val fagsakPersonId = UUID.randomUUID()
+
+    @BeforeEach
+    internal fun setUp() {
+        every { fagsakPersonService.hentAktivIdent(fagsakPersonId) } returns "12345678910"
+    }
+
+    @Test
+    internal fun `skal returnere personopplysninger med fullmakt ukjent hvis bruker kun har veilederrolle`() {
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any()) } returns dto(fullmakt = null)
+        every { tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER) } returns false
+
+        val respons = personopplysningerController.personopplysningerFraFagsakPersonId(fagsakPersonId)
+
+        assertThat(respons.data?.fullmakt).isNull()
+    }
+
+    @Test
+    internal fun `skal kaste tydelig feil hvis fullmakt er ukjent og bruker har reell saksbehandler- eller beslutterrolle`() {
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any()) } returns
+            dto(fullmakt = null, fullmaktIkkeTilgangÅrsak = "mangler geografisk tilgang i tilgangsmaskinen")
+        every { tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER) } returns true
+
+        val feil =
+            assertThrows<Feil> {
+                personopplysningerController.personopplysningerFraFagsakPersonId(fagsakPersonId)
+            }
+        assertThat(feil.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(feil.frontendFeilmelding).contains("mangler geografisk tilgang i tilgangsmaskinen")
+    }
+
+    @Test
+    internal fun `skal ikke kaste feil hvis fullmakt er kjent selv om bruker har saksbehandlerrolle`() {
+        every { personopplysningerService.hentPersonopplysningerFraRegister(any()) } returns dto(fullmakt = emptyList())
+        every { tilgangService.harTilgangTilRolle(BehandlerRolle.SAKSBEHANDLER) } returns true
+
+        val respons = personopplysningerController.personopplysningerFraFagsakPersonId(fagsakPersonId)
+
+        assertThat(respons.data?.fullmakt).isEmpty()
+    }
+
+    private fun dto(
+        fullmakt: List<no.nav.familie.ef.sak.opplysninger.personopplysninger.dto.FullmaktDto>?,
+        fullmaktIkkeTilgangÅrsak: String? = null,
+    ) = PersonopplysningerDto(
+        personIdent = "12345678910",
+        navn = NavnDto("", "", "", ""),
+        kjønn = Kjønn.MANN,
+        adressebeskyttelse = null,
+        folkeregisterpersonstatus = null,
+        fødselsdato = null,
+        dødsdato = null,
+        statsborgerskap = emptyList(),
+        sivilstand = emptyList(),
+        adresse = emptyList(),
+        fullmakt = fullmakt,
+        fullmaktIkkeTilgangÅrsak = fullmaktIkkeTilgangÅrsak,
+        egenAnsatt = false,
+        barn = emptyList(),
+        innflyttingTilNorge = emptyList(),
+        utflyttingFraNorge = emptyList(),
+        oppholdstillatelse = emptyList(),
+        vergemål = emptyList(),
+    )
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
@@ -10,11 +10,9 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import java.time.LocalDate
 
@@ -55,9 +53,9 @@ class FullmaktClientTest {
             ),
         )
 
-        val response = fullmaktClient.hentFullmakt("12345678911111")
-        assertThat(response).isNotNull
-        val fullmakter = response!!
+        val resultat = fullmaktClient.hentFullmakt("12345678911111")
+        assertThat(resultat.fullmakter).isNotNull
+        val fullmakter = resultat.fullmakter!!
         assertThat(fullmakter.size).isEqualTo(1)
         assertThat(fullmakter.first().fullmektigsNavn).isEqualTo("fullmektigsNavn")
         assertThat(fullmakter.first().fullmektig).isEqualTo("fullmektigIdent")
@@ -74,7 +72,7 @@ class FullmaktClientTest {
     }
 
     @Test
-    fun `hent fullmakt returnerer null når saksbehandler er geografisk avvist av tilgangsmaskinen`() {
+    fun `hent fullmakt returnerer null med årsak når saksbehandler er geografisk avvist av tilgangsmaskinen`() {
         WireMock.stubFor(
             queryMappingForHentFullmakt.willReturn(
                 WireMock
@@ -87,12 +85,13 @@ class FullmaktClientTest {
             ),
         )
 
-        val response = fullmaktClient.hentFullmakt("12345678911111")
-        assertThat(response).isNull()
+        val resultat = fullmaktClient.hentFullmakt("12345678911111")
+        assertThat(resultat.fullmakter).isNull()
+        assertThat(resultat.ikkeTilgangÅrsak).isEqualTo("mangler geografisk tilgang i tilgangsmaskinen")
     }
 
     @Test
-    fun `hent fullmakt kaster videre ved andre 403-feil`() {
+    fun `hent fullmakt returnerer null med generisk årsak ved andre 403-feil`() {
         WireMock.stubFor(
             queryMappingForHentFullmakt.willReturn(
                 WireMock
@@ -103,7 +102,9 @@ class FullmaktClientTest {
             ),
         )
 
-        assertThrows<HttpClientErrorException.Forbidden> { fullmaktClient.hentFullmakt("12345678911111") }
+        val resultat = fullmaktClient.hentFullmakt("12345678911111")
+        assertThat(resultat.fullmakter).isNull()
+        assertThat(resultat.ikkeTilgangÅrsak).isEqualTo("tilgangsmaskinen avviste kallet med feilkode EN_ANNEN_FEILKODE")
     }
 
     private val queryMappingForHentFullmakt: MappingBuilder = WireMock.post(WireMock.urlPathEqualTo("/api/internbruker/fullmakt/fullmaktsgiver"))

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/fullmakt/FullmaktClientTest.kt
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import java.time.LocalDate
 
@@ -55,19 +57,53 @@ class FullmaktClientTest {
 
         val response = fullmaktClient.hentFullmakt("12345678911111")
         assertThat(response).isNotNull
-        assertThat(response.size).isEqualTo(1)
-        assertThat(response.first().fullmektigsNavn).isEqualTo("fullmektigsNavn")
-        assertThat(response.first().fullmektig).isEqualTo("fullmektigIdent")
-        assertThat(response.first().gyldigFraOgMed).isEqualTo(LocalDate.of(2024, 7, 8))
-        assertThat(response.first().gyldigTilOgMed).isEqualTo(LocalDate.of(2024, 7, 9))
-        assertThat(response.first().omraade.size).isEqualTo(1)
+        val fullmakter = response!!
+        assertThat(fullmakter.size).isEqualTo(1)
+        assertThat(fullmakter.first().fullmektigsNavn).isEqualTo("fullmektigsNavn")
+        assertThat(fullmakter.first().fullmektig).isEqualTo("fullmektigIdent")
+        assertThat(fullmakter.first().gyldigFraOgMed).isEqualTo(LocalDate.of(2024, 7, 8))
+        assertThat(fullmakter.first().gyldigTilOgMed).isEqualTo(LocalDate.of(2024, 7, 9))
+        assertThat(fullmakter.first().omraade.size).isEqualTo(1)
         assertThat(
-            response
+            fullmakter
                 .first()
                 .omraade
                 .first()
                 .tema,
         ).isEqualTo("ENF")
+    }
+
+    @Test
+    fun `hent fullmakt returnerer null når saksbehandler er geografisk avvist av tilgangsmaskinen`() {
+        WireMock.stubFor(
+            queryMappingForHentFullmakt.willReturn(
+                WireMock
+                    .aResponse()
+                    .withStatus(HttpStatus.FORBIDDEN.value())
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .withBody(
+                        """{"errorCode":"SAKSBEHANDLER_AVVIST_TILGANGSMASKINEN_GEOGRAFISK"}""",
+                    ),
+            ),
+        )
+
+        val response = fullmaktClient.hentFullmakt("12345678911111")
+        assertThat(response).isNull()
+    }
+
+    @Test
+    fun `hent fullmakt kaster videre ved andre 403-feil`() {
+        WireMock.stubFor(
+            queryMappingForHentFullmakt.willReturn(
+                WireMock
+                    .aResponse()
+                    .withStatus(HttpStatus.FORBIDDEN.value())
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .withBody("""{"errorCode":"EN_ANNEN_FEILKODE"}"""),
+            ),
+        )
+
+        assertThrows<HttpClientErrorException.Forbidden> { fullmaktClient.hentFullmakt("12345678911111") }
     }
 
     private val queryMappingForHentFullmakt: MappingBuilder = WireMock.post(WireMock.urlPathEqualTo("/api/internbruker/fullmakt/fullmaktsgiver"))

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingType
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig
 import no.nav.familie.ef.sak.infrastruktur.config.PdlClientConfig.Companion.ANNEN_FORELDER_FNR
+import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.kontantstøtte.KontantstøtteService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
@@ -37,8 +38,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
 import java.time.LocalDate
 
 internal class GrunnlagsdataServiceTest {
@@ -123,6 +126,15 @@ internal class GrunnlagsdataServiceTest {
         assertThat(catchThrowable { service.hentGrunnlagsdata(behandlingId) })
 
         verify(exactly = 0) { personService.hentSøker(any()) }
+    }
+
+    @Test
+    internal fun `skal kaste feil hvis fullmakt er ukjent - grunnlagsdata skal ikke kunne opprettes uten avklart fullmakt`() {
+        every { personService.hentSøker(any()) } returns PdlClientConfig.opprettPdlSøker()
+        every { fullmaktService.hentFullmakt(any()) } returns null
+
+        val feil = assertThrows<Feil> { service.hentFraRegisterForPersonOgAndreForeldre("1", emptyList()) }
+        assertThat(feil.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/GrunnlagsdataServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerI
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereInnvilgetVedtak
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.domene.TidligereVedtaksperioder
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktResultat
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.medl.MedlService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.pdl.Fullmakt
@@ -100,13 +101,15 @@ internal class GrunnlagsdataServiceTest {
     internal fun setUp() {
         every { søknadService.hentOvergangsstønad(any()) } returns søknad
         every { fullmaktService.hentFullmakt(any()) } returns
-            listOf(
-                Fullmakt(
-                    LocalDate.of(2020, 1, 1),
-                    LocalDate.of(2021, 1, 1),
-                    "11111133333",
-                    MotpartsRolle.FULLMEKTIG,
-                    listOf(),
+            FullmaktResultat(
+                listOf(
+                    Fullmakt(
+                        LocalDate.of(2020, 1, 1),
+                        LocalDate.of(2021, 1, 1),
+                        "11111133333",
+                        MotpartsRolle.FULLMEKTIG,
+                        listOf(),
+                    ),
                 ),
             )
     }
@@ -131,10 +134,11 @@ internal class GrunnlagsdataServiceTest {
     @Test
     internal fun `skal kaste feil hvis fullmakt er ukjent - grunnlagsdata skal ikke kunne opprettes uten avklart fullmakt`() {
         every { personService.hentSøker(any()) } returns PdlClientConfig.opprettPdlSøker()
-        every { fullmaktService.hentFullmakt(any()) } returns null
+        every { fullmaktService.hentFullmakt(any()) } returns FullmaktResultat(fullmakter = null, ikkeTilgangÅrsak = "mangler geografisk tilgang i tilgangsmaskinen")
 
         val feil = assertThrows<Feil> { service.hentFraRegisterForPersonOgAndreForeldre("1", emptyList()) }
         assertThat(feil.httpStatus).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(feil.frontendFeilmelding).contains("mangler geografisk tilgang i tilgangsmaskinen")
     }
 
     @Test
@@ -164,7 +168,7 @@ internal class GrunnlagsdataServiceTest {
                     fullmakt = emptyList(),
                     vergemaalEllerFremtidsfullmakt = emptyList(),
                 )
-        every { fullmaktService.hentFullmakt(any()) } returns listOf()
+        every { fullmaktService.hentFullmakt(any()) } returns FullmaktResultat(fullmakter = emptyList())
         service.hentFraRegisterForPersonOgAndreForeldre("1", emptyList())
 
         verify(exactly = 0) { pdlClient.hentPersonKortBolk(any()) }

--- a/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/service/PersonopplysningerServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerI
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.TidligereVedtaksperioderService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.egenansatt.EgenAnsattClient
+import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktResultat
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.fullmakt.FullmaktService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.AdresseMapper
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.mapper.InnflyttingUtflyttingMapper
@@ -65,7 +66,7 @@ internal class PersonopplysningerServiceTest {
                 finnesUtbetaling = false,
                 emptyList(),
             )
-        every { fullmaktService.hentFullmakt(any()) } returns listOf(Fullmakt(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1), "11111133333", MotpartsRolle.FULLMEKTIG, listOf()))
+        every { fullmaktService.hentFullmakt(any()) } returns FullmaktResultat(listOf(Fullmakt(LocalDate.of(2020, 1, 1), LocalDate.of(2021, 1, 1), "11111133333", MotpartsRolle.FULLMEKTIG, listOf())))
         val grunnlagsdataRegisterService =
             GrunnlagsdataRegisterService(
                 personService,

--- a/src/test/resources/json/grunnlagsdata_v2.json
+++ b/src/test/resources/json/grunnlagsdata_v2.json
@@ -350,7 +350,7 @@
             "nullable" : true
           }
         },
-        "nullable" : false
+        "nullable" : true
       },
       "kjønn" : {
         "name" : "kjønn",

--- a/src/test/resources/json/personopplysningerDto.json
+++ b/src/test/resources/json/personopplysningerDto.json
@@ -50,6 +50,7 @@
     "navn" : "11111133333 mellomnavn Etternavn",
     "områder" : [ ]
   } ],
+  "fullmaktIkkeTilgangÅrsak" : null,
   "egenAnsatt" : true,
   "barn" : [ {
     "personIdent" : "01012067050",


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved visning av personopplysninger vises det nå feilmeldingen fra fullmakt dersom bruker ikke har tilgang.
Dersom bruker bare har rolle veileder vises fullmakt bare som "ukjent", se vedlagt bilde.
For saksbehandlere/besluttere skal funksjonaliteten være det samme før, bare at feilmeldingen skal vises for dem dersom de ikke har tilgang til fullmakt.

<img width="1081" height="1141" alt="Screenshot 2026-08-05 at 14 49 56" src="https://github.com/user-attachments/assets/0533a2f8-1ce1-4b10-8d53-6acccc960633" />

Tilhørende PR i frontend: https://github.com/navikt/familie-ef-sak-frontend/pull/3476
