### PR TITLE
Fjerner familie-ef-proxy fra outbound

### DIFF
--- a/.nais/preprod.yaml
+++ b/.nais/preprod.yaml
@@ -58,9 +58,6 @@ spec:
         - application: familie-ef-mottak
         - application: familie-ef-soknad-api
         - application: familie-klage
-        - application: familie-ef-proxy
-          namespace: teamfamilie
-          cluster: dev-fss
         - application: familie-ba-sak
         - application: bidrag-grunnlag
           namespace: bidrag

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -71,9 +71,6 @@ spec:
           cluster: prod-gcp
         - application: tilleggsstonader-integrasjoner
           namespace: tilleggsstonader
-        - application: familie-ef-proxy
-          namespace: teamfamilie
-          cluster: prod-fss
     outbound:
       rules:
         - application: api-intern


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
ef-sak går ikke lenger mot ef-proxy