### PR TITLE
Bruke preauth alle controllere

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/BehandlingController.kt
@@ -128,7 +128,6 @@ class BehandlingController(
         @RequestBody dto: OppdaterErRegelendring2026Dto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         behandlingService.oppdaterErRegelendring2026(behandlingId, dto.erRegelendring2026)
 
@@ -151,13 +150,13 @@ class BehandlingController(
         )
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("{behandlingId}/regelendring-2026/begrunnelse")
     fun lagreRegelendring2026(
         @PathVariable behandlingId: UUID,
         @RequestBody dto: OppdaterRegelendring2026BegrunnelseDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         feilHvis(dto.begrunnelse.isBlank()) { "Begrunnelse kan ikke være tom" }
         regelendring2026Service.oppdaterBegrunnelse(behandlingId, dto.begrunnelse)
         return Ressurs.success(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/FørstegangsbehandlingController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.behandling
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.behandling.dto.FørstegangsbehandlingDto
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.web.bind.annotation.PathVariable
@@ -17,13 +18,13 @@ class FørstegangsbehandlingController(
     private val førstegangsbehandlingService: FørstegangsbehandlingService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("{fagsakId}/opprett")
     fun opprettFørstegangsbehandlingManuelt(
         @PathVariable fagsakId: UUID,
         @RequestBody førstegangsBehandlingRequest: FørstegangsbehandlingDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val behandling = førstegangsbehandlingService.opprettFørstegangsbehandling(fagsakId, førstegangsBehandlingRequest)
         return Ressurs.success(behandling.id)

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/henlegg/HenleggBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/henlegg/HenleggBehandlingController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.felles.util.isEqualOrAfter
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
@@ -46,13 +47,13 @@ class HenleggBehandlingController(
         return Ressurs.success(henleggService.genererHenleggelsesbrev(behandlingId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("{behandlingId}/henlegg")
     fun henleggBehandling(
         @PathVariable behandlingId: UUID,
         @RequestBody henlagt: HenlagtDto,
     ): Ressurs<BehandlingDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         val henlagtBehandling = henleggService.henleggBehandling(behandlingId, henlagt)
         val fagsak: Fagsak = fagsakService.hentFagsak(henlagtBehandling.fagsakId)
         if (henlagt.skalSendeHenleggelsesbrev) {
@@ -100,13 +101,13 @@ class HenleggBehandlingController(
         }
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("{behandlingId}/henlegg/behandling-uten-oppgave")
     fun henleggBehandlingUtenOppgave(
         @PathVariable behandlingId: UUID,
         @RequestBody henlagt: HenlagtDto,
     ): Ressurs<BehandlingDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         feilHvis(!featureToggleService.isEnabled(toggle = Toggle.HENLEGG_BEHANDLING_UTEN_OPPGAVE)) {
             "Henleggelse av behandling uten å henlegge oppgave er ikke mulig - toggle ikke enablet for bruker"
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/behandling/revurdering/RevurderingController.kt
@@ -5,6 +5,7 @@ import no.nav.familie.ef.sak.behandling.dto.RevurderingDto
 import no.nav.familie.ef.sak.behandling.dto.RevurderingsinformasjonDto
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.journalføring.dto.VilkårsbehandleNyeBarn
 import no.nav.familie.kontrakter.ef.felles.BehandlingÅrsak
@@ -24,12 +25,12 @@ class RevurderingController(
     private val revurderingService: RevurderingService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("{fagsakId}")
     fun startRevurdering(
         @RequestBody revurderingDto: RevurderingDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(revurderingDto.fagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         brukerfeilHvis(revurderingDto.behandlingsårsak == BehandlingÅrsak.SØKNAD) {
             "Systemet har ikke støtte for å revurdere med årsak “Søknad”. " +
                 "Vurder om behandlingen skal opprettes via en oppgave i oppgavebenken, " +
@@ -47,25 +48,25 @@ class RevurderingController(
         return Ressurs.success(revurdering.id)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("informasjon/{behandlingId}")
     fun lagreRevurderingsinformasjon(
         @PathVariable behandlingId: UUID,
         @RequestBody revurderingsinformasjonDto: RevurderingsinformasjonDto,
     ): Ressurs<RevurderingsinformasjonDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val oppdatertRevurderingsinformasjon =
             revurderingService.lagreRevurderingsinformasjon(behandlingId, revurderingsinformasjonDto)
         return Ressurs.success(oppdatertRevurderingsinformasjon)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @DeleteMapping("informasjon/{behandlingId}")
     fun slettRevurderingsinformasjon(
         @PathVariable behandlingId: UUID,
     ): Ressurs<String> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         revurderingService.slettRevurderingsinformasjon(behandlingId)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevMellomlagerController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.brev
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.brev.dto.MellomlagreBrevRequestDto
 import no.nav.familie.ef.sak.brev.dto.MellomlagretBrevResponse
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.web.bind.annotation.GetMapping
@@ -20,13 +21,13 @@ class BrevMellomlagerController(
     private val tilgangService: TilgangService,
     private val mellomlagringBrevService: MellomlagringBrevService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{behandlingId}")
     fun mellomlagreBrevverdier(
         @PathVariable behandlingId: UUID,
         @RequestBody mellomlagretBrev: MellomlagreBrevRequestDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return Ressurs.success(
             mellomlagringBrevService.mellomLagreBrev(
@@ -53,13 +54,13 @@ class BrevMellomlagerController(
         )
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/fagsak/{fagsakId}")
     fun mellomlagreFrittståendeSanitybrev(
         @PathVariable fagsakId: UUID,
         @RequestBody mellomlagreBrev: MellomlagreBrevRequestDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return Ressurs.success(
             mellomlagringBrevService.mellomLagreFrittståendeSanitybrev(

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/BrevmottakereController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.web.bind.annotation.GetMapping
@@ -26,13 +27,13 @@ class BrevmottakereController(
         return Ressurs.success(brevmottakereService.hentBrevmottakere(behandlingId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{behandlingId}")
     fun velgBrevmottakere(
         @PathVariable behandlingId: UUID,
         @RequestBody brevmottakere: BrevmottakereDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return Ressurs.success(brevmottakereService.lagreBrevmottakere(behandlingId, brevmottakere))
     }
@@ -46,13 +47,13 @@ class BrevmottakereController(
         return Ressurs.success(brevmottakereService.hentBrevnottakereForFagsak(fagsakId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("fagsak/{fagsakId}")
     fun velgBrevmottakereForFagsak(
         @PathVariable fagsakId: UUID,
         @RequestBody brevmottakere: BrevmottakereDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         return Ressurs.success(brevmottakereService.lagreBrevmottakereForFagsak(fagsakId, brevmottakere))
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/FrittståendeBrevController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.brev.dto.FrittståendeSanitybrevDto
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.web.bind.annotation.PathVariable
@@ -18,6 +19,7 @@ class FrittståendeBrevController(
     private val frittståendeBrevService: FrittståendeBrevService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{fagsakId}/{brevMal}")
     fun forhåndsvisFrittsåendeSanitybrev(
         @PathVariable fagsakId: UUID,
@@ -25,17 +27,16 @@ class FrittståendeBrevController(
         @RequestBody brevRequest: JsonNode,
     ): Ressurs<ByteArray> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(frittståendeBrevService.lagFrittståendeSanitybrev(fagsakId, brevMal, brevRequest))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/send/{fagsakId}")
     fun sendFrittsåendeSanitybrev(
         @PathVariable fagsakId: UUID,
         @RequestBody sendBrevRequest: FrittståendeSanitybrevDto,
     ): Ressurs<Unit> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(frittståendeBrevService.sendFrittståendeSanitybrev(fagsakId, sendBrevRequest))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/brev/VedtaksbrevController.kt
@@ -2,6 +2,8 @@ package no.nav.familie.ef.sak.brev
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleBeslutterEllerApplikasjon
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.Ressurs
 import org.springframework.validation.annotation.Validated
@@ -30,6 +32,7 @@ class VedtaksbrevController(
         return Ressurs.success(brevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev(behandlingId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{behandlingId}/{brevMal}")
     fun lagSaksbehandlerbrev(
         @PathVariable behandlingId: UUID,
@@ -38,7 +41,6 @@ class VedtaksbrevController(
     ): Ressurs<ByteArray> {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(brevService.lagSaksbehandlerSanitybrev(saksbehandling, brevRequest, brevMal))
     }
 
@@ -48,6 +50,7 @@ class VedtaksbrevController(
         @PathVariable behandlingId: UUID,
     ): Ressurs<ByteArray> = foråndsvisBeslutterbrev(behandlingId)
 
+    @HarRolleBeslutterEllerApplikasjon
     @PostMapping("/beslutter/vis/{behandlingId}")
     fun forhåndsvisBeslutterbrev(
         @PathVariable behandlingId: UUID,
@@ -56,7 +59,6 @@ class VedtaksbrevController(
     private fun foråndsvisBeslutterbrev(behandlingId: UUID): Ressurs<ByteArray> {
         val saksbehandling = behandlingService.hentSaksbehandling(behandlingId)
         tilgangService.validerTilgangTilBehandling(saksbehandling, AuditLoggerEvent.ACCESS)
-        tilgangService.validerHarBeslutterrolle()
         return Ressurs.success(brevService.forhåndsvisBeslutterBrev(saksbehandling))
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/ekstern/EksternBehandlingController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.felles.util.FnrUtil
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.ef.søknad.KanSendePåminnelseRequest
@@ -56,24 +57,24 @@ class EksternBehandlingController(
         @RequestBody personIdent: PersonIdent,
     ): Ressurs<Boolean> = Ressurs.success(eksternBehandlingService.harLøpendeBarnetilsyn(personIdent.ident))
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @GetMapping("kan-opprette-revurdering-klage/{eksternFagsakId}")
     fun kanOppretteRevurdering(
         @PathVariable eksternFagsakId: Long,
     ): Ressurs<KanOppretteRevurderingResponse> {
         tilgangService.validerTilgangTilEksternFagsak(eksternFagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         feilHvisIkke(SikkerhetContext.kallKommerFraKlage(), HttpStatus.UNAUTHORIZED) {
             IKKE_AUTORISERT_KLIENT_MELDING
         }
         return Ressurs.success(eksternBehandlingService.kanOppretteRevurdering(eksternFagsakId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("opprett-revurdering-klage/{eksternFagsakId}")
     fun opprettRevurderingKlage(
         @PathVariable eksternFagsakId: Long,
     ): Ressurs<OpprettRevurderingResponse> {
         tilgangService.validerTilgangTilEksternFagsak(eksternFagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         feilHvisIkke(SikkerhetContext.kallKommerFraKlage(), HttpStatus.UNAUTHORIZED) {
             IKKE_AUTORISERT_KLIENT_MELDING
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/AutomatiskMigreringController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/AutomatiskMigreringController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.behandling.migrering.AutomatiskMigreringService
 import no.nav.familie.ef.sak.behandling.migrering.MigreringExceptionType
 import no.nav.familie.ef.sak.fagsak.domain.PersonIdent
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,30 +20,30 @@ class AutomatiskMigreringController(
     private val automatiskMigreringService: AutomatiskMigreringService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @GetMapping
     fun migrerAutomatiskt(
         @RequestParam antall: Int,
     ) {
-        tilgangService.validerHarForvalterrolle()
         brukerfeilHvis(antall > 100) {
             "Kan ikke migrere fler enn 100"
         }
         automatiskMigreringService.migrerAutomatisk(antall)
     }
 
+    @HarRolleForvalter
     @PostMapping("rekjoer")
     fun rekjoer(
         @RequestBody personIdent: PersonIdent,
     ) {
-        tilgangService.validerHarForvalterrolle()
         automatiskMigreringService.rekjør(personIdent.ident)
     }
 
+    @HarRolleForvalter
     @PostMapping("rekjoer/{arsak}")
     fun rekjoer(
         @PathVariable("arsak") årsak: MigreringExceptionType,
     ) {
-        tilgangService.validerHarForvalterrolle()
         automatiskMigreringService.rekjør(årsak)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/DvhForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/DvhForvaltningController.kt
@@ -4,6 +4,7 @@ import no.nav.familie.ef.sak.behandling.BehandlingService
 import no.nav.familie.ef.sak.behandling.domain.BehandlingStatus
 import no.nav.familie.ef.sak.behandlingsflyt.task.BehandlingsstatistikkTask
 import no.nav.familie.ef.sak.infrastruktur.exception.Feil
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.web.bind.annotation.PostMapping
@@ -20,11 +21,11 @@ class DvhForvaltningController(
     private val behandlingService: BehandlingService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping(path = ["/sak/ferdigstill"])
     fun sendFerdigstiltBehandlingTilDvh(
         @RequestBody dvhForvaltning: DvhForvaltningDto,
     ) {
-        tilgangService.validerHarForvalterrolle()
         val behandling = behandlingService.hentBehandling(dvhForvaltning.behandlingId)
         if (behandling.status != BehandlingStatus.FERDIGSTILT) {
             throw Feil("Behandlingen må være ferdigstilt for at man skal kunne sende ferdig-hendelse til DVH")

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InitForberedOppgaverForTerminBarnTaskController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InitForberedOppgaverForTerminBarnTaskController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.oppgaveterminbarn.ForberedOppgaverTerminbarnTask
 import no.nav.familie.prosessering.domene.Task
@@ -18,9 +19,9 @@ class InitForberedOppgaverForTerminBarnTaskController(
     private val taskService: TaskService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping("/initialiser")
     fun opprettTask(): ResponseEntity<Unit> {
-        tilgangService.validerHarForvalterrolle()
         taskService.save(
             Task(
                 ForberedOppgaverTerminbarnTask.TYPE,

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InitOppfølgingsoppgaverForBarnTaskController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/InitOppfølgingsoppgaverForBarnTaskController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.OppfølgingOppgaveBarnFyllerÅrService
 import no.nav.familie.ef.sak.iverksett.oppgaveforbarn.OpprettTasksForBarnFyltÅrTask
@@ -20,15 +21,15 @@ class InitOppfølgingsoppgaverForBarnTaskController(
     private val barnFyllerÅrOppfølgingsoppgaveService: OppfølgingOppgaveBarnFyllerÅrService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping("/initialiser")
     fun opprettTask() {
-        tilgangService.validerHarForvalterrolle()
         taskService.save(OpprettTasksForBarnFyltÅrTask.opprettTask(LocalDate.now().plusDays(1)))
     }
 
+    @HarRolleForvalter
     @PostMapping("/dry-run")
     fun dryRun() {
-        tilgangService.validerHarForvalterrolle()
         barnFyllerÅrOppfølgingsoppgaveService.opprettTasksForAlleBarnSomHarFyltÅr(dryRun = true)
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/IverksettProxyTaskForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/IverksettProxyTaskForvaltningController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import io.swagger.v3.oas.annotations.Operation
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -24,6 +25,7 @@ class IverksettProxyTaskForvaltningController(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @HarRolleForvalter
     @PostMapping("kopier/taskid/{taskId}")
     @Operation(
         description =
@@ -36,7 +38,6 @@ class IverksettProxyTaskForvaltningController(
     fun restartIverksettTask(
         @PathVariable taskId: Long,
     ): KopiertTaskResponse {
-        tilgangService.validerHarForvalterrolle()
         val url = URI.create("$familieEfIverksettUri/api/forvaltning/task/restart/$taskId")
         val postForEntity =
             restClient

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/KonsistensavstemmingForvaltningController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingPayload
 import no.nav.familie.ef.sak.behandlingsflyt.task.KonsistensavstemmingTask
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.iverksett.IverksettClient
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -24,9 +25,9 @@ class KonsistensavstemmingForvaltningController(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @HarRolleForvalter
     @PostMapping
     fun kjørKonsistensavstemming() {
-        tilgangService.validerHarForvalterrolle()
         val triggerdato = LocalDate.now()
         logger.info("Oppretter manuell tasks for konsistensavstemming for dato=$triggerdato")
         taskService.saveAll(
@@ -43,11 +44,9 @@ class KonsistensavstemmingForvaltningController(
         )
     }
 
+    @HarRolleForvalter
     @GetMapping("test-timeout")
     fun timeoutTest(
         @RequestParam(name = "sekunder") sekunder: Long,
-    ): String {
-        tilgangService.validerHarForvalterrolle()
-        return iverksettClient.timeoutTest(sekunder)
-    }
+    ): String = iverksettClient.timeoutTest(sekunder)
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/ManuellGOmregningController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/ManuellGOmregningController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.ef.sak.beregning.Grunnbeløpsperioder
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.tilkjentytelse.TilkjentYtelseService
 import no.nav.familie.kontrakter.felles.Ressurs
@@ -30,18 +31,18 @@ class ManuellGOmregningController(
 ) {
     val logger: Logger = LoggerFactory.getLogger(javaClass)
 
+    @HarRolleForvalter
     @PostMapping(path = ["startjobb"])
     fun opprettGOmregningTasksForBehandlingerMedGammeltGBelop(): Ressurs<Int> {
-        tilgangService.validerHarForvalterrolle()
         val antallTaskerOpprettet = gOmregningTaskService.opprettGOmregningTaskForBehandlingerMedUtdatertG()
         return Ressurs.success(antallTaskerOpprettet)
     }
 
+    @HarRolleForvalter
     @PostMapping(path = ["{fagsakId}"])
     fun opprettGOmregningTaskForFagsak(
         @PathVariable fagsakId: UUID,
     ) {
-        tilgangService.validerHarForvalterrolle()
         validerHarLøpendeStønadEtterSisteGrunnbeløpdato(fagsakId)
 
         val opprettTask = gOmregningTask.opprettTask(fagsakId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/MinsideForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/MinsideForvaltningsController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.felles.dto.PersonIdentDto
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.minside.MinSideKafkaProducerService
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,20 +15,20 @@ class MinsideForvaltningsController(
     private val minSideKafkaProducerService: MinSideKafkaProducerService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping("aktiver")
     fun aktiverPersonForMinSide(
         @RequestBody personIdentDto: PersonIdentDto,
     ) {
-        tilgangService.validerHarForvalterrolle()
         validerPersonIdent(personIdentDto)
         minSideKafkaProducerService.aktiver(personIdent = personIdentDto.personIdent)
     }
 
+    @HarRolleForvalter
     @PostMapping("deaktiver")
     fun deaktiverPersonForMinSide(
         @RequestBody personIdentDto: PersonIdentDto,
     ) {
-        tilgangService.validerHarForvalterrolle()
         validerPersonIdent(personIdentDto)
         minSideKafkaProducerService.deaktiver(personIdent = personIdentDto.personIdent)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveOppryddingForvaltningsController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning
 
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import org.slf4j.LoggerFactory
@@ -16,12 +17,12 @@ class OppgaveOppryddingForvaltningsController(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    @HarRolleForvalter
     @PostMapping("start-opprydding")
     fun ryddOppgaver(
         @RequestBody runType: RunType,
     ) {
         logger.info("Starter opprydding av oppgaver")
-        tilgangService.validerHarForvalterrolle()
         val task = taskService.save(OppgaveOppryddingForvaltningsTask.opprettTask(runType))
 
         logger.info("Opprettet task for opprydding av oppfølgingsoppgaver: ${task.id}")

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/OppgaveforvaltningsController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.forvaltning
 
 import io.swagger.v3.oas.annotations.Operation
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.kontrakter.felles.oppgave.Oppgavetype
 import no.nav.familie.prosessering.internal.TaskService
@@ -36,6 +37,7 @@ class OppgaveforvaltningsController(
     private val taskService: TaskService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping("behandling/{behandlingId}")
     @Operation(
         description =
@@ -46,7 +48,6 @@ class OppgaveforvaltningsController(
     fun loggOppgavemetadataFor(
         @PathVariable behandlingId: UUID,
     ) {
-        tilgangService.validerHarForvalterrolle()
         val task = LoggOppgaveMetadataTask.opprettTask(behandlingId)
         taskService.save(task)
     }
@@ -60,11 +61,11 @@ class OppgaveforvaltningsController(
         summary =
             "Lag ny ekstern BehandleSak- eller GodkjenneVedtak-oppgave",
     )
+    @HarRolleForvalter
     @PostMapping("gjenopprett-oppgave/behandling/{behandlingId}")
     fun gjenopprettOppgaveForBehandling(
         @PathVariable behandlingId: UUID,
     ) {
-        tilgangService.validerHarForvalterrolle()
         val task = GjennoprettOppgavePåBehandlingTask.opprettTask(behandlingId)
         taskService.save(task)
     }
@@ -75,12 +76,12 @@ class OppgaveforvaltningsController(
         summary =
             "Ferdigstill BehandleSak- eller GodkjenneVedtak-oppgave i EF-sak og feilregistrer  oppgave i Gosys",
     )
+    @HarRolleForvalter
     @PostMapping("ferdigstill/oppgavetype/{oppgavetype}/behandlingid/{behandlingId}")
     fun ferdigstillOppgavtypeForBehandling(
         @PathVariable behandlingId: UUID,
         @PathVariable oppgavetype: OppgavetypeSomKanFerdigstilles,
     ) {
-        tilgangService.validerHarForvalterrolle()
         val task = FerdigstillOppgavetypePåBehandlingTask.opprettTask(ForvaltningFerdigstillRequest(behandlingId = behandlingId, oppgavetype = oppgavetype))
         taskService.save(task)
     }
@@ -89,11 +90,11 @@ class OppgaveforvaltningsController(
         description = "Synk oppgave med behandling",
         summary = "Synk oppgave med behandling",
     )
+    @HarRolleForvalter
     @PostMapping("synkroniser/{behandlingId}")
     fun synkroniserOppgaveMedBehandling(
         @PathVariable behandlingId: UUID,
     ) {
-        tilgangService.validerHarForvalterrolle()
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
         val task = SynkOppgaveForBehandlingTask.opprettTask(behandlingId)
         taskService.save(task)

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/PdlSjekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/PdlSjekkController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.forvaltning
 
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.PersonopplysningerService
@@ -27,11 +28,11 @@ class PdlSjekkController(
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
+    @HarRolleForvalter
     @PostMapping
     fun sjekkIdenter(
         @RequestBody identer: Set<String>,
     ): Int {
-        tilgangService.validerHarForvalterrolle()
         val count =
             identer
                 .map { aktørId ->
@@ -49,11 +50,11 @@ class PdlSjekkController(
         return count
     }
 
+    @HarRolleForvalter
     @PostMapping("/annenforelder")
     fun sjekkAnnenForelder(
         @RequestBody ident: String,
     ): Int {
-        tilgangService.validerHarForvalterrolle()
         val søker = personService.hentSøker(ident)
         val strengesteAdressebeskyttelseForPersonMedRelasjoner = personopplysningerService.hentStrengesteAdressebeskyttelseForPersonMedRelasjoner(ident)
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/aktivitetsplikt/AutomatiskBrevInnhentingAktivitetspliktController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ef.sak.forvaltning.aktivitetsplikt
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.prosessering.internal.TaskService
 import org.springframework.web.bind.annotation.PostMapping
@@ -19,11 +20,11 @@ class AutomatiskBrevInnhentingAktivitetspliktController(
     private val featureToggleService: FeatureToggleService,
     private val tilgangService: TilgangService,
 ) {
+    @HarRolleForvalter
     @PostMapping("/opprett-tasks")
     fun opprettTasks(
         @RequestBody aktivitetspliktRequest: AktivitetspliktRequest,
     ) {
-        tilgangService.validerHarForvalterrolle()
         feilHvis(!featureToggleService.isEnabled(Toggle.AUTOMATISKE_BREV_INNHENTING_AKTIVITETSPLIKT) && aktivitetspliktRequest.liveRun) {
             "Toggle for automatiske brev for innhenting av aktiitetsplikt er ikke påskrudd"
         }

--- a/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/forvaltning/uttrekk/AndelshistorikkUttrekkController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.ef.sak.forvaltning.uttrekk
 
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleForvalter
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.vedtak.historikk.VedtakHistorikkService
 import org.slf4j.LoggerFactory
@@ -25,9 +26,9 @@ class AndelshistorikkUttrekkController(
     private val logger = LoggerFactory.getLogger(javaClass)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
+    @HarRolleForvalter
     @GetMapping("/manglertilsyn")
     fun hentDataManglerTilsyn2022(): ResponseEntity<String> {
-        tilgangService.validerHarForvalterrolle()
         val fagsakerMedTilsynManglerKandidater = andelshistorikkUttrekkRepository.finnFagsakerMedTilsynManglerKandidater()
 
         val fagsakerMedAndelshistorikk: List<UttrekkFagsakMedAndelshistorikk> =

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/RolleAnnotasjoner.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/sikkerhet/RolleAnnotasjoner.kt
@@ -11,3 +11,8 @@ annotation class HarRolleSaksbehandlerEllerApplikasjon
 @Retention(AnnotationRetention.RUNTIME)
 @PreAuthorize("hasRole('FORVALTER')")
 annotation class HarRolleForvalter
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@PreAuthorize("hasAnyRole('BESLUTTER', 'APPLICATION')")
+annotation class HarRolleBeslutterEllerApplikasjon

--- a/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.ef.sak.infrastruktur.exception.feilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.feilHvisIkke
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.FeatureToggleService
 import no.nav.familie.ef.sak.infrastruktur.featuretoggle.Toggle
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.journalføring.dto.JournalføringRequestV2
 import no.nav.familie.ef.sak.journalføring.dto.JournalføringResponse
@@ -76,6 +77,7 @@ class JournalpostController(
         return journalpostService.hentDokument(journalpostId, dokumentInfoId)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{journalpostId}/fullfor/v2")
     fun fullførJournalpostV2(
         @PathVariable journalpostId: String,
@@ -83,7 +85,6 @@ class JournalpostController(
     ): Ressurs<String> {
         val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         if (journalføringRequest.gjelderKlage()) {
             journalføringKlageService.fullførJournalpostV2(journalføringRequest, journalpost)
@@ -93,6 +94,7 @@ class JournalpostController(
         return Ressurs.success(journalpostId)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{journalpostId}/oppdater-dokumenter")
     fun oppdaterDokumenter(
         @PathVariable journalpostId: String,
@@ -100,13 +102,13 @@ class JournalpostController(
     ): Ressurs<String> {
         val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         journalpostService.oppdaterDokumenterPåJournalpost(journalpost, request)
 
         return Ressurs.success(journalpostId)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{journalpostId}/opprett-behandling-med-soknadsdata-fra-en-ferdigstilt-journalpost")
     fun opprettBehandlingMedSøknadsdataFraEnFerdigstiltJournalpost(
         @PathVariable journalpostId: String,
@@ -117,7 +119,6 @@ class JournalpostController(
         }
         val (journalpost, personIdent) = finnJournalpostOgPersonIdent(journalpostId)
         tilgangService.validerTilgangTilPersonMedBarn(personIdent, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         brukerfeilHvisIkke(journalpost.harStrukturertSøknad()) { "Journalposten inneholder ikke en digital søknad" }
         return Ressurs.success(
             journalføringService.opprettBehandlingMedSøknadsdataFraEnFerdigstiltJournalpost(

--- a/src/main/kotlin/no/nav/familie/ef/sak/klage/KlageController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/klage/KlageController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.klage
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.fagsak.FagsakService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.klage.dto.KlagebehandlingerDto
 import no.nav.familie.ef.sak.klage.dto.OpprettKlageDto
@@ -23,13 +24,13 @@ class KlageController(
     private val klageService: KlageService,
     private val fagsakService: FagsakService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/fagsak/{fagsakId}")
     fun opprettKlage(
         @PathVariable fagsakId: UUID,
         @RequestBody opprettKlageDto: OpprettKlageDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilFagsak(fagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         klageService.validerOgOpprettKlage(fagsakService.hentFagsak(fagsakId), opprettKlageDto)
         return Ressurs.success(fagsakId)
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.oppgave
 
 import no.nav.familie.ef.sak.felles.util.FnrUtil.validerOptionalIdent
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
@@ -92,13 +93,13 @@ class OppgaveController(
         return Ressurs.success(oppgaveResponse.tilDto())
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping(path = ["/{gsakOppgaveId}/fordel"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun fordelOppgave(
         @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
         @RequestParam("saksbehandler") saksbehandler: String,
         @RequestParam("versjon") versjon: Int?,
     ): Ressurs<Long> {
-        tilgangService.validerHarSaksbehandlerrolle()
         if (!tilgangService.validerSaksbehandler(saksbehandler)) {
             throw ApiFeil("Kunne ikke validere saksbehandler : $saksbehandler", HttpStatus.BAD_REQUEST)
         }
@@ -106,20 +107,18 @@ class OppgaveController(
         return Ressurs.success(oppgaveService.fordelOppgave(gsakOppgaveId, saksbehandler, versjon, endretAvSaksbehandler))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping(path = ["/{gsakOppgaveId}/tilbakestill"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun tilbakestillFordelingPåOppgave(
         @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
         @RequestParam(name = "versjon") versjon: Int?,
-    ): Ressurs<Long> {
-        tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(oppgaveService.tilbakestillFordelingPåOppgave(gsakOppgaveId, versjon))
-    }
+    ): Ressurs<Long> = Ressurs.success(oppgaveService.tilbakestillFordelingPåOppgave(gsakOppgaveId, versjon))
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @GetMapping(path = ["/{gsakOppgaveId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun hentOppgave(
         @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
     ): Ressurs<OppgaveDto> {
-        tilgangService.validerHarSaksbehandlerrolle()
         val efOppgave = oppgaveService.hentEfOppgave(gsakOppgaveId)
         return efOppgave?.let { Ressurs.success(OppgaveDto(it.behandlingId, it.gsakOppgaveId)) }
             ?: Ressurs.funksjonellFeil(
@@ -128,13 +127,11 @@ class OppgaveController(
             )
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @GetMapping("/oppslag/{gsakOppgaveId}")
     fun hentOppgaveFraGosys(
         @PathVariable(name = "gsakOppgaveId") gsakOppgaveId: Long,
-    ): Ressurs<OppgaveEfDto> {
-        tilgangService.validerHarSaksbehandlerrolle()
-        return Ressurs.success(oppgaveService.hentOppgave(gsakOppgaveId).tilDto())
-    }
+    ): Ressurs<OppgaveEfDto> = Ressurs.success(oppgaveService.hentOppgave(gsakOppgaveId).tilDto())
 
     @Deprecated("Har ikke lenger behov for logging - fjern etter at frontend slutter å kalle på dette endepunktet")
     @GetMapping("{behandlingId}/tilordnet-ressurs")

--- a/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/samværsavtale/SamværsavtaleController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.samværsavtale
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.samværsavtale.dto.JournalførBeregnetSamværRequest
 import no.nav.familie.ef.sak.samværsavtale.dto.SamværsavtaleDto
@@ -29,32 +30,32 @@ class SamværsavtaleController(
         return Ressurs.success(samværsavtaleService.hentSamværsavtalerForBehandling(behandlingId).tilDto())
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping
     fun oppdaterSamværsavtale(
         @RequestBody request: SamværsavtaleDto,
     ): Ressurs<List<SamværsavtaleDto>> {
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         samværsavtaleService.opprettEllerErstattSamværsavtale(request)
         return Ressurs.success(samværsavtaleService.hentSamværsavtalerForBehandling(request.behandlingId).tilDto())
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/journalfor")
     fun journalførBeregnetSamvær(
         @RequestBody request: JournalførBeregnetSamværRequest,
     ): Ressurs<String> {
         tilgangService.validerTilgangTilPersonMedBarn(request.personIdent, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(samværsavtaleService.journalførBeregnetSamvær(request))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @DeleteMapping("{behandlingId}/{behandlingBarnId}")
     fun slettSamværsavtale(
         @PathVariable behandlingId: UUID,
         @PathVariable behandlingBarnId: UUID,
     ): Ressurs<List<SamværsavtaleDto>> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
         samværsavtaleService.slettSamværsavtale(behandlingId, behandlingBarnId)
         return Ressurs.success(samværsavtaleService.hentSamværsavtalerForBehandling(behandlingId).tilDto())
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/tilbakekreving/TilbakekrevingController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ef.sak.tilbakekreving
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
 import no.nav.familie.ef.sak.behandling.BehandlingService
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.tilbakekreving.domain.tilDto
 import no.nav.familie.ef.sak.tilbakekreving.dto.TilbakekrevingDto
@@ -24,23 +25,23 @@ class TilbakekrevingController(
     private val behandlingService: BehandlingService,
     private val tilbakekrevingService: TilbakekrevingService,
 ) {
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/{behandlingId}")
     fun lagreTilbakekreving(
         @PathVariable behandlingId: UUID,
         @RequestBody tilbakekrevingDto: TilbakekrevingDto,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         tilbakekrevingService.lagreTilbakekreving(tilbakekrevingDto, behandlingId)
         return Ressurs.success(behandlingId)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("/fagsak/{fagsakId}/opprett-tilbakekreving")
     fun opprettManuellTilbakekreving(
         @PathVariable fagsakId: UUID,
     ): Ressurs<String> {
         tilgangService.validerTilgangTilFagsak(fagsakId = fagsakId, AuditLoggerEvent.CREATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         tilbakekrevingService.opprettManuellTilbakekreving(fagsakId)
         return Ressurs.success("Opprettelse av manuell behandling iverksatt.")
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vedtak/VedtakController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.ef.sak.behandlingsflyt.steg.StegService
 import no.nav.familie.ef.sak.infrastruktur.exception.ApiFeil
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvis
 import no.nav.familie.ef.sak.infrastruktur.exception.brukerfeilHvisIkke
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppgave.TilordnetRessursService
 import no.nav.familie.ef.sak.opplysninger.personopplysninger.secureLogger
@@ -148,12 +149,12 @@ class VedtakController(
         return Ressurs.success(stegService.håndterSteg(behandling, beregnYtelseSteg, vedtak).id)
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @DeleteMapping("/{behandlingId}")
     fun nullstillVedtak(
         @PathVariable behandlingId: UUID,
     ): Ressurs<UUID> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         nullstillVedtakService.nullstillVedtak(behandlingId)
         return Ressurs.success(behandlingId)

--- a/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/vilkår/VurderingController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.ef.sak.vilkår
 
 import no.nav.familie.ef.sak.AuditLoggerEvent
+import no.nav.familie.ef.sak.infrastruktur.sikkerhet.HarRolleSaksbehandlerEllerApplikasjon
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.vilkår.dto.EnkeltVilkårForGjenbrukRequest
 import no.nav.familie.ef.sak.vilkår.dto.GjenbruktVilkårResponseDto
@@ -38,12 +39,12 @@ class VurderingController(
     @GetMapping("regler")
     fun hentRegler(): Ressurs<Vilkårsregler> = Ressurs.success(Vilkårsregler.ALLE_VILKÅRSREGLER)
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("vilkar")
     fun oppdaterVurderingVilkår(
         @RequestBody vilkårsvurdering: SvarPåVurderingerDto,
     ): Ressurs<VilkårsvurderingDto> {
         tilgangService.validerTilgangTilBehandling(vilkårsvurdering.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         try {
             return Ressurs.success(vurderingStegService.oppdaterVilkår(vilkårsvurdering))
         } catch (e: Exception) {
@@ -57,21 +58,21 @@ class VurderingController(
         }
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("nullstill")
     fun nullstillVilkår(
         @RequestBody request: OppdaterVilkårsvurderingDto,
     ): Ressurs<VilkårsvurderingDto> {
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.DELETE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(vurderingStegService.nullstillVilkår(request))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("ikkevurder")
     fun settVilkårTilSkalIkkeVurderes(
         @RequestBody request: OppdaterVilkårsvurderingDto,
     ): Ressurs<VilkårsvurderingDto> {
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(vurderingStegService.settVilkårTilSkalIkkeVurderes(request))
     }
 
@@ -83,15 +84,16 @@ class VurderingController(
         return Ressurs.success(vurderingService.hentOpprettEllerOppdaterVurderinger(behandlingId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @GetMapping("{behandlingId}/oppdater")
     fun oppdaterRegisterdata(
         @PathVariable behandlingId: UUID,
     ): Ressurs<VilkårDto> {
         tilgangService.validerTilgangTilBehandling(behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
         return Ressurs.success(vurderingService.oppdaterGrunnlagsdataOgHentEllerOpprettVurderinger(behandlingId))
     }
 
+    @HarRolleSaksbehandlerEllerApplikasjon
     @PostMapping("gjenbruk-enkelt-vilkar")
     fun gjenbrukEnkeltVilkår(
         @RequestBody request: EnkeltVilkårForGjenbrukRequest,
@@ -100,7 +102,6 @@ class VurderingController(
 
         tilgangService.validerTilgangTilBehandling(behandlingForGjenbruk.id, AuditLoggerEvent.ACCESS)
         tilgangService.validerTilgangTilBehandling(request.behandlingId, AuditLoggerEvent.UPDATE)
-        tilgangService.validerHarSaksbehandlerrolle()
 
         val (_, metadata) = vurderingService.hentGrunnlagOgMetadata(request.behandlingId)
         val gjenbruktVilkårResponse = gjenbrukVilkårService.gjenbrukInngangsvilkårVurderingOgSamværsavtale(request.behandlingId, behandlingForGjenbruk.id, request.vilkårId, metadata.barn)

--- a/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/OppslagSpringRunnerTest.kt
@@ -215,6 +215,11 @@ abstract class OppslagSpringRunnerTest {
             return onBehalfOfToken(roles = listOf(rolleConfig.forvalter, rolleConfig.veilederRolle))
         }
 
+    protected val lokalVeilederToken: String
+        get() {
+            return onBehalfOfToken(role = rolleConfig.veilederRolle)
+        }
+
     protected fun onBehalfOfToken(
         role: String = rolleConfig.beslutterRolle,
         saksbehandler: String = "julenissen",

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostControllerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostControllerIntegrasjonsTest.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.ef.sak.journalføring
+
+import no.nav.familie.ef.sak.OppslagSpringRunnerTest
+import no.nav.familie.ef.sak.journalføring.dto.JournalføringRequestV2
+import no.nav.familie.ef.sak.journalføring.dto.Journalføringsaksjon
+import no.nav.familie.ef.sak.journalføring.dto.Journalføringsårsak
+import no.nav.familie.kontrakter.felles.Ressurs
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import java.util.UUID
+
+internal class JournalpostControllerIntegrasjonsTest : OppslagSpringRunnerTest() {
+    @Test
+    internal fun `Skal returnere 403 FORBIDDEN med status IKKE_TILGANG dersom bruker kun har veilederrolle`() {
+        headers.setBearerAuth(lokalVeilederToken)
+
+        val response = fullførJournalpostV2("111")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
+    }
+
+    private fun fullførJournalpostV2(journalpostId: String): ResponseEntity<Ressurs<String>> =
+        testRestTemplate.exchange(
+            localhost("/api/journalpost/$journalpostId/fullfor/v2"),
+            HttpMethod.POST,
+            HttpEntity(
+                JournalføringRequestV2(
+                    dokumentTitler = null,
+                    fagsakId = UUID.randomUUID(),
+                    oppgaveId = "dummy-oppgave",
+                    journalførendeEnhet = "9991",
+                    aksjon = Journalføringsaksjon.OPPRETT_BEHANDLING,
+                    årsak = Journalføringsårsak.DIGITAL_SØKNAD,
+                ),
+                headers,
+            ),
+        )
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/journalføring/JournalpostControllerTest.kt
@@ -150,31 +150,6 @@ internal class JournalpostControllerTest {
     }
 
     @Test
-    internal fun `skal feile hvis bruker er veileder`() {
-        every {
-            journalpostService.hentJournalpost(any())
-        } returns journalpostMedFødselsnummer
-
-        every {
-            tilgangService.validerHarSaksbehandlerrolle()
-        } throws ManglerTilgang("Bruker mangler tilgang", "Mangler tilgang til bruker")
-
-        assertThrows<ManglerTilgang> {
-            journalpostController.fullførJournalpostV2(
-                journalpostMedFødselsnummer.journalpostId,
-                JournalføringRequestV2(
-                    dokumentTitler = null,
-                    fagsakId = UUID.randomUUID(),
-                    oppgaveId = "dummy-oppgave",
-                    journalførendeEnhet = "9991",
-                    aksjon = Journalføringsaksjon.OPPRETT_BEHANDLING,
-                    årsak = Journalføringsårsak.DIGITAL_SØKNAD,
-                ),
-            )
-        }
-    }
-
-    @Test
     fun `skal journalføre som klage i v2 hvis årsak er klage`() {
         setupFullførJournalføringV2()
 

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerIntegrasjonsTest.kt
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.resttestclient.exchange
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import java.util.UUID
 
@@ -41,6 +42,16 @@ internal class OppgaveControllerIntegrasjonsTest : OppslagSpringRunnerTest() {
         val response = søkOppgave("19117313797")
         assertThat(response.body?.status).isEqualTo(Ressurs.Status.FUNKSJONELL_FEIL)
         assertThat(response.body?.frontendFeilmelding).isEqualTo("Finner ingen personer for valgt personident")
+    }
+
+    @Test
+    internal fun `Skal returnere 403 FORBIDDEN med status IKKE_TILGANG dersom bruker kun har veilederrolle ved fordeling av oppgave`() {
+        headers.setBearerAuth(lokalVeilederToken)
+
+        val response = fordelOppgave(gsakOppgaveId = 24680L, saksbehandler = "Z999999")
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.FORBIDDEN)
+        assertThat(response.body?.status).isEqualTo(Ressurs.Status.IKKE_TILGANG)
     }
 
     @Test
@@ -222,6 +233,16 @@ internal class OppgaveControllerIntegrasjonsTest : OppslagSpringRunnerTest() {
             localhost("/api/oppgave/soek"),
             HttpMethod.POST,
             HttpEntity(FinnOppgaveRequestDto(ident = personIdent), headers),
+        )
+
+    private fun fordelOppgave(
+        gsakOppgaveId: Long,
+        saksbehandler: String,
+    ): ResponseEntity<Ressurs<Long>> =
+        testRestTemplate.exchange(
+            localhost("/api/oppgave/$gsakOppgaveId/fordel?saksbehandler=$saksbehandler"),
+            HttpMethod.POST,
+            HttpEntity<Ressurs<Long>>(headers),
         )
 
     private fun hentAnsvarligSaksbehandler(behandlingId: UUID): ResponseEntity<Ressurs<SaksbehandlerDto>> =

--- a/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/oppgave/OppgaveControllerTest.kt
@@ -8,7 +8,6 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
-import no.nav.familie.ef.sak.infrastruktur.exception.ManglerTilgang
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.SikkerhetContext
 import no.nav.familie.ef.sak.infrastruktur.sikkerhet.TilgangService
 import no.nav.familie.ef.sak.oppfølgingsoppgave.OppfølgingsoppgaveService
@@ -26,7 +25,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 internal class OppgaveControllerTest {
@@ -122,21 +120,6 @@ internal class OppgaveControllerTest {
         oppgaveController.hentOppgaver(FinnOppgaveRequestDto(ident = null))
         verify(exactly = 0) { personService.hentAktørIder(any()) }
         assertThat(finnOppgaveRequestSlot.captured.aktørId).isEqualTo(null)
-    }
-
-    @Test
-    internal fun `skal feile hvis bruker er veileder`() {
-        every {
-            tilgangService.validerTilgangTilPersonMedBarn(any(), any())
-        } just Runs
-
-        every {
-            tilgangService.validerHarSaksbehandlerrolle()
-        } throws ManglerTilgang("Bruker mangler tilgang", "Mangler tilgang")
-
-        assertThrows<ManglerTilgang> {
-            oppgaveController.fordelOppgave(123, "dummy saksbehandler", null)
-        }
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

refactor(sikkerhet): erstatt manuelle rollesjekker med preauth i alle controllere

Fortsetter arbeidet fra [#3202 ](https://github.com/navikt/familie-ef-sak/pull/3202)ved å bytte ut validerHarSaksbehandlerrolle/ validerHarForvalterrolle/validerHarBeslutterrolle med @PreAuthorize-annotasjoner i resten av controllerne. Ny annotasjon @HarRolleBeslutterEllerApplikasjon lagt til. Erstatter to unit-tester som ikke lenger dekker sjekken med HTTP-integrasjonstester (403/IKKE_TILGANG for veileder).
