### PR TITLE
Fjerner whitespace før likhetssjekk i skyggekjøring

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjørInfotrygdTask.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infotrygd/skygge/SkyggekjørInfotrygdTask.kt
@@ -10,6 +10,7 @@ import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdFinnesResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriode
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeRequest
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdPeriodeResponse
+import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSak
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSakResponse
 import no.nav.familie.kontrakter.ef.infotrygd.InfotrygdSøkRequest
 import no.nav.familie.kontrakter.felles.jsonMapper
@@ -45,7 +46,7 @@ class SkyggekjørInfotrygdTask(
                     request = request,
                     forventetRespons = forventetRespons,
                     faktiskRespons = { infotrygdReplikaGcpClient.hentPerioder(jsonMapper.readValue<InfotrygdPeriodeRequest>(request)) },
-                    normaliser = InfotrygdPeriodeResponse::normalisert,
+                    normaliser = InfotrygdPeriodeResponse::trim,
                 )
             }
 
@@ -57,7 +58,7 @@ class SkyggekjørInfotrygdTask(
                     faktiskRespons = {
                         infotrygdReplikaGcpClient.hentSammenslåttePerioder(jsonMapper.readValue<InfotrygdPeriodeRequest>(request))
                     },
-                    normaliser = InfotrygdPeriodeResponse::normalisert,
+                    normaliser = InfotrygdPeriodeResponse::trim,
                 )
             }
 
@@ -67,7 +68,7 @@ class SkyggekjørInfotrygdTask(
                     request = request,
                     forventetRespons = forventetRespons,
                     faktiskRespons = { infotrygdReplikaGcpClient.hentSaker(jsonMapper.readValue<InfotrygdSøkRequest>(request)) },
-                    normaliser = InfotrygdSakResponse::normalisert,
+                    normaliser = InfotrygdSakResponse::trim,
                 )
             }
 
@@ -79,7 +80,7 @@ class SkyggekjørInfotrygdTask(
                     faktiskRespons = {
                         infotrygdReplikaGcpClient.hentInfotrygdFinnes(jsonMapper.readValue<InfotrygdSøkRequest>(request))
                     },
-                    normaliser = InfotrygdFinnesResponse::normalisert,
+                    normaliser = InfotrygdFinnesResponse::trim,
                 )
             }
         }
@@ -158,7 +159,7 @@ enum class SkyggeInfotrygdOperasjon {
     HENT_INNSLAG_HOS_INFOTRYGD,
 }
 
-private fun InfotrygdPeriodeResponse.normalisert(): InfotrygdPeriodeResponse =
+private fun InfotrygdPeriodeResponse.trim(): InfotrygdPeriodeResponse =
     copy(
         overgangsstønad = overgangsstønad.normalisertePerioder(),
         barnetilsyn = barnetilsyn.normalisertePerioder(),
@@ -167,9 +168,26 @@ private fun InfotrygdPeriodeResponse.normalisert(): InfotrygdPeriodeResponse =
 
 private fun List<InfotrygdPeriode>.normalisertePerioder(): List<InfotrygdPeriode> = map { it.copy(barnIdenter = it.barnIdenter.sorted()) }.sortedBy { it.toString() }
 
-private fun InfotrygdSakResponse.normalisert(): InfotrygdSakResponse = copy(saker = saker.sortedBy { it.toString() })
+private fun InfotrygdSakResponse.trim(): InfotrygdSakResponse = copy(saker = saker.map { it.trim() }.sortedBy { it.toString() })
 
-private fun InfotrygdFinnesResponse.normalisert(): InfotrygdFinnesResponse =
+/**
+ * Enkelte String-felter fra Infotrygd er fastbredde CHAR-kolonner i DB2. On-prem og GCP-replikaen kan derfor
+ * returnere disse med ulik whitespace-padding selv om verdien reelt sett er lik (eller tom). Trimmes bort her
+ * for at slike rene formateringsforskjeller ikke skal trigge falske avvik i skyggekjøringen.
+ */
+private fun InfotrygdSak.trim(): InfotrygdSak =
+    copy(
+        saksnr = saksnr?.trim(),
+        saksblokk = saksblokk?.trim(),
+        kapittelnr = kapittelnr?.trim(),
+        årsakskode = årsakskode?.trim(),
+        behandlendeEnhet = behandlendeEnhet?.trim(),
+        registrertAvEnhet = registrertAvEnhet?.trim(),
+        tkNr = tkNr?.trim(),
+        region = region?.trim(),
+    )
+
+private fun InfotrygdFinnesResponse.trim(): InfotrygdFinnesResponse =
     copy(
         vedtak = vedtak.sortedBy { it.toString() },
         saker = saker.sortedBy { it.toString() },


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skyggekjøring trenger ikke slå ut på whitespaces