### PR TITLE
Bruk riktig mapper i rest clients

### DIFF
--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
@@ -10,7 +10,9 @@ import org.springframework.boot.http.client.HttpClientSettings
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.web.client.RestClient
+import tools.jackson.databind.json.JsonMapper
 import java.time.Duration
 
 @Configuration
@@ -18,6 +20,7 @@ class RestClientConfig(
     private val entraIDRestClientFactory: EntraIDRestClientFactory,
     private val consumerIdClientInterceptor: ConsumerIdClientInterceptor,
     private val mdcValuesPropagatingClientInterceptor: MdcValuesPropagatingClientInterceptor,
+    private val jsonMapper: JsonMapper,
 ) {
     private val requestFactory: ClientHttpRequestFactory =
         ClientHttpRequestFactoryBuilder
@@ -29,7 +32,40 @@ class RestClientConfig(
                     .withReadTimeout(Duration.ofSeconds(30)),
             )
 
-    private fun RestClient.medTimeout(): RestClient = this.mutate().requestFactory(requestFactory).build()
+    /**
+     * RestClient.builder() (og EntraIDRestClientFactory sine fabrikkmetoder) bruker Spring sin
+     * default JsonMapper, som ikke har KotlinFeature.KotlinPropertyNameAsImplicitName aktivert.
+     * Da blir felter med navn som starter med æ/ø/å (f.eks. årMånedFra) mistet under serialisering.
+     *
+     * Rotårsak: Kotlin-kompilatoren kapitaliserer ikke æ/ø/å i genererte getter-navn, så en
+     * property "årMånedFra" får getteren "getårMånedFra()" (ikke "getÅrMånedFra()" som man
+     * skulle forvente). Jackson 3 sin default AccessorNamingStrategy krever at basenavnet som er
+     * igjen etter at "get"-prefikset er fjernet starter med stor bokstav, og forkaster derfor
+     * "årMånedFra" som en gyldig property - feltet blir usynlig for serialisering. Med
+     * KotlinFeature.KotlinPropertyNameAsImplicitName slått på bruker Kotlin-modulen det faktiske
+     * Kotlin-egenskapsnavnet direkte i stedet for å utlede navnet fra getter-metoden, og unngår
+     * dermed problemet. Vi bruker derfor eksplisitt vår egen jsonMapper, som bygger videre på
+     * no.nav.familie.kontrakter.felles.jsonMapper (fra Maven-artifaktet no.nav.familie.kontrakter:felles),
+     * som har denne featuren aktivert.
+     */
+    private fun RestClient.medJsonMapperFraFellesKontrakter(): RestClient =
+        this
+            .mutate()
+            .configureMessageConverters { converters ->
+                converters
+                    .registerDefaults()
+                    // withJsonConverter overstyrer JSON-converteren som ellers auto-detekteres,
+                    // uavhengig av hvor i listen den defaultmessig havner (f.eks. foran YAML-converteren
+                    // som også er på classpath via springdoc/swagger-core)
+                    .withJsonConverter(JacksonJsonHttpMessageConverter(jsonMapper))
+            }.build()
+
+    private fun RestClient.medTimeout(): RestClient =
+        this
+            .mutate()
+            .requestFactory(requestFactory)
+            .build()
+            .medJsonMapperFraFellesKontrakter()
 
     private fun hybrid(scope: String): RestClient = entraIDRestClientFactory.lagHybridRestKlient(scope) { SikkerhetContext.hentJwt()?.tokenValue }.medTimeout()
 
@@ -172,4 +208,5 @@ class RestClientConfig(
             .requestInterceptor(mdcValuesPropagatingClientInterceptor)
             .requestFactory(requestFactory)
             .build()
+            .medJsonMapperFraFellesKontrakter()
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfigAlleKlienterTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfigAlleKlienterTest.kt
@@ -1,0 +1,131 @@
+package no.nav.familie.ef.sak.infrastruktur.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.familie.felles.tokenklient.entraid.EntraIDRestClientFactory
+import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
+import no.nav.familie.log.interceptor.MdcValuesPropagatingClientInterceptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.springframework.web.client.RestClient
+import java.net.URI
+import java.time.YearMonth
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Regresjonstest som fanger opp at *alle* RestClient-bønner definert i RestClientConfig faktisk
+ * serialiserer felter som starter med æ/ø/å riktig - ikke bare de vi manuelt har testet
+ * (utenAuthRestClient/iverksettRestClient). Testen finner alle @Bean-metoder i RestClientConfig
+ * som returnerer RestClient via refleksjon, slik at den også dekker nye RestClient-bønner som
+ * legges til i fremtiden uten at noen husker å legge til en egen test for dem.
+ *
+ * Se RestClientConfigJsonMapperTest for detaljert forklaring av selve bugen.
+ */
+class RestClientConfigAlleKlienterTest {
+    data class DtoMedÆøåFelt(
+        val årMånedFra: YearMonth,
+        val vanligFelt: String,
+    )
+
+    @AfterEach
+    fun tearDownEachTest() {
+        wiremockServer.resetAll()
+    }
+
+    @TestFactory
+    fun `alle RestClient-bønner i RestClientConfig serialiserer felter som starter med æøå riktig`(): List<DynamicTest> {
+        val restClientBeanFunksjoner =
+            RestClientConfig::class
+                .memberFunctions
+                .filter { it.returnType.classifier == RestClient::class }
+
+        assertThat(restClientBeanFunksjoner).isNotEmpty
+
+        return restClientBeanFunksjoner.map { funksjon ->
+            DynamicTest.dynamicTest(funksjon.name) {
+                funksjon.isAccessible = true
+                val args =
+                    funksjon.parameters
+                        .drop(1) // dropp "this"-parameteret
+                        .associateWith { "dummy-scope" }
+                val restClient = funksjon.callBy(mapOf(funksjon.parameters[0] to restClientConfig) + args) as RestClient
+
+                val path = "/test-${funksjon.name}"
+                wiremockServer.stubFor(
+                    post(urlEqualTo(path))
+                        .willReturn(
+                            aResponse()
+                                .withStatus(200)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{}"),
+                        ),
+                )
+
+                restClient
+                    .post()
+                    .uri(URI.create("${wiremockServer.baseUrl()}$path"))
+                    .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                    .body(DtoMedÆøåFelt(YearMonth.of(2024, 1), "verdi"))
+                    .retrieve()
+                    .toBodilessEntity()
+
+                val body =
+                    wiremockServer
+                        .findAll(postRequestedFor(urlEqualTo(path)))
+                        .single()
+                        .bodyAsString
+                assertThat(body)
+                    .withFailMessage(
+                        "RestClient-bønnen '${funksjon.name}' mister felt som starter med æ/ø/å ved " +
+                            "serialisering. Sjekk at bønnen bruker medJsonMapperFraFellesKontrakter()/medTimeout() i RestClientConfig.",
+                    ).contains("\"årMånedFra\":\"2024-01\"")
+            }
+        }
+    }
+
+    companion object {
+        private lateinit var wiremockServer: WireMockServer
+        private lateinit var restClientConfig: RestClientConfig
+
+        @BeforeAll
+        @JvmStatic
+        fun initClass() {
+            wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+            wiremockServer.start()
+
+            val entraIDRestClientFactory =
+                mockk<EntraIDRestClientFactory> {
+                    // Speiler den ekte fabrikken sin oppførsel: bygger RestClient via
+                    // RestClient.builder() direkte, uten den riktige jsonMapper-en.
+                    every { lagMaskinTilMaskinRestKlient(any()) } answers { RestClient.builder().build() }
+                    every { lagHybridRestKlient(any(), any()) } answers { RestClient.builder().build() }
+                    every { lagOboRestKlient(any(), any()) } answers { RestClient.builder().build() }
+                }
+
+            restClientConfig =
+                RestClientConfig(
+                    entraIDRestClientFactory = entraIDRestClientFactory,
+                    consumerIdClientInterceptor = ConsumerIdClientInterceptor("familie-ef-sak", "test"),
+                    mdcValuesPropagatingClientInterceptor = MdcValuesPropagatingClientInterceptor(),
+                    jsonMapper = JsonMapperProvider.jsonMapper,
+                )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            wiremockServer.stop()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfigJsonMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfigJsonMapperTest.kt
@@ -1,0 +1,125 @@
+package no.nav.familie.ef.sak.infrastruktur.config
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import io.mockk.mockk
+import no.nav.familie.felles.tokenklient.entraid.EntraIDRestClientFactory
+import no.nav.familie.log.interceptor.ConsumerIdClientInterceptor
+import no.nav.familie.log.interceptor.MdcValuesPropagatingClientInterceptor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.web.client.RestClient
+import java.net.URI
+import java.time.YearMonth
+
+/**
+ * Regresjonstest for feilen der felter som starter med æ/ø/å (f.eks. årMånedFra) forsvant fra
+ * JSON-en når en RestClient bygges med RestClient.builder() direkte (slik alle RestClient-bønnene
+ * i RestClientConfig gjør, enten direkte eller via EntraIDRestClientFactory). Uten
+ * medJsonMapperFraFellesKontrakter() bruker Spring sin default JsonMapper, som mangler
+ * KotlinFeature.KotlinPropertyNameAsImplicitName, og da mister Kotlin-modulen navnet på felter som
+ * starter med æ/ø/å helt (feltet blir ikke bare feilaktig navngitt, men utelatt fra JSON-en).
+ */
+class RestClientConfigJsonMapperTest {
+    data class DtoMedÆøåFelt(
+        val årMånedFra: YearMonth,
+        val vanligFelt: String,
+    )
+
+    @AfterEach
+    fun tearDownEachTest() {
+        wiremockServer.resetAll()
+    }
+
+    @Test
+    fun `utenAuthRestClient serialiserer felter som starter med æøå riktig`() {
+        wiremockServer.stubFor(
+            post(urlEqualTo("/test"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                        .withBody("{}"),
+                ),
+        )
+
+        val restClient = restClientConfig.utenAuthRestClient()
+        restClient
+            .post()
+            .uri(URI.create("${wiremockServer.baseUrl()}/test"))
+            .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+            .body(DtoMedÆøåFelt(YearMonth.of(2024, 1), "verdi"))
+            .retrieve()
+            .toBodilessEntity()
+
+        val body =
+            wiremockServer
+                .findAll(postRequestedFor(urlEqualTo("/test")))
+                .single()
+                .bodyAsString
+        assertThat(body).contains("\"årMånedFra\":\"2024-01\"")
+    }
+
+    @Test
+    fun `default RestClient uten fix mister felt som starter med æøå (dokumenterer bugen)`() {
+        wiremockServer.stubFor(
+            post(urlEqualTo("/test-uten-fix"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                        .withBody("{}"),
+                ),
+        )
+
+        val restClientUtenFix = RestClient.builder().build()
+        restClientUtenFix
+            .post()
+            .uri(URI.create("${wiremockServer.baseUrl()}/test-uten-fix"))
+            .body(DtoMedÆøåFelt(YearMonth.of(2024, 1), "verdi"))
+            .retrieve()
+            .toBodilessEntity()
+
+        val body =
+            wiremockServer
+                .findAll(postRequestedFor(urlEqualTo("/test-uten-fix")))
+                .single()
+                .bodyAsString
+        assertThat(body).doesNotContain("årMånedFra")
+        assertThat(body).contains("vanligFelt")
+    }
+
+    companion object {
+        private lateinit var wiremockServer: WireMockServer
+        private lateinit var restClientConfig: RestClientConfig
+
+        @BeforeAll
+        @JvmStatic
+        fun initClass() {
+            wiremockServer = WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort())
+            wiremockServer.start()
+
+            restClientConfig =
+                RestClientConfig(
+                    entraIDRestClientFactory = mockk<EntraIDRestClientFactory>(),
+                    consumerIdClientInterceptor = ConsumerIdClientInterceptor("familie-ef-sak", "test"),
+                    mdcValuesPropagatingClientInterceptor = MdcValuesPropagatingClientInterceptor(),
+                    jsonMapper = JsonMapperProvider.jsonMapper,
+                )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            wiremockServer.stop()
+        }
+    }
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
I forbindelse med at lagSaksbehandlingsblankettTask feilet i prod, ble det oppdaget at årMånedFra i skolepengevedtaket ikke ble sendt videre til brevet riktig. Verdien ble satt til null, selv om den faktisk var tilgjengelig.

Årsaken er endringer som gjorde at REST-klientene gikk tilbake til å bruke Spring sin default ObjectMapper. Vi må sørge for at familie sin JsonMapper benyttes, slik at blant annet KotlinPropertyNameAsImplicitName er aktivert. Dette er nødvendig for at felter som starter med æ, ø eller å skal mappes riktig.

Mulig årsakRevurdering må sendes til statistikk på nytt, slik som sist.