### PR TITLE
Direkte kall uten proxy

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -111,7 +111,7 @@ spec:
         - host: ikomp-q2.dev-fss-pub.nais.io
         - host: aareg-services.dev-fss-pub.nais.io
         - host: ereg-services.dev-fss-pub.nais.io
-        - host: team-inntekt-proxy.dev-fss-pub.nais.io
+        - host: sigrun-q2.dev-fss-pub.nais.io
         - host: arbeid-og-inntekt-q2.dev-fss-pub.nais.io
   azure:
     application:

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -111,7 +111,7 @@ spec:
         - host: ikomp-q2.dev-fss-pub.nais.io
         - host: aareg-services.dev-fss-pub.nais.io
         - host: ereg-services.dev-fss-pub.nais.io
-        - host: sigrun-q2.dev-fss-pub.nais.io
+        - host: sigrun-q2.dev.adeo.no
         - host: arbeid-og-inntekt-q2.dev-fss-pub.nais.io
   azure:
     application:

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -111,7 +111,7 @@ spec:
         - host: ikomp-q2.dev-fss-pub.nais.io
         - host: aareg-services.dev-fss-pub.nais.io
         - host: ereg-services.dev-fss-pub.nais.io
-        - host: sigrun-q2.dev.adeo.no
+        - host: team-inntekt-proxy.dev-fss-pub.nais.io
         - host: arbeid-og-inntekt-q2.dev-fss-pub.nais.io
   azure:
     application:

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -99,6 +99,9 @@ spec:
           namespace: team-rocket
         - application: logging
           namespace: nais-system
+        - application: sigrun-q2
+          namespace: team-inntekt
+          cluster: dev-fss
       external:
         - host: api-gw-q1.oera.no
         - host: familie-oppdrag.dev-fss-pub.nais.io

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -90,8 +90,6 @@ spec:
         - application: familie-dokument
         - application: familie-ks-sak
         - application: familie-ef-infotrygd-replika
-        - application: familie-ef-proxy
-          cluster: dev-fss
         - application: historisk-pensjon
           namespace: historisk
         - application: paw-arbeidssoekerregisteret-api-oppslag-v2
@@ -109,10 +107,12 @@ spec:
         - host: familie-oppdrag.dev-fss-pub.nais.io
         - host: familie-integrasjoner.dev-fss-pub.nais.io
         - host: familie-ef-infotrygd.dev-fss-pub.nais.io
-        - host: familie-ef-proxy.dev-fss-pub.nais.io
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
         - host: ikomp-q2.dev-fss-pub.nais.io
         - host: aareg-services.dev-fss-pub.nais.io
+        - host: ereg-services.dev-fss-pub.nais.io
+        - host: sigrun-q2.dev-fss-pub.nais.io
+        - host: arbeid-og-inntekt-q2.dev-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -58,7 +58,7 @@ spec:
         - application: familie-ef-mottak
         - application: familie-ef-soknad-api
         - application: familie-klage
-        - application: familie-ef-proxy-test
+        - application: familie-ef-proxy
           namespace: teamfamilie
           cluster: dev-fss
         - application: familie-ba-sak

--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -58,9 +58,6 @@ spec:
         - application: familie-ef-mottak
         - application: familie-ef-soknad-api
         - application: familie-klage
-        - application: familie-ef-proxy
-          namespace: teamfamilie
-          cluster: dev-fss
         - application: familie-ef-proxy-test
           namespace: teamfamilie
           cluster: dev-fss

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -99,6 +99,9 @@ spec:
           namespace: team-rocket
         - application: logging
           namespace: nais-system
+        - application: sigrun
+          namespace: team-inntekt
+          cluster: prod-fss
       external:
         - host: api-gw.oera.no
         - host: familie-oppdrag.prod-fss-pub.nais.io

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -62,9 +62,6 @@ spec:
         - application: familie-ef-personhendelse
         - application: familie-ef-mottak
         - application: familie-ef-soknad-api
-        - application: familie-ef-proxy
-          namespace: teamfamilie
-          cluster: prod-fss
         - application: familie-ba-sak
         - application: bidrag-grunnlag
           namespace: bidrag

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -71,6 +71,9 @@ spec:
           cluster: prod-gcp
         - application: tilleggsstonader-integrasjoner
           namespace: tilleggsstonader
+        - application: familie-ef-proxy
+          namespace: teamfamilie
+          cluster: prod-fss
     outbound:
       rules:
         - application: api-intern

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -89,8 +89,6 @@ spec:
         - application: familie-ef-infotrygd-replika
         - application: historisk-pensjon
           namespace: historisk
-        - application: familie-ef-proxy
-          cluster: prod-fss
         - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
         - application: skjermede-personer-pip
@@ -106,9 +104,11 @@ spec:
         - host: familie-oppdrag.prod-fss-pub.nais.io
         - host: familie-integrasjoner.prod-fss-pub.nais.io
         - host: familie-ef-infotrygd.prod-fss-pub.nais.io
-        - host: familie-ef-proxy.prod-fss-pub.nais.io
         - host: teamfamilie-unleash-api.nav.cloud.nais.io
         - host: ikomp.prod-fss-pub.nais.io
+        - host: ereg-services.prod-fss-pub.nais.io
+        - host: sigrun.prod-fss-pub.nais.io
+        - host: arbeid-og-inntekt.prod-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/ArbeidOgInntektClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/amelding/ekstern/ArbeidOgInntektClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.amelding.ekstern
 
-import no.nav.familie.kontrakter.felles.PersonIdent
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
@@ -10,40 +9,44 @@ import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
+/**
+ * Kaller arbeid-og-inntekt direkte istedenfor via familie-ef-proxy.
+ * Krever ingen Azure AD-token, kun nettverkstilgang (webproxy/access policy) og Nav-Personident-header.
+ */
 @Component
 class ArbeidOgInntektClient(
-    @Value("\${FAMILIE_EF_PROXY_URL}") private val uri: URI,
-    @Qualifier("efProxyRestClient") private val restClient: RestClient,
+    @Value("\${ARBEID_OG_INNTEKT_URL}") private val uri: URI,
+    @Qualifier("utenAuthRestClient") private val restClient: RestClient,
 ) {
     private val genererUrlUri =
         UriComponentsBuilder
             .fromUri(uri)
-            .pathSegment("api/ainntekt/generer-url")
+            .pathSegment("api", "v2", "redirect", "sok", "a-inntekt")
             .build()
             .toUri()
 
     private val genererUrlUriArbeidsforhold =
         UriComponentsBuilder
             .fromUri(uri)
-            .pathSegment("api/ainntekt/generer-url-arbeidsforhold")
+            .pathSegment("api", "v2", "redirect", "sok", "arbeidstaker")
             .build()
             .toUri()
 
     fun genererAInntektArbeidsforholdUrl(personIdent: String): String =
         restClient
-            .post()
+            .get()
             .uri(genererUrlUriArbeidsforhold)
+            .header("Nav-Personident", personIdent)
             .accept(MediaType.TEXT_PLAIN)
-            .body(PersonIdent(personIdent))
             .retrieve()
             .body<String>()!!
 
     fun genererAInntektUrl(personIdent: String): String =
         restClient
-            .post()
+            .get()
             .uri(genererUrlUri)
+            .header("Nav-Personident", personIdent)
             .accept(MediaType.TEXT_PLAIN)
-            .body(PersonIdent(personIdent))
             .retrieve()
             .body<String>()!!
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
@@ -68,7 +68,11 @@ class RestClientConfig(
     @Bean("sigrunRestClient")
     fun sigrunRestClient(
         @Value("\${SIGRUN_SCOPE}") scope: String,
-    ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope).medTimeout()
+    ): RestClient =
+        entraIDRestClientFactory
+            .lagOboRestKlient(scope) {
+                SikkerhetContext.hentJwt()?.tokenValue ?: error("OBO-kall mot Sigrun uten innlogget bruker")
+            }.medTimeout()
 
     /**
      * medlemskap MEDL (MedlClient)

--- a/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/infrastruktur/config/RestClientConfig.kt
@@ -62,12 +62,12 @@ class RestClientConfig(
     ): RestClient = hybrid(scope)
 
     /**
-     * familie-ef-proxy (EregClient, ArbeidOgInntektClient, SigrunClient)
+     * Sigrun (SigrunClient)
      * Kun maskin-til-maskin, appen har ingen OBO/jwt-bearer-registrering i Azure AD.
      */
-    @Bean("efProxyRestClient")
-    fun efProxyRestClient(
-        @Value("\${FAMILIE_EF_PROXY_SCOPE}") scope: String,
+    @Bean("sigrunRestClient")
+    fun sigrunRestClient(
+        @Value("\${SIGRUN_SCOPE}") scope: String,
     ): RestClient = entraIDRestClientFactory.lagMaskinTilMaskinRestKlient(scope).medTimeout()
 
     /**
@@ -163,7 +163,11 @@ class RestClientConfig(
         @Value("\${EF_IVERKSETT_SCOPE}") scope: String,
     ): RestClient = hybrid(scope)
 
-    /** Uten autentisering – for interne familie-tjenester uten auth (BrevClient, FamilieDokumentClient) */
+    /**
+     * Uten autentisering – for interne familie-tjenester uten auth (BrevClient, FamilieDokumentClient)
+     * og for eksterne FSS-tjenester som kun er beskyttet av nettverkstilgang, ikke Azure AD-token
+     * (EregClient, ArbeidOgInntektClient)
+     */
     @Bean("utenAuthRestClient")
     fun utenAuthRestClient(): RestClient =
         RestClient

--- a/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/ereg/EregClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/ereg/EregClient.kt
@@ -8,24 +8,31 @@ import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
+/**
+ * Kaller ereg-services direkte istedenfor via familie-ef-proxy.
+ * Krever ingen Azure AD-token, kun nettverkstilgang (webproxy/access policy).
+ */
 @Component
 class EregClient(
-    @Value("\${FAMILIE_EF_PROXY_URL}")
-    private val familieEfProxyUri: URI,
-    @Qualifier("efProxyRestClient")
+    @Value("\${EREG_URL}")
+    private val eregUri: URI,
+    @Qualifier("utenAuthRestClient")
     private val restClient: RestClient,
 ) {
-    fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<OrganisasjonDto> {
-        val uriBuilder =
+    fun hentOrganisasjoner(organisasjonsnumre: List<String>): List<OrganisasjonDto> = organisasjonsnumre.map(::hentOrganisasjon)
+
+    private fun hentOrganisasjon(organisasjonsnummer: String): OrganisasjonDto {
+        val uri =
             UriComponentsBuilder
-                .fromUri(familieEfProxyUri)
-                .pathSegment("api/ereg")
-                .queryParam("organisasjonsnumre", organisasjonsnumre)
+                .fromUri(eregUri)
+                .pathSegment("v1", "organisasjon", organisasjonsnummer)
+                .build()
+                .toUri()
 
         return restClient
             .get()
-            .uri(uriBuilder.build().toUri())
+            .uri(uri)
             .retrieve()
-            .body<List<OrganisasjonDto>>()!!
+            .body<OrganisasjonDto>()!!
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.ef.sak.sigrun.ekstern
 
-import no.nav.familie.kontrakter.felles.PersonIdent
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -10,10 +9,14 @@ import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
+/**
+ * Kaller Sigrun (Skatteetaten) direkte istedenfor via familie-ef-proxy.
+ * Krever maskin-til-maskin Azure AD-token (SIGRUN_SCOPE).
+ */
 @Component
 class SigrunClient(
-    @Value("\${FAMILIE_EF_PROXY_URL}") private val uri: URI,
-    @Qualifier("efProxyRestClient") private val restClient: RestClient,
+    @Value("\${SIGRUN_URL}") private val uri: URI,
+    @Qualifier("sigrunRestClient") private val restClient: RestClient,
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
@@ -24,65 +27,30 @@ class SigrunClient(
         val uri =
             UriComponentsBuilder
                 .fromUri(uri)
-                .pathSegment("api/sigrun/pensjonsgivendeinntekt")
-                .queryParam("inntektsaar", inntektsår.toString())
+                .pathSegment("api", "v1", "pensjonsgivendeinntektforfolketrygden")
                 .build()
                 .toUri()
+
+        val request =
+            PensjonsgivendeInntektRequest(
+                personident = fødselsnummer,
+                inntektsaar = inntektsår.toString(),
+            )
 
         val response =
             restClient
                 .post()
                 .uri(uri)
-                .body(PersonIdent(fødselsnummer))
+                .body(request)
                 .retrieve()
                 .body<PensjonsgivendeInntektResponse>()!!
         secureLogger.info("Pensjonsgivende inntekt for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }
-
-    fun hentSummertSkattegrunnlag(
-        fødselsnummer: String,
-        inntektsår: Int,
-    ): SummertSkattegrunnlag {
-        val uri =
-            UriComponentsBuilder
-                .fromUri(uri)
-                .pathSegment("api/sigrun/summertskattegrunnlag")
-                .queryParam("inntektsaar", inntektsår.toString())
-                .build()
-                .toUri()
-
-        val response =
-            restClient
-                .post()
-                .uri(uri)
-                .body(PersonIdent(fødselsnummer))
-                .retrieve()
-                .body<SummertSkattegrunnlag>()!!
-        secureLogger.info("Summert skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
-        return response
-    }
-
-    fun hentBeregnetSkatt(
-        fødselsnummer: String,
-        inntektsår: Int,
-    ): List<BeregnetSkatt> {
-        val uri =
-            UriComponentsBuilder
-                .fromUri(uri)
-                .pathSegment("api/sigrun/beregnetskatt")
-                .queryParam("inntektsaar", inntektsår)
-                .build()
-                .toUri()
-
-        val response =
-            restClient
-                .post()
-                .uri(uri)
-                .body(PersonIdent(fødselsnummer))
-                .retrieve()
-                .body<List<BeregnetSkatt>>()!!
-        secureLogger.info("Beregnet skattegrunnlag for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
-        return response
-    }
 }
+
+data class PensjonsgivendeInntektRequest(
+    val personident: String,
+    val inntektsaar: String,
+    val rettighetspakke: String = "navEnsligForsoerger",
+)

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -1,17 +1,13 @@
 package no.nav.familie.ef.sak.sigrun.ekstern
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpRequest
-import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.stereotype.Component
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
-import java.nio.charset.StandardCharsets
 
 /**
  * Kaller Sigrun (Skatteetaten) direkte istedenfor via familie-ef-proxy.
@@ -20,54 +16,8 @@ import java.nio.charset.StandardCharsets
 @Component
 class SigrunClient(
     @Value("\${SIGRUN_URL}") private val uri: URI,
-    @Qualifier("sigrunRestClient") sigrunClient: RestClient,
+    @Qualifier("sigrunRestClient") private val restClient: RestClient,
 ) {
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
-
-    // Legger på en loggende interceptor FØRST i kjeden (før token-interceptoren i
-    // entraIDRestClientFactory). Dette er bevisst, siden token-henting (Azure AD)
-    // kan feile før selve HTTP-kallet til Sigrun bygges - da må vi likevel ha logget
-    // at et kall var på vei, ellers forsvinner det sporløst.
-    private val restClient: RestClient =
-        sigrunClient
-            .mutate()
-            .requestInterceptors { interceptors -> interceptors.add(0, loggendeInterceptor()) }
-            .build()
-
-    private fun loggendeInterceptor(): ClientHttpRequestInterceptor =
-        ClientHttpRequestInterceptor { request, body, execution ->
-            logRequest(request, body)
-            execution.execute(request, body)
-        }
-
-    private fun logRequest(
-        request: HttpRequest,
-        body: ByteArray,
-    ) {
-        val headere =
-            request.headers.headerNames().joinToString("\n") { navn ->
-                val verdier = request.headers[navn].orEmpty()
-                val visning = if (navn.equals("Authorization", ignoreCase = true)) maskerAuthorization(verdier) else verdier
-                "  $navn: $visning"
-            }
-        secureLogger.info(
-            """
-            Kall til Sigrun:
-            ${request.method} ${request.uri}
-            Headers:
-            $headere
-            Body:
-            ${String(body, StandardCharsets.UTF_8)}
-            """.trimIndent(),
-        )
-    }
-
-    private fun maskerAuthorization(verdier: List<String>): List<String> =
-        verdier.map { verdi ->
-            val skjemaPrefiks = verdi.substringBefore(" ", "ukjent-skjema")
-            "$skjemaPrefiks(maskert, lengde=${verdi.length})"
-        }
-
     fun hentPensjonsgivendeInntekt(
         fødselsnummer: String,
         inntektsår: Int,
@@ -85,21 +35,16 @@ class SigrunClient(
                 inntektsaar = inntektsår.toString(),
             )
 
-        val response =
-            try {
-                restClient
-                    .post()
-                    .uri(uri)
-                    .body(request)
-                    .retrieve()
-                    .body<PensjonsgivendeInntektResponse>()!!
-            } catch (e: HttpClientErrorException.NotFound) {
-                return PensjonsgivendeInntektResponse(fødselsnummer, inntektsår, emptyList())
-            } catch (e: Exception) {
-                secureLogger.error("Feil ved kall til Sigrun ($uri): ${e.message}", e)
-                throw e
-            }
-        return response
+        return try {
+            restClient
+                .post()
+                .uri(uri)
+                .body(request)
+                .retrieve()
+                .body<PensjonsgivendeInntektResponse>()!!
+        } catch (e: HttpClientErrorException.NotFound) {
+            PensjonsgivendeInntektResponse(fødselsnummer, inntektsår, emptyList())
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -27,7 +27,7 @@ class SigrunClient(
         val uri =
             UriComponentsBuilder
                 .fromUri(uri)
-                .pathSegment("api", "v1", "pensjonsgivendeinntektforfolketrygden")
+                .pathSegment("v1", "pensjonsgivendeinntektforfolketrygden")
                 .build()
                 .toUri()
 
@@ -54,3 +54,14 @@ data class PensjonsgivendeInntektRequest(
     val inntektsaar: String,
     val rettighetspakke: String = "navEnsligForsoerger",
 )
+
+
+fun main() {
+    val request =
+        PensjonsgivendeInntektRequest(
+            personident = "fødselsnummer",
+            inntektsaar = "inntektsår",
+        )
+
+    println("request: $request")
+}

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpRequest
 import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
@@ -92,11 +93,12 @@ class SigrunClient(
                     .body(request)
                     .retrieve()
                     .body<PensjonsgivendeInntektResponse>()!!
+            } catch (e: HttpClientErrorException.NotFound) {
+                return PensjonsgivendeInntektResponse(fødselsnummer, inntektsår, emptyList())
             } catch (e: Exception) {
                 secureLogger.error("Feil ved kall til Sigrun ($uri): ${e.message}", e)
                 throw e
             }
-        secureLogger.info("Pensjonsgivende inntekt for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }
 }

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -3,11 +3,14 @@ package no.nav.familie.ef.sak.sigrun.ekstern
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpRequestInterceptor
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
+import java.nio.charset.StandardCharsets
 
 /**
  * Kaller Sigrun (Skatteetaten) direkte istedenfor via familie-ef-proxy.
@@ -16,9 +19,51 @@ import java.net.URI
 @Component
 class SigrunClient(
     @Value("\${SIGRUN_URL}") private val uri: URI,
-    @Qualifier("sigrunRestClient") private val restClient: RestClient,
+    @Qualifier("sigrunRestClient") sigrunClient: RestClient,
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+    // Legger på en loggende interceptor sist i kjeden, slik at Authorization-headeren
+    // (satt av auth-interceptoren i entraIDRestClientFactory) er med når vi logger.
+    private val restClient: RestClient =
+        sigrunClient
+            .mutate()
+            .requestInterceptor(loggendeInterceptor())
+            .build()
+
+    private fun loggendeInterceptor(): ClientHttpRequestInterceptor =
+        ClientHttpRequestInterceptor { request, body, execution ->
+            logRequest(request, body)
+            execution.execute(request, body)
+        }
+
+    private fun logRequest(
+        request: HttpRequest,
+        body: ByteArray,
+    ) {
+        val headere =
+            request.headers.headerNames().joinToString("\n") { navn ->
+                val verdier = request.headers[navn].orEmpty()
+                val visning = if (navn.equals("Authorization", ignoreCase = true)) maskerAuthorization(verdier) else verdier
+                "  $navn: $visning"
+            }
+        secureLogger.info(
+            """
+            Kall til Sigrun:
+            ${request.method} ${request.uri}
+            Headers:
+            $headere
+            Body:
+            ${String(body, StandardCharsets.UTF_8)}
+            """.trimIndent(),
+        )
+    }
+
+    private fun maskerAuthorization(verdier: List<String>): List<String> =
+        verdier.map { verdi ->
+            val skjemaPrefiks = verdi.substringBefore(" ", "ukjent-skjema")
+            "$skjemaPrefiks(maskert, lengde=${verdi.length})"
+        }
 
     fun hentPensjonsgivendeInntekt(
         fødselsnummer: String,
@@ -27,7 +72,7 @@ class SigrunClient(
         val uri =
             UriComponentsBuilder
                 .fromUri(uri)
-                .pathSegment("v1", "pensjonsgivendeinntektforfolketrygden")
+                .pathSegment("api", "v1", "pensjonsgivendeinntektforfolketrygden")
                 .build()
                 .toUri()
 
@@ -54,14 +99,3 @@ data class PensjonsgivendeInntektRequest(
     val inntektsaar: String,
     val rettighetspakke: String = "navEnsligForsoerger",
 )
-
-
-fun main() {
-    val request =
-        PensjonsgivendeInntektRequest(
-            personident = "fødselsnummer",
-            inntektsaar = "inntektsår",
-        )
-
-    println("request: $request")
-}

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClient.kt
@@ -23,12 +23,14 @@ class SigrunClient(
 ) {
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
 
-    // Legger på en loggende interceptor sist i kjeden, slik at Authorization-headeren
-    // (satt av auth-interceptoren i entraIDRestClientFactory) er med når vi logger.
+    // Legger på en loggende interceptor FØRST i kjeden (før token-interceptoren i
+    // entraIDRestClientFactory). Dette er bevisst, siden token-henting (Azure AD)
+    // kan feile før selve HTTP-kallet til Sigrun bygges - da må vi likevel ha logget
+    // at et kall var på vei, ellers forsvinner det sporløst.
     private val restClient: RestClient =
         sigrunClient
             .mutate()
-            .requestInterceptor(loggendeInterceptor())
+            .requestInterceptors { interceptors -> interceptors.add(0, loggendeInterceptor()) }
             .build()
 
     private fun loggendeInterceptor(): ClientHttpRequestInterceptor =
@@ -83,12 +85,17 @@ class SigrunClient(
             )
 
         val response =
-            restClient
-                .post()
-                .uri(uri)
-                .body(request)
-                .retrieve()
-                .body<PensjonsgivendeInntektResponse>()!!
+            try {
+                restClient
+                    .post()
+                    .uri(uri)
+                    .body(request)
+                    .retrieve()
+                    .body<PensjonsgivendeInntektResponse>()!!
+            } catch (e: Exception) {
+                secureLogger.error("Feil ved kall til Sigrun ($uri): ${e.message}", e)
+                throw e
+            }
         secureLogger.info("Pensjonsgivende inntekt for inntektsår $inntektsår: $response") // Fjernes når det er litt mer kjennskap til dataene
         return response
     }

--- a/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
+++ b/src/main/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunDomain.kt
@@ -23,22 +23,6 @@ enum class Skatteordning {
     KILDESKATT_PAA_LOENN,
 }
 
-data class SummertSkattegrunnlag(
-    val grunnlag: List<Grunnlag>,
-    val svalbardGrunnlag: List<Grunnlag>,
-    val skatteoppgjoersdato: String,
-)
-
-data class Grunnlag(
-    val tekniskNavn: String,
-    val beloep: Int,
-)
-
-data class BeregnetSkatt(
-    val tekniskNavn: String,
-    val verdi: String,
-)
-
 /*
 {
   "norskPersonidentifikator": "09528731462",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,3 +38,7 @@ FAMILIE_TILBAKE_SCOPE: api://dev-gcp.tilbake.tilbakekreving-backend/.default
 
 INNTEKT_URL: https://ikomp-q2.dev-fss-pub.nais.io
 INNTEKT_SCOPE: api://dev-fss.team-inntekt.ikomp-q2/.default
+
+SIGRUN_URL: https://sigrun-q2.dev-fss-pub.nais.io
+SIGRUN_SCOPE: api://dev-fss.team-inntekt.sigrun-q2/.default
+ARBEID_OG_INNTEKT_URL: https://arbeid-og-inntekt-q2.dev-fss-pub.nais.io

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,6 +39,6 @@ FAMILIE_TILBAKE_SCOPE: api://dev-gcp.tilbake.tilbakekreving-backend/.default
 INNTEKT_URL: https://ikomp-q2.dev-fss-pub.nais.io
 INNTEKT_SCOPE: api://dev-fss.team-inntekt.ikomp-q2/.default
 
-SIGRUN_URL: https://sigrun-q2.dev-fss-pub.nais.io
+SIGRUN_URL: https://sigrun-q2.intern.dev.nav.no
 SIGRUN_SCOPE: api://dev-fss.team-inntekt.sigrun-q2/.default
 ARBEID_OG_INNTEKT_URL: https://arbeid-og-inntekt-q2.dev-fss-pub.nais.io

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,6 +39,6 @@ FAMILIE_TILBAKE_SCOPE: api://dev-gcp.tilbake.tilbakekreving-backend/.default
 INNTEKT_URL: https://ikomp-q2.dev-fss-pub.nais.io
 INNTEKT_SCOPE: api://dev-fss.team-inntekt.ikomp-q2/.default
 
-SIGRUN_URL: https://sigrun-q2.intern.dev.nav.no
+SIGRUN_URL: https://sigrun-q2.dev-fss-pub.nais.io
 SIGRUN_SCOPE: api://dev-fss.team-inntekt.sigrun-q2/.default
 ARBEID_OG_INNTEKT_URL: https://arbeid-og-inntekt-q2.dev-fss-pub.nais.io

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ REPR_API_SCOPE: api://${DEPLOY_ENV}-gcp.repr.repr-api/.default
 EF_IVERKSETT_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-iverksett/.default
 FAMILIE_TILBAKE_SCOPE: api://${DEPLOY_ENV}-gcp.tilbake.tilbakekreving-backend/.default
 FAMILIE_KLAGE_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-klage/.default
-FAMILIE_EF_PROXY_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-proxy/.default
+SIGRUN_SCOPE: api://${DEPLOY_ENV}-fss.team-inntekt.sigrun/.default
 INFOTRYGD_REPLIKA_SCOPE: api://${DEPLOY_ENV}-fss.teamfamilie.familie-ef-infotrygd/.default
 INFOTRYGD_REPLIKA_GCP_SCOPE: api://${DEPLOY_ENV}-gcp.teamfamilie.familie-ef-infotrygd-replika/.default
 ARBEIDSSOKER_SCOPE: api://${DEPLOY_ENV}-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default
@@ -96,7 +96,9 @@ INFOTRYGD_REPLIKA_API_URL: https://familie-ef-infotrygd.${ON_PREM_URL_ENV}-fss-p
 INFOTRYGD_REPLIKA_GCP_API_URL: http://familie-ef-infotrygd-replika
 PDL_URL: https://pdl-api.${ON_PREM_URL_ENV}-fss-pub.nais.io
 REPR_API_URL: http://repr-api.repr
-FAMILIE_EF_PROXY_URL: https://familie-ef-proxy.${ON_PREM_URL_ENV}-fss-pub.nais.io
+EREG_URL: https://ereg-services.${ON_PREM_URL_ENV}-fss-pub.nais.io
+ARBEID_OG_INNTEKT_URL: https://arbeid-og-inntekt.${ON_PREM_URL_ENV}-fss-pub.nais.io
+SIGRUN_URL: https://sigrun.${ON_PREM_URL_ENV}-fss-pub.nais.io
 ARBEIDSSOKER_URL: http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw
 HISTORISK_PENSJON_URL: http://historisk-pensjon.historisk
 FAMILIE_KS_SAK_URL: http://familie-ks-sak

--- a/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/SigrunClientMock.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/infrastruktur/config/SigrunClientMock.kt
@@ -1,45 +1,16 @@
 package no.nav.familie.ef.sak.no.nav.familie.ef.sak.infrastruktur.config
 
-import io.mockk.every
 import io.mockk.mockk
-import no.nav.familie.ef.sak.sigrun.ekstern.BeregnetSkatt
-import no.nav.familie.ef.sak.sigrun.ekstern.Grunnlag
-import no.nav.familie.ef.sak.sigrun.ekstern.PensjonsgivendeInntektForSkatteordning
-import no.nav.familie.ef.sak.sigrun.ekstern.PensjonsgivendeInntektResponse
 import no.nav.familie.ef.sak.sigrun.ekstern.SigrunClient
-import no.nav.familie.ef.sak.sigrun.ekstern.Skatteordning
-import no.nav.familie.ef.sak.sigrun.ekstern.SummertSkattegrunnlag
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.context.annotation.Profile
-import java.time.LocalDate
 
 @Configuration
 class SigrunClientMock {
     @Profile("mock-sigrun")
     @Bean
     @Primary
-    fun sigrunClient(): SigrunClient {
-        val mockk = mockk<SigrunClient>()
-        val beregnetSkattMockResponse =
-            listOf(
-                BeregnetSkatt(
-                    "tekniskNavn",
-                    "verdi",
-                ),
-            )
-
-        val summertSkattegrunnlagMockResponse =
-            SummertSkattegrunnlag(
-                listOf(Grunnlag("personinntektNaering", 400000)),
-                listOf(Grunnlag("svalbardPersoninntektNaering", 350000)),
-                LocalDate.of(2022, 12, 31).toString(),
-            )
-
-        every { mockk.hentBeregnetSkatt(any(), any()) } returns beregnetSkattMockResponse
-        every { mockk.hentSummertSkattegrunnlag(any(), any()) } returns summertSkattegrunnlagMockResponse
-
-        return mockk
-    }
+    fun sigrunClient(): SigrunClient = mockk<SigrunClient>()
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/ereg/EregClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/opplysninger/personopplysninger/ereg/EregClientTest.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.ef.sak.opplysninger.personopplysninger.ereg
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import org.assertj.core.api.Assertions.assertThat
@@ -43,13 +42,26 @@ class EregClientTest {
     @Test
     fun `hent organisasjon response`() {
         WireMock.stubFor(
-            queryMappingForHentOrganisasjon.willReturn(
-                WireMock
-                    .aResponse()
-                    .withStatus(HttpStatus.OK.value())
-                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                    .withBody(eregHentOrganisasjonResponse),
-            ),
+            WireMock
+                .get(WireMock.urlPathEqualTo("/v1/organisasjon/${orgnumre[0]}"))
+                .willReturn(
+                    WireMock
+                        .aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(eregOrganisasjonResponse(orgnumre[0], "PENGELØS SPAREBANK")),
+                ),
+        )
+        WireMock.stubFor(
+            WireMock
+                .get(WireMock.urlPathEqualTo("/v1/organisasjon/${orgnumre[1]}"))
+                .willReturn(
+                    WireMock
+                        .aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(eregOrganisasjonResponse(orgnumre[1], "SJOKKERENDE ELEKTRIKER")),
+                ),
         )
 
         val response = eregClient.hentOrganisasjoner(orgnumre)
@@ -64,157 +76,82 @@ class EregClientTest {
 
     private val orgnumre = listOf("972674818", "999999929")
 
-    private val queryMappingForHentOrganisasjon: MappingBuilder = WireMock.get(WireMock.urlPathEqualTo("/api/ereg"))
-
-    private val eregHentOrganisasjonResponse =
-        """
-        [
-            {
-                "organisasjonsnummer": "972674818",
-                "type": "Virksomhet",
-                "navn": {
-                    "redigertnavn": "PENGELØS SPAREBANK",
-                    "navnelinje1": "PENGELØS SPAREBANK",
-                    "bruksperiode": {
-                        "fom": "2021-06-02T09:23:59.803"
-                    },
-                    "gyldighetsperiode": {
-                        "fom": "2021-06-02"
-                    }
+    private fun eregOrganisasjonResponse(
+        organisasjonsnummer: String,
+        redigertnavn: String,
+    ) = """
+        {
+            "organisasjonsnummer": "$organisasjonsnummer",
+            "type": "Virksomhet",
+            "navn": {
+                "redigertnavn": "$redigertnavn",
+                "navnelinje1": "$redigertnavn",
+                "bruksperiode": {
+                    "fom": "2021-06-02T09:23:59.803"
                 },
-                "organisasjonDetaljer": {
-                    "registreringsdato": "2020-03-31T00:00:00",
-                    "enhetstyper": [
-                        {
-                            "enhetstype": "BEDR",
-                            "bruksperiode": {
-                                "fom": "2020-03-31T13:37:24.419"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2020-03-31"
-                            }
-                        }
-                    ],
-                    "navn": [
-                        {
-                            "redigertnavn": "PENGELØS SPAREBANK",
-                            "navnelinje1": "PENGELØS SPAREBANK",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.803"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
-                        }
-                    ],
-                    "forretningsadresser": [
-                        {
-                            "type": "Forretningsadresse",
-                            "adresselinje1": "BOLSTADVEIEN 30",
-                            "postnummer": "4532",
-                            "poststed": "ØYSLEBØ",
-                            "landkode": "NO",
-                            "kommunenummer": "4205",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.805"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
-                        }
-                    ],
-                    "postadresser": [
-                        {
-                            "type": "Postadresse",
-                            "adresselinje1": "BOLSTADVEIEN 30",
-                            "postnummer": "4532",
-                            "poststed": "ØYSLEBØ",
-                            "landkode": "NO",
-                            "kommunenummer": "4205",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.807"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
-                        }
-                    ],
-                    "sistEndret": "2021-06-02"
+                "gyldighetsperiode": {
+                    "fom": "2021-06-02"
                 }
             },
-            {
-                "organisasjonsnummer": "999999929",
-                "type": "Virksomhet",
-                "navn": {
-                    "redigertnavn": "SJOKKERENDE ELEKTRIKER",
-                    "navnelinje1": "SJOKKERENDE ELEKTRIKER",
-                    "bruksperiode": {
-                        "fom": "2021-06-02T09:23:59.839"
-                    },
-                    "gyldighetsperiode": {
-                        "fom": "2021-06-02"
+            "organisasjonDetaljer": {
+                "registreringsdato": "2020-03-31T00:00:00",
+                "enhetstyper": [
+                    {
+                        "enhetstype": "BEDR",
+                        "bruksperiode": {
+                            "fom": "2020-03-31T13:37:24.419"
+                        },
+                        "gyldighetsperiode": {
+                            "fom": "2020-03-31"
+                        }
                     }
-                },
-                "organisasjonDetaljer": {
-                    "registreringsdato": "2021-06-02T00:00:00",
-                    "enhetstyper": [
-                        {
-                            "enhetstype": "BEDR",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:21:17.472"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
+                ],
+                "navn": [
+                    {
+                        "redigertnavn": "$redigertnavn",
+                        "navnelinje1": "$redigertnavn",
+                        "bruksperiode": {
+                            "fom": "2021-06-02T09:23:59.803"
+                        },
+                        "gyldighetsperiode": {
+                            "fom": "2021-06-02"
                         }
-                    ],
-                    "navn": [
-                        {
-                            "redigertnavn": "SJOKKERENDE ELEKTRIKER",
-                            "navnelinje1": "SJOKKERENDE ELEKTRIKER",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.839"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
+                    }
+                ],
+                "forretningsadresser": [
+                    {
+                        "type": "Forretningsadresse",
+                        "adresselinje1": "BOLSTADVEIEN 30",
+                        "postnummer": "4532",
+                        "poststed": "ØYSLEBØ",
+                        "landkode": "NO",
+                        "kommunenummer": "4205",
+                        "bruksperiode": {
+                            "fom": "2021-06-02T09:23:59.805"
+                        },
+                        "gyldighetsperiode": {
+                            "fom": "2021-06-02"
                         }
-                    ],
-                    "forretningsadresser": [
-                        {
-                            "type": "Forretningsadresse",
-                            "adresselinje1": "DRIVHUSVEGEN 40",
-                            "postnummer": "9027",
-                            "poststed": "RAMFJORDBOTN",
-                            "landkode": "NO",
-                            "kommunenummer": "5401",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.84"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
+                    }
+                ],
+                "postadresser": [
+                    {
+                        "type": "Postadresse",
+                        "adresselinje1": "BOLSTADVEIEN 30",
+                        "postnummer": "4532",
+                        "poststed": "ØYSLEBØ",
+                        "landkode": "NO",
+                        "kommunenummer": "4205",
+                        "bruksperiode": {
+                            "fom": "2021-06-02T09:23:59.807"
+                        },
+                        "gyldighetsperiode": {
+                            "fom": "2021-06-02"
                         }
-                    ],
-                    "postadresser": [
-                        {
-                            "type": "Postadresse",
-                            "adresselinje1": "DRIVHUSVEGEN 40",
-                            "postnummer": "9027",
-                            "poststed": "RAMFJORDBOTN",
-                            "landkode": "NO",
-                            "kommunenummer": "5401",
-                            "bruksperiode": {
-                                "fom": "2021-06-02T09:23:59.841"
-                            },
-                            "gyldighetsperiode": {
-                                "fom": "2021-06-02"
-                            }
-                        }
-                    ],
-                    "sistEndret": "2021-06-02"
-                }
+                    }
+                ],
+                "sistEndret": "2021-06-02"
             }
-        ]
+        }
         """.trimIndent()
 }

--- a/src/test/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClientTest.kt
+++ b/src/test/kotlin/no/nav/familie/ef/sak/sigrun/ekstern/SigrunClientTest.kt
@@ -48,7 +48,7 @@ class SigrunClientTest {
     fun `hent pensjonsgivende inntekt fra sigrun og map til objekt`() {
         wiremockServerItem.stubFor(
             WireMock
-                .post(urlEqualTo("/api/sigrun/pensjonsgivendeinntekt?inntektsaar=2022"))
+                .post(urlEqualTo("/api/v1/pensjonsgivendeinntektforfolketrygden"))
                 .willReturn(
                     WireMock
                         .aResponse()
@@ -69,65 +69,6 @@ class SigrunClientTest {
         assertThat(pensjonsgivendeInntektResponse.pensjonsgivendeInntekt?.first()?.datoForFastsetting).isEqualTo(LocalDate.of(2023, 9, 27))
         assertThat(pensjonsgivendeInntektResponse.pensjonsgivendeInntekt?.last()?.skatteordning).isEqualTo(Skatteordning.SVALBARD)
         assertThat(pensjonsgivendeInntektResponse.pensjonsgivendeInntekt?.last()?.pensjonsgivendeInntektAvLoennsinntekt).isEqualTo(492160)
-    }
-
-    @Test
-    fun `hent beregnetskatt fra sigrun og map til objekt`() {
-        wiremockServerItem.stubFor(
-            WireMock
-                .post(urlEqualTo("/api/sigrun/beregnetskatt?inntektsaar=2022"))
-                .willReturn(
-                    WireMock
-                        .aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                        .withBody(beregnetSkattRessursResponseJson),
-                ),
-        )
-        val beregnetSkatt = sigrunClient.hentBeregnetSkatt("123", 2022)
-        assertThat(beregnetSkatt.size).isEqualTo(7)
-        assertThat(beregnetSkatt.first().verdi).isEqualTo("814952")
-        assertThat(beregnetSkatt.first().tekniskNavn).isEqualTo("personinntektFiskeFangstFamiliebarnehage")
-    }
-
-    @Test
-    fun `hent beregnetskatt fra sigrun og map til objekt med skatteoppgjørsdato`() {
-        wiremockServerItem.stubFor(
-            WireMock
-                .post(urlEqualTo("/api/sigrun/beregnetskatt?inntektsaar=2022"))
-                .willReturn(
-                    WireMock
-                        .aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                        .withBody(beregnetSkattMedOppgjørsdatoJson),
-                ),
-        )
-        val beregnetSkatt = sigrunClient.hentBeregnetSkatt("123", 2022)
-        assertThat(beregnetSkatt.size).isEqualTo(2)
-        assertThat(beregnetSkatt.last().verdi).isEqualTo("200000")
-        assertThat(beregnetSkatt.last().tekniskNavn).isEqualTo("personinntektNaering")
-    }
-
-    @Test
-    fun `hent summertskattegrunnlag fra sigrun og map til objekt`() {
-        wiremockServerItem.stubFor(
-            WireMock
-                .post(urlEqualTo("/api/sigrun/summertskattegrunnlag?inntektsaar=2018"))
-                .willReturn(
-                    WireMock
-                        .aResponse()
-                        .withStatus(HttpStatus.OK.value())
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                        .withBody(summertSkattegrunnlagJson),
-                ),
-        )
-        val summertSkattegrunnlag = sigrunClient.hentSummertSkattegrunnlag("123", 2018)
-        assertThat(summertSkattegrunnlag.grunnlag.size).isEqualTo(4)
-        assertThat(summertSkattegrunnlag.skatteoppgjoersdato).isEqualTo("2018-10-04")
-        assertThat(summertSkattegrunnlag.svalbardGrunnlag.size).isEqualTo(4)
-        assertThat(summertSkattegrunnlag.svalbardGrunnlag.first().tekniskNavn).isEqualTo("samledePaaloepteRenter")
-        assertThat(summertSkattegrunnlag.svalbardGrunnlag.first().beloep).isEqualTo(779981)
     }
 
     private val pensjonsgivendeInntektResponseJson =
@@ -155,93 +96,4 @@ class SigrunClientTest {
           ]
         }
         """.trimIndent()
-
-    private val beregnetSkattMedOppgjørsdatoJson =
-        """
-        [
-          {
-            "tekniskNavn": "skatteoppgjoersdato",
-            "verdi": "2022-05-01"
-          },
-          {
-            "tekniskNavn": "personinntektNaering",
-            "verdi": "200000"
-          }
-        ]
-        """.trimIndent()
-
-    private val beregnetSkattRessursResponseJson = """
-        [
-          {
-            "tekniskNavn": "personinntektFiskeFangstFamiliebarnehage",
-            "verdi": "814952"
-          },
-          {
-            "tekniskNavn": "personinntektNaering",
-            "verdi": "785896"
-          },
-          {
-            "tekniskNavn": "personinntektBarePensjonsdel",
-            "verdi": "844157"
-          },
-          {
-            "tekniskNavn": "svalbardLoennLoennstrekkordningen",
-            "verdi": "874869"
-          },
-          {
-            "tekniskNavn": "personinntektLoenn",
-            "verdi": "746315"
-          },
-          {
-            "tekniskNavn": "svalbardPersoninntektNaering",
-            "verdi": "696009"
-          },
-          {
-            "tekniskNavn": "skatteoppgjoersdato",
-            "verdi": "2017-08-09"
-          }
-        ]
-    """
-
-    private val summertSkattegrunnlagJson = """
-        {
-          "grunnlag": [
-            {
-              "tekniskNavn": "samledePaaloepteRenter",
-              "beloep": 779981
-            },
-            {
-              "tekniskNavn": "andreFradragsberettigedeKostnader",
-              "beloep": 59981
-            },
-            {
-              "tekniskNavn": "samletSkattepliktigOverskuddAvUtleieAvFritidseiendom",
-              "beloep": 1609981
-            },
-            {
-              "tekniskNavn": "skattepliktigAvkastningEllerKundeutbytte",
-              "beloep": 1749981
-            }
-          ],
-          "skatteoppgjoersdato": "2018-10-04",
-          "svalbardGrunnlag": [
-            {
-              "tekniskNavn": "samledePaaloepteRenter",
-              "beloep": 779981
-            },
-            {
-              "tekniskNavn": "samletAndelAvInntektIBoligselskapEllerBoligsameie",
-              "beloep": 849981
-            },
-            {
-              "tekniskNavn": "loennsinntektMedTrygdeavgiftspliktOmfattetAvLoennstrekkordningen",
-              "beloep": 1779981
-            },
-            {
-              "tekniskNavn": "skattepliktigAvkastningEllerKundeutbytte",
-              "beloep": 1749981
-            }
-          ]
-        }
-        """
 }

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -21,7 +21,10 @@ FAMILIE_INTEGRASJONER_URL: http://localhost:8386
 FAMILIE_BREV_API_URL: http://localhost:8001
 FAMILIE_BLANKETT_API_URL: http://localhost:8033
 #FAMILIE_EF_IVERKSETT_URL: http://localhost:8094 # Fordi iverksett og klage er på samme url/port lokalt så må vi kommentere ut den av de vi ikke vil kjøre opp mot lokalt
-FAMILIE_EF_PROXY_URL: http://localhost:8002
+EREG_URL: http://localhost:8002
+ARBEID_OG_INNTEKT_URL: http://localhost:8002
+SIGRUN_URL: http://localhost:8002
+SIGRUN_SCOPE: api://dev-fss.team-inntekt.sigrun-q2/.default
 FAMILIE_DOKUMENT_URL: http://localhost:8082
 FAMILIE_KLAGE_URL: http://localhost:8094
 FAMILIE_KS_SAK_URL: http://localhost:8083


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Unngår kall via proxy. 

Dette er testet:
- Arbeid og inntekt: Lenker i admin-menyen. Dette endepunktet krever ingen token.
- Ereg: Søk etter organisasjon i brevmeny. Dette endepunktet krever ingen token.
- Næringsinntekt (Sigrun): Vis inntekt i brukeroversikt. Her har vi fått tilgang til ef-sak spesifikt. Ber om at de fjerner tilgangen til familie-ef-proxy når det er verifisert at dette virker i prod også. Det har blitt en liten forbedring med denne endringen, hvor det nå brukes OBO-token i stedet for M2M-token. Endepunktet returnerer 404 hvis inntekt ikke finnes for gitt person og inntektsår, og håndteres derfor eksplisitt.

Squashes før merge 😅 

<img width="1490" height="342" alt="Screenshot 2026-08-17 at 21 52 22" src="https://github.com/user-attachments/assets/88aea061-da06-4ab9-b4eb-52e923fc5191" />

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29417)